### PR TITLE
transform_data: GUI + klickbarer Start

### DIFF
--- a/docs/modules/transform_data.md
+++ b/docs/modules/transform_data.md
@@ -2,11 +2,30 @@
 
 Liest einen Jira-JSON-Export und eine Workflow-Definition und erzeugt drei XLSX-Dateien mit Stage-Time-Metriken.
 
-## Verwendung
+## Start
+
+### GUI
 
 ```bash
+python -m transform_data
+```
+
+Öffnet ein Fenster mit Datei-Auswahl-Dialogen. Wenn eine JSON-Datei gewählt wird, werden Ausgabeordner und Präfix automatisch vorbelegt.
+
+```bash
+python -m transform_data.gui
+```
+
+Startet die GUI direkt (ohne Argument-Prüfung).
+
+### Kommandozeile
+
+```bash
+python -m transform_data <json_datei> <workflow_datei> [Optionen]
 python -m transform_data.transform <json_datei> <workflow_datei> [Optionen]
 ```
+
+Beide Varianten sind gleichwertig. Die zweite (`transform_data.transform`) ist immer ein reiner CLI-Aufruf, unabhängig von der Anzahl der Argumente.
 
 **Argumente**
 
@@ -20,8 +39,18 @@ python -m transform_data.transform <json_datei> <workflow_datei> [Optionen]
 **Beispiel**
 
 ```bash
-python -m transform_data.transform data/ART_A.json data/workflow_ART_A.txt --output-dir out/ --prefix ART_A
+python -m transform_data data/ART_A.json data/workflow_ART_A.txt --output-dir out/ --prefix ART_A
 ```
+
+### Übersicht
+
+| Befehl | Ergebnis |
+|--------|----------|
+| `python -m transform_data` | GUI |
+| `python -m transform_data <json> <workflow>` | CLI |
+| `python -m transform_data.gui` | GUI (direkt) |
+| `python -m transform_data.transform <json> <workflow>` | CLI (direkt) |
+| `python -m transform_data --help` | CLI-Hilfe |
 
 Erzeugt:
 

--- a/start_gui.pyw
+++ b/start_gui.pyw
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from transform_data.gui import TransformApp
+
+TransformApp().mainloop()

--- a/transform_data/__main__.py
+++ b/transform_data/__main__.py
@@ -1,0 +1,24 @@
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) > 1:
+        from transform_data.transform import main as cli_main
+        cli_main()
+    else:
+        try:
+            import tkinter  # noqa: F401
+        except ImportError:
+            print(
+                "tkinter ist in dieser Python-Umgebung nicht verfügbar.\n"
+                "Bitte CLI verwenden:\n"
+                "  python -m transform_data.transform <json_datei> <workflow_datei>",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        from transform_data.gui import TransformApp
+        TransformApp().mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/transform_data/gui.py
+++ b/transform_data/gui.py
@@ -1,0 +1,163 @@
+import threading
+import tkinter as tk
+from tkinter import filedialog, scrolledtext, ttk
+from pathlib import Path
+
+from .transform import run_transform
+
+
+class TransformApp(tk.Tk):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("transform_data")
+        self.resizable(True, True)
+
+        self._json_var = tk.StringVar()
+        self._workflow_var = tk.StringVar()
+        self._output_dir_var = tk.StringVar()
+        self._prefix_var = tk.StringVar()
+        self._auto_prefix: str = ""   # tracks the last auto-filled prefix value
+
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        pad = {"padx": 8, "pady": 4}
+        self.columnconfigure(1, weight=1)
+
+        # --- Input rows ---
+        tk.Label(self, text="JSON-Datei", anchor="w").grid(row=0, column=0, sticky="w", **pad)
+        tk.Entry(self, textvariable=self._json_var, state="readonly", width=55).grid(
+            row=0, column=1, sticky="ew", **pad
+        )
+        ttk.Button(self, text="Durchsuchen…", command=self._pick_json).grid(
+            row=0, column=2, **pad
+        )
+
+        tk.Label(self, text="Workflow-Datei", anchor="w").grid(row=1, column=0, sticky="w", **pad)
+        tk.Entry(self, textvariable=self._workflow_var, state="readonly", width=55).grid(
+            row=1, column=1, sticky="ew", **pad
+        )
+        ttk.Button(self, text="Durchsuchen…", command=self._pick_workflow).grid(
+            row=1, column=2, **pad
+        )
+
+        tk.Label(self, text="Ausgabeordner", anchor="w").grid(row=2, column=0, sticky="w", **pad)
+        tk.Entry(self, textvariable=self._output_dir_var, state="readonly", width=55).grid(
+            row=2, column=1, sticky="ew", **pad
+        )
+        ttk.Button(self, text="Durchsuchen…", command=self._pick_output_dir).grid(
+            row=2, column=2, **pad
+        )
+
+        # --- Prefix row ---
+        tk.Label(self, text="Präfix", anchor="w").grid(row=3, column=0, sticky="w", **pad)
+        tk.Entry(self, textvariable=self._prefix_var, width=55).grid(
+            row=3, column=1, sticky="ew", **pad
+        )
+
+        # --- Run button ---
+        self._run_btn = ttk.Button(self, text="Ausführen", command=self._run)
+        self._run_btn.grid(row=4, column=0, columnspan=3, pady=8)
+
+        # --- Log area ---
+        tk.Label(self, text="Log", anchor="w").grid(row=5, column=0, sticky="w", **pad)
+        self._log_area = scrolledtext.ScrolledText(
+            self, height=12, state="disabled", wrap="word"
+        )
+        self._log_area.grid(row=6, column=0, columnspan=3, sticky="nsew", **pad)
+        self.rowconfigure(6, weight=1)
+
+    # --- File pickers ---
+
+    def _pick_json(self) -> None:
+        path = filedialog.askopenfilename(
+            title="JSON-Datei wählen",
+            filetypes=[("JSON-Dateien", "*.json"), ("Alle Dateien", "*.*")],
+        )
+        if not path:
+            return
+        self._json_var.set(path)
+
+        # Auto-fill output dir if still empty
+        if not self._output_dir_var.get():
+            self._output_dir_var.set(str(Path(path).parent))
+
+        # Auto-fill prefix if still empty or matches the previous auto-value
+        stem = Path(path).stem
+        current_prefix = self._prefix_var.get()
+        if not current_prefix or current_prefix == self._auto_prefix:
+            self._prefix_var.set(stem)
+            self._auto_prefix = stem
+
+    def _pick_workflow(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Workflow-Datei wählen",
+            filetypes=[("Textdateien", "*.txt"), ("Alle Dateien", "*.*")],
+        )
+        if path:
+            self._workflow_var.set(path)
+
+    def _pick_output_dir(self) -> None:
+        path = filedialog.askdirectory(title="Ausgabeordner wählen")
+        if path:
+            self._output_dir_var.set(path)
+
+    # --- Run ---
+
+    def _run(self) -> None:
+        json_path = self._json_var.get().strip()
+        workflow_path = self._workflow_var.get().strip()
+
+        if not json_path:
+            self._log("FEHLER: Keine JSON-Datei ausgewählt.")
+            return
+        if not workflow_path:
+            self._log("FEHLER: Keine Workflow-Datei ausgewählt.")
+            return
+        if not Path(json_path).is_file():
+            self._log(f"FEHLER: JSON-Datei nicht gefunden: {json_path}")
+            return
+        if not Path(workflow_path).is_file():
+            self._log(f"FEHLER: Workflow-Datei nicht gefunden: {workflow_path}")
+            return
+
+        output_dir_str = self._output_dir_var.get().strip()
+        output_dir = Path(output_dir_str) if output_dir_str else None
+        prefix = self._prefix_var.get().strip() or None
+
+        self._set_running(True)
+        self._log("--- Transformation gestartet ---")
+
+        def worker() -> None:
+            try:
+                run_transform(
+                    Path(json_path),
+                    Path(workflow_path),
+                    output_dir=output_dir,
+                    prefix=prefix,
+                    log=self._log,
+                )
+                self._log("--- Fertig ---")
+            except Exception as exc:
+                self._log(f"FEHLER: {exc}")
+            finally:
+                self.after(0, lambda: self._set_running(False))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    # --- Helpers ---
+
+    def _log(self, msg: str) -> None:
+        def _append() -> None:
+            self._log_area.configure(state="normal")
+            self._log_area.insert("end", msg + "\n")
+            self._log_area.see("end")
+            self._log_area.configure(state="disabled")
+        self.after(0, _append)
+
+    def _set_running(self, running: bool) -> None:
+        self._run_btn.configure(state="disabled" if running else "normal")
+
+
+if __name__ == "__main__":
+    TransformApp().mainloop()

--- a/transform_data/transform.py
+++ b/transform_data/transform.py
@@ -3,6 +3,7 @@ transform_data CLI
 
 Usage:
     python -m transform_data.transform <json_file> <workflow_file> [options]
+    python -m transform_data                                          (GUI)
 
 Example:
     python -m transform_data.transform transform_data/ART_A.json transform_data/workflow_ART_A.txt
@@ -10,6 +11,7 @@ Example:
 """
 
 import argparse
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -18,9 +20,44 @@ from .processor import process_issues
 from .writers import write_transitions, write_issue_times, write_cfd
 
 
+def run_transform(
+    json_file: Path,
+    workflow_file: Path,
+    output_dir: Path | None = None,
+    prefix: str | None = None,
+    log: Callable[[str], None] = print,
+) -> None:
+    """
+    Execute the full transformation pipeline.
+
+    Called by both the CLI (main) and the GUI. The log parameter accepts
+    any callable that takes a single string — defaults to print for CLI use.
+    """
+    workflow = parse_workflow(workflow_file)
+    reference_dt = datetime.now(tz=timezone.utc)
+    records = process_issues(json_file, workflow, reference_dt)
+
+    resolved_output_dir = output_dir or json_file.parent
+    resolved_output_dir.mkdir(parents=True, exist_ok=True)
+    resolved_prefix = prefix or json_file.stem
+
+    transitions_path = resolved_output_dir / f"{resolved_prefix}_Transitions.xlsx"
+    issue_times_path = resolved_output_dir / f"{resolved_prefix}_IssueTimes.xlsx"
+    cfd_path = resolved_output_dir / f"{resolved_prefix}_CFD.xlsx"
+
+    write_transitions(records, transitions_path)
+    write_issue_times(records, workflow, issue_times_path)
+    write_cfd(records, workflow, cfd_path, reference_dt)
+
+    log(f"Processed {len(records)} issues")
+    log(f"  {transitions_path}")
+    log(f"  {issue_times_path}")
+    log(f"  {cfd_path}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Transform Jira JSON export into stage-time metrics CSVs."
+        description="Transform Jira JSON export into stage-time metrics XLSXs."
     )
     parser.add_argument("json_file", type=Path, help="Jira JSON export file")
     parser.add_argument("workflow_file", type=Path, help="Workflow definition file")
@@ -33,27 +70,7 @@ def main() -> None:
         help="Output file prefix (default: stem of json_file)"
     )
     args = parser.parse_args()
-
-    workflow = parse_workflow(args.workflow_file)
-    reference_dt = datetime.now(tz=timezone.utc)
-    records = process_issues(args.json_file, workflow, reference_dt)
-
-    output_dir = args.output_dir or args.json_file.parent
-    output_dir.mkdir(parents=True, exist_ok=True)
-    prefix = args.prefix or args.json_file.stem
-
-    transitions_path = output_dir / f"{prefix}_Transitions.xlsx"
-    issue_times_path = output_dir / f"{prefix}_IssueTimes.xlsx"
-    cfd_path = output_dir / f"{prefix}_CFD.xlsx"
-
-    write_transitions(records, transitions_path)
-    write_issue_times(records, workflow, issue_times_path)
-    write_cfd(records, workflow, cfd_path, reference_dt)
-
-    print(f"Processed {len(records)} issues")
-    print(f"  {transitions_path}")
-    print(f"  {issue_times_path}")
-    print(f"  {cfd_path}")
+    run_transform(args.json_file, args.workflow_file, args.output_dir, args.prefix)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `run_transform()` aus `main()` extrahiert — gemeinsame Pipeline für CLI und GUI
- `gui.py`: tkinter-GUI mit Datei-Pickern, Auto-Befüllung, Threading und Log-Bereich
- `__main__.py`: Routing zwischen GUI (keine Args) und CLI (Args vorhanden)
- `start_gui.pyw`: Doppelklick-Start ohne Konsolenfenster
- Dokumentation aktualisiert (alle Startvarianten)

## Test plan

- [x] `python -m transform_data.transform` erzeugt valide XLSX-Dateien (CLI unverändert)
- [x] `python -m transform_data` öffnet die GUI
- [x] Doppelklick auf `start_gui.pyw` öffnet die GUI ohne Konsolenfenster

🤖 Generated with [Claude Code](https://claude.com/claude-code)