### PR TITLE
docs: zweisprachige Dokumentation (DE/EN)

### DIFF
--- a/docs/development.en.md
+++ b/docs/development.en.md
@@ -1,0 +1,46 @@
+# Development
+
+## Prerequisites
+
+- Python >= 3.11
+- Git
+
+## Setup
+
+```bash
+git clone https://github.com/Jaegerfeld/situation-report.git
+cd situation-report
+python -m venv .venv
+.venv\Scripts\activate       # Windows
+# source .venv/bin/activate  # Linux/macOS
+pip install -e ".[docs]"
+```
+
+## Preview documentation locally
+
+```bash
+mkdocs serve
+```
+
+The documentation is then available at [http://127.0.0.1:8000](http://127.0.0.1:8000).
+
+## Branch convention
+
+New work on a module is done on a dedicated branch:
+
+```
+dev/<module_name>
+```
+
+After completion, a pull request is opened against `main`. The finished state is tagged with the module name (e.g. `transform_data`).
+
+## Technology stack
+
+| Area | Technology |
+|------|------------|
+| Language | Python >= 3.11 |
+| Package management | pip / pyproject.toml |
+| Version control | Git / GitHub |
+| Documentation | MkDocs + Material Theme |
+| Data source | Jira REST API |
+| Output format | XLSX (openpyxl) |

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -1,0 +1,29 @@
+# SituationReport
+
+Toolsuite for retrieving Jira issue data and preparing it for metrics and reports.
+
+## Modules
+
+| Module | Description | Status |
+|--------|-------------|--------|
+| [`transform_data`](modules/transform_data.md) | Transform raw Jira data into stage-time metrics | available |
+| [`get_data`](modules/get_data.md) | Retrieve data from Jira via REST API | planned |
+| [`build_reports`](modules/build_reports.md) | Generate metrics and reports | planned |
+| [`testdata_generator`](modules/testdata_generator.md) | Generate synthetic test data | planned |
+| [`simulate`](modules/simulate.md) | Simulations and prediction models | planned |
+
+## Setup
+
+```bash
+python -m venv .venv
+.venv\Scripts\activate       # Windows
+# source .venv/bin/activate  # Linux/macOS
+pip install -e .
+```
+
+To preview the documentation locally:
+
+```bash
+pip install -e ".[docs]"
+mkdocs serve
+```

--- a/docs/modules/build_reports.en.md
+++ b/docs/modules/build_reports.en.md
@@ -1,0 +1,6 @@
+# build_reports
+
+!!! note "Planned"
+    This module is not yet implemented.
+
+Generates metrics and reports based on the data prepared by `transform_data`.

--- a/docs/modules/get_data.en.md
+++ b/docs/modules/get_data.en.md
@@ -1,0 +1,6 @@
+# get_data
+
+!!! note "Planned"
+    This module is not yet implemented.
+
+Retrieves data from Jira via REST API and produces the JSON export consumed by `transform_data`.

--- a/docs/modules/index.en.md
+++ b/docs/modules/index.en.md
@@ -1,0 +1,18 @@
+# Modules
+
+SituationReport is structured as a monorepo. Each module is a standalone Python package in the root directory.
+
+```
+situation-report/
+├── get_data/
+├── transform_data/
+├── build_reports/
+├── testdata_generator/
+└── simulate/
+```
+
+The modules are independently usable. The typical data flow is:
+
+```
+get_data  →  transform_data  →  build_reports
+```

--- a/docs/modules/simulate.en.md
+++ b/docs/modules/simulate.en.md
@@ -1,0 +1,6 @@
+# simulate
+
+!!! note "Planned"
+    This module is not yet implemented.
+
+Simulations and prediction models based on historical Jira data.

--- a/docs/modules/testdata_generator.en.md
+++ b/docs/modules/testdata_generator.en.md
@@ -1,0 +1,6 @@
+# testdata_generator
+
+!!! note "Planned"
+    This module is not yet implemented.
+
+Generates synthetic Jira test data for development and testing.

--- a/docs/modules/transform_data.en.md
+++ b/docs/modules/transform_data.en.md
@@ -1,0 +1,112 @@
+# transform_data
+
+Reads a Jira JSON export and a workflow definition and produces three XLSX files with stage-time metrics.
+
+## Start
+
+### GUI
+
+```bash
+python -m transform_data
+```
+
+Opens a window with file selection dialogs. When a JSON file is chosen, the output folder and prefix are automatically pre-filled.
+
+```bash
+python -m transform_data.gui
+```
+
+Launches the GUI directly (without argument checking).
+
+### Command line
+
+```bash
+python -m transform_data <json_file> <workflow_file> [options]
+python -m transform_data.transform <json_file> <workflow_file> [options]
+```
+
+Both variants are equivalent. The second (`transform_data.transform`) is always a pure CLI call, regardless of the number of arguments.
+
+**Arguments**
+
+| Argument | Description |
+|----------|-------------|
+| `json_file` | Jira JSON export (required) |
+| `workflow_file` | Workflow definition file (required) |
+| `--output-dir` | Output directory (default: directory of the JSON file) |
+| `--prefix` | Output file prefix (default: stem of the JSON filename) |
+
+**Example**
+
+```bash
+python -m transform_data data/ART_A.json data/workflow_ART_A.txt --output-dir out/ --prefix ART_A
+```
+
+### Overview
+
+| Command | Result |
+|---------|--------|
+| `python -m transform_data` | GUI |
+| `python -m transform_data <json> <workflow>` | CLI |
+| `python -m transform_data.gui` | GUI (direct) |
+| `python -m transform_data.transform <json> <workflow>` | CLI (direct) |
+| `python -m transform_data --help` | CLI help |
+
+## Workflow definition file
+
+Text file, one stage per line.
+
+```
+Funnel:To Do
+Analysis
+Implementation
+<First>Analysis
+<InProgress>Implementation
+<Closed>Done
+Done
+```
+
+| Format | Meaning |
+|--------|---------|
+| `Stage` | Canonical stage name |
+| `Stage:Alias1:Alias2` | Stage with Jira status names mapped to it |
+| `<First>Stage` | This stage sets the "First Date" |
+| `<InProgress>Stage` | This stage sets the "Implementation Date" |
+| `<Closed>Stage` | This stage sets the "Closed Date" |
+
+## Output files
+
+### Transitions.xlsx
+
+One row per status change per issue, sorted chronologically.
+
+| Column | Content |
+|--------|---------|
+| Key | Issue key |
+| Transition | Stage name (or "Created") |
+| Timestamp | Time of the transition |
+
+### IssueTimes.xlsx
+
+One row per issue with time spent (in minutes) per stage.
+
+| Column | Content |
+|--------|---------|
+| Project, Key, Issuetype, Status, … | Issue master data |
+| Created Date | Creation timestamp |
+| First Date | First entry into the `<First>` stage |
+| Implementation Date | First entry into the `<InProgress>` stage |
+| Closed Date | First entry into the `<Closed>` stage |
+| *Stage columns* | Minutes spent in the respective stage |
+| Resolution | Jira resolution |
+
+### CFD.xlsx
+
+Cumulative Flow Diagram — one row per calendar day. Stage columns contain the number of issues in each stage on that day.
+
+## Stage-time calculation
+
+- Time from issue creation to the first explicit transition is attributed to the initial stage.
+- Unmapped initial statuses fall back to the first stage in the workflow definition.
+- The last stage accumulates time until the execution time (`reference_dt`).
+- Issues without transitions have zero for all stages.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,9 +5,21 @@ repo_url: https://github.com/Jaegerfeld/situation-report
 repo_name: Jaegerfeld/situation-report
 edit_uri: edit/main/docs/
 
+plugins:
+  - search
+  - i18n:
+      docs_structure: suffix
+      languages:
+        - locale: de
+          default: true
+          name: Deutsch
+          build: true
+        - locale: en
+          name: English
+          build: true
+
 theme:
   name: material
-  language: de
   palette:
     - scheme: default
       primary: indigo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = ["openpyxl>=3.1"]
 
 [project.optional-dependencies]
-docs = ["mkdocs-material>=9.5"]
+docs = ["mkdocs-material>=9.5", "mkdocs-static-i18n>=1.3", "babel>=2.14"]
 
 [tool.setuptools.packages.find]
 include = ["get_data*", "transform_data*", "build_reports*", "testdata_generator*", "simulate*"]


### PR DESCRIPTION
## Summary

- mkdocs-static-i18n Plugin eingerichtet (Suffix-Struktur: `*.en.md`)
- Alle 7 Dokumentationsseiten ins Englische übersetzt
- Sprachumschalter im Theme (Deutsch Standard, English unter `/en/`)
- `mkdocs-static-i18n` und `babel` als Docs-Abhängigkeiten hinzugefügt

## Test plan

- [x] `mkdocs build` erfolgreich für beide Sprachen
- [x] Deutsche Seiten unter `/`, englische unter `/en/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)