### PR TITLE
transform_data: unmapped status handling + workflow validation

### DIFF
--- a/transform_data/processor.py
+++ b/transform_data/processor.py
@@ -43,7 +43,7 @@ class IssueRecord:
     first_date: datetime | None
     inprogress_date: datetime | None
     closed_date: datetime | None
-    stage_minutes: dict[str, int]  # canonical stage -> minutes (only from explicit transitions)
+    stage_minutes: dict[str, int]  # canonical stage -> minutes
     resolution: str
     initial_stage: str | None      # stage before any transition (for CFD)
     transitions: list[Transition]  # sorted by timestamp; first entry is always "Created"
@@ -53,14 +53,20 @@ def process_issues(
     json_path: Path,
     workflow: Workflow,
     reference_dt: datetime | None = None,
-) -> list[IssueRecord]:
+) -> tuple[list[IssueRecord], set[str]]:
     """
     Parse Jira JSON export and compute per-issue stage times.
 
+    Returns a tuple of:
+    - list of IssueRecord objects
+    - set of Jira status names that appear in the data but are not mapped
+      in the workflow definition
+
     Stage time rules:
-    - Only explicit status transitions from the Jira changelog are counted.
-    - Time from issue creation to first transition is NOT counted.
-    - The current (last) stage accumulates time up to reference_dt.
+    - Time from issue creation to first transition is attributed to the initial stage.
+    - When a transition targets an unmapped status, time continues to accumulate
+      in the last known stage (carry-forward).
+    - The current (last known) stage accumulates time up to reference_dt.
     - Issues with no transitions have all-zero stage times.
     """
     if reference_dt is None:
@@ -68,6 +74,7 @@ def process_issues(
 
     data = json.loads(json_path.read_text(encoding="utf-8"))
     records: list[IssueRecord] = []
+    unmapped_statuses: set[str] = set()
 
     for issue in data["issues"]:
         key = issue["key"]
@@ -92,12 +99,21 @@ def process_issues(
                     raw.append((item["fromString"], item["toString"], ts))
         raw.sort(key=lambda x: x[2])
 
-        # Initial stage for CFD: the status the issue had before its first transition.
-        # If no transitions, use the current status (it has never changed).
+        # Collect unmapped statuses for this issue
         initial_status = raw[0][0] if raw else current_status
-        initial_stage = workflow.status_to_stage.get(initial_status)
+        if initial_status not in workflow.status_to_stage:
+            unmapped_statuses.add(initial_status)
+        for _, to_s, _ in raw:
+            if to_s not in workflow.status_to_stage:
+                unmapped_statuses.add(to_s)
 
-        # Build sorted transition list (for Transitions CSV and CFD)
+        # Initial stage for CFD: the status the issue had before its first transition.
+        # If unmapped, fall back to the first stage in the workflow.
+        initial_stage = workflow.status_to_stage.get(initial_status) or (
+            workflow.stages[0] if workflow.stages else None
+        )
+
+        # Build sorted transition list (for Transitions sheet and CFD)
         transitions: list[Transition] = [Transition(key, "Created", created)]
         for _, to_status, ts in raw:
             label = workflow.status_to_stage.get(to_status, to_status)
@@ -108,34 +124,40 @@ def process_issues(
             (workflow.status_to_stage.get(to_s), ts) for _, to_s, ts in raw
         ]
 
-        # Compute cumulative minutes per stage
+        # Compute cumulative minutes per stage using carry-forward for unmapped statuses:
+        # when a transition targets an unmapped status, time keeps accumulating in the
+        # last known stage rather than being lost.
         stage_minutes: dict[str, int] = {s: 0 for s in workflow.stages}
         first_date: datetime | None = None
         inprogress_date: datetime | None = None
         closed_date: datetime | None = None
 
-        # Count the pre-transition period (creation → first explicit transition) in the
-        # initial stage. If the initial status is unmapped, fall back to the first stage
-        # in the workflow (typically "Funnel").
-        if mapped:
-            pre_stage = initial_stage or (workflow.stages[0] if workflow.stages else None)
-            if pre_stage:
-                pre_duration = max(0, int((mapped[0][1] - created).total_seconds() / 60))
-                stage_minutes[pre_stage] += pre_duration
+        # Pre-transition period: creation → first explicit transition, attributed to
+        # the initial stage (carry-forward applies here too via initial_stage fallback).
+        current_stage: str | None = initial_stage
+        if mapped and current_stage:
+            pre_duration = max(0, int((mapped[0][1] - created).total_seconds() / 60))
+            stage_minutes[current_stage] += pre_duration
 
         for i, (stage, entry_ts) in enumerate(mapped):
-            if stage is None:
-                continue
             exit_ts = mapped[i + 1][1] if i + 1 < len(mapped) else reference_dt
             duration = max(0, int((exit_ts - entry_ts).total_seconds() / 60))
-            stage_minutes[stage] += duration
 
-            if stage == workflow.first_stage and first_date is None:
-                first_date = entry_ts
-            if stage == workflow.inprogress_stage and inprogress_date is None:
-                inprogress_date = entry_ts
-            if stage == workflow.closed_stage and closed_date is None:
-                closed_date = entry_ts
+            if stage is None:
+                # Unmapped: carry forward time to the last known stage
+                if current_stage:
+                    stage_minutes[current_stage] += duration
+            else:
+                # Mapped: accumulate in this stage and advance the pointer
+                stage_minutes[stage] += duration
+                current_stage = stage
+
+                if stage == workflow.first_stage and first_date is None:
+                    first_date = entry_ts
+                if stage == workflow.inprogress_stage and inprogress_date is None:
+                    inprogress_date = entry_ts
+                if stage == workflow.closed_stage and closed_date is None:
+                    closed_date = entry_ts
 
         records.append(IssueRecord(
             project=project,
@@ -153,4 +175,4 @@ def process_issues(
             transitions=transitions,
         ))
 
-    return records
+    return records, unmapped_statuses

--- a/transform_data/transform.py
+++ b/transform_data/transform.py
@@ -34,6 +34,12 @@ def run_transform(
     any callable that takes a single string — defaults to print for CLI use.
     """
     workflow = parse_workflow(workflow_file)
+
+    if workflow.first_stage is None:
+        log("WARNUNG: Kein <First>-Marker in der Workflow-Datei — First Date wird nicht berechnet.")
+    if workflow.closed_stage is None:
+        log("WARNUNG: Kein <Closed>-Marker in der Workflow-Datei — Closed Date wird nicht berechnet.")
+
     reference_dt = datetime.now(tz=timezone.utc)
     records, unmapped = process_issues(json_file, workflow, reference_dt)
 

--- a/transform_data/transform.py
+++ b/transform_data/transform.py
@@ -35,7 +35,13 @@ def run_transform(
     """
     workflow = parse_workflow(workflow_file)
     reference_dt = datetime.now(tz=timezone.utc)
-    records = process_issues(json_file, workflow, reference_dt)
+    records, unmapped = process_issues(json_file, workflow, reference_dt)
+
+    if unmapped:
+        log(f"WARNUNG: {len(unmapped)} Status in den Daten nicht in der Workflow-Datei gemappt:")
+        for s in sorted(unmapped):
+            log(f"  - {s}")
+        log("  > Zeit dieser Status wird der letzten bekannten Stage zugerechnet.")
 
     resolved_output_dir = output_dir or json_file.parent
     resolved_output_dir.mkdir(parents=True, exist_ok=True)

--- a/transform_data/workflow.py
+++ b/transform_data/workflow.py
@@ -48,4 +48,16 @@ def parse_workflow(filepath: Path) -> Workflow:
     if inprogress_stage is None and "Implementation" in stages:
         inprogress_stage = "Implementation"
 
+    # Validate that marker stages actually exist in the workflow
+    for marker, name in (
+        ("<First>", first_stage),
+        ("<Closed>", closed_stage),
+        ("<InProgress>", inprogress_stage),
+    ):
+        if name is not None and name not in stages:
+            raise ValueError(
+                f"Workflow-Fehler: {marker}{name} ist kein bekannter Stage-Name. "
+                f"Bekannte Stages: {', '.join(stages)}"
+            )
+
     return Workflow(stages, status_to_stage, first_stage, closed_stage, inprogress_stage)

--- a/transform_data/writers.py
+++ b/transform_data/writers.py
@@ -92,7 +92,10 @@ def write_cfd(
         current = record.initial_stage
         for t in record.transitions[1:]:   # skip "Created" entry
             if t.timestamp.date() <= day:
-                current = workflow.status_to_stage.get(t.label)
+                # carry-forward: only advance if the transition target is mapped
+                mapped_stage = workflow.status_to_stage.get(t.label)
+                if mapped_stage is not None:
+                    current = mapped_stage
             else:
                 break
         return current


### PR DESCRIPTION
## Summary

- Nicht gemappte Jira-Status werden gesammelt und als Warnung ausgegeben (CLI + GUI)
- Zeit bei unmapped Transitionen wird der letzten bekannten Stage zugerechnet (carry-forward)
- CFD-Berechnung nutzt ebenfalls carry-forward
- Fehlende `<First>`/`<Closed>`-Marker erzeugen eine Warnung
- Tippfehler im Marker-Stage-Namen führen zu einem Fehler beim Parsen mit Liste der gültigen Stages

## Test plan

- [x] Vollständige Workflow-Datei: nur bekannter unmapped Status "To Do" gemeldet
- [x] Status-missing-Datei: alle 9 fehlenden Status korrekt aufgelistet
- [x] Keine Marker: Warnungen für First Date und Closed Date
- [x] Tippfehler im Marker: ValueError mit klarer Fehlermeldung

🤖 Generated with [Claude Code](https://claude.com/claude-code)