### PR TITLE
docs: transform_data Dokumentation aktualisiert (DE + EN)

### DIFF
--- a/docs/modules/transform_data.en.md
+++ b/docs/modules/transform_data.en.md
@@ -10,13 +10,15 @@ Reads a Jira JSON export and a workflow definition and produces three XLSX files
 python -m transform_data
 ```
 
-Opens a window with file selection dialogs. When a JSON file is chosen, the output folder and prefix are automatically pre-filled.
+Opens a window with file selection dialogs. When a JSON file is chosen, the output folder and prefix are automatically pre-filled. Warnings and results appear in the log area.
 
 ```bash
 python -m transform_data.gui
 ```
 
 Launches the GUI directly (without argument checking).
+
+Alternatively: double-click `start_gui.pyw` in the project directory — opens the GUI without a console window.
 
 ### Command line
 
@@ -42,6 +44,12 @@ Both variants are equivalent. The second (`transform_data.transform`) is always 
 python -m transform_data data/ART_A.json data/workflow_ART_A.txt --output-dir out/ --prefix ART_A
 ```
 
+Produces:
+
+- `out/ART_A_Transitions.xlsx`
+- `out/ART_A_IssueTimes.xlsx`
+- `out/ART_A_CFD.xlsx`
+
 ### Overview
 
 | Command | Result |
@@ -51,19 +59,20 @@ python -m transform_data data/ART_A.json data/workflow_ART_A.txt --output-dir ou
 | `python -m transform_data.gui` | GUI (direct) |
 | `python -m transform_data.transform <json> <workflow>` | CLI (direct) |
 | `python -m transform_data --help` | CLI help |
+| Double-click `start_gui.pyw` | GUI without console window |
 
 ## Workflow definition file
 
 Text file, one stage per line.
 
 ```
-Funnel:To Do
-Analysis
-Implementation
+Funnel:New:Open
+Analysis:In Analysis
+Implementation:In Progress
+Done:Canceled
 <First>Analysis
 <InProgress>Implementation
 <Closed>Done
-Done
 ```
 
 | Format | Meaning |
@@ -71,8 +80,31 @@ Done
 | `Stage` | Canonical stage name |
 | `Stage:Alias1:Alias2` | Stage with Jira status names mapped to it |
 | `<First>Stage` | This stage sets the "First Date" |
-| `<InProgress>Stage` | This stage sets the "Implementation Date" |
+| `<InProgress>Stage` | This stage sets the "Implementation Date" (default: stage named "Implementation") |
 | `<Closed>Stage` | This stage sets the "Closed Date" |
+
+### Workflow file validation
+
+The following checks are performed when loading the workflow file:
+
+| Situation | Behaviour |
+|-----------|-----------|
+| `<First>` / `<Closed>` not defined | Warning: date column stays empty |
+| Stage name in marker does not exist in the file | **Error** with list of valid stage names |
+| Stage defined but never reached by any issue | No intervention — date column stays empty |
+
+### Unmapped Jira statuses
+
+If the Jira export contains statuses that are not defined as a stage or alias in the workflow file, the tool issues a warning:
+
+```
+WARNING: 2 statuses in the data are not mapped in the workflow file:
+  - To Do
+  - Unknown
+  > Time in these statuses is attributed to the last known stage.
+```
+
+Time spent in unmapped statuses is attributed to the **last known stage** (carry-forward). Issues remain fully present in all outputs.
 
 ## Output files
 
@@ -108,5 +140,17 @@ Cumulative Flow Diagram — one row per calendar day. Stage columns contain the 
 
 - Time from issue creation to the first explicit transition is attributed to the initial stage.
 - Unmapped initial statuses fall back to the first stage in the workflow definition.
-- The last stage accumulates time until the execution time (`reference_dt`).
+- When a transition targets an unmapped status, time continues to accumulate in the **last known stage** (carry-forward).
+- The last known stage accumulates time until the execution time.
 - Issues without transitions have zero for all stages.
+
+## Tests
+
+```bash
+python -m pytest tests/transform_data/
+```
+
+| Type | Directory | Content |
+|------|-----------|---------|
+| Unit | `tests/transform_data/unit/` | Isolated tests for `workflow.py` and `processor.py` with synthetic fixtures |
+| Acceptance | `tests/transform_data/acceptance/` | Tests against the real ART_A dataset; verify business correctness |

--- a/docs/modules/transform_data.md
+++ b/docs/modules/transform_data.md
@@ -10,13 +10,15 @@ Liest einen Jira-JSON-Export und eine Workflow-Definition und erzeugt drei XLSX-
 python -m transform_data
 ```
 
-Öffnet ein Fenster mit Datei-Auswahl-Dialogen. Wenn eine JSON-Datei gewählt wird, werden Ausgabeordner und Präfix automatisch vorbelegt.
+Öffnet ein Fenster mit Datei-Auswahl-Dialogen. Wenn eine JSON-Datei gewählt wird, werden Ausgabeordner und Präfix automatisch vorbelegt. Warnungen und Ergebnisse erscheinen im Log-Bereich.
 
 ```bash
 python -m transform_data.gui
 ```
 
 Startet die GUI direkt (ohne Argument-Prüfung).
+
+Alternativ: Doppelklick auf `start_gui.pyw` im Projektverzeichnis — öffnet die GUI ohne Konsolenfenster.
 
 ### Kommandozeile
 
@@ -42,6 +44,12 @@ Beide Varianten sind gleichwertig. Die zweite (`transform_data.transform`) ist i
 python -m transform_data data/ART_A.json data/workflow_ART_A.txt --output-dir out/ --prefix ART_A
 ```
 
+Erzeugt:
+
+- `out/ART_A_Transitions.xlsx`
+- `out/ART_A_IssueTimes.xlsx`
+- `out/ART_A_CFD.xlsx`
+
 ### Übersicht
 
 | Befehl | Ergebnis |
@@ -51,34 +59,52 @@ python -m transform_data data/ART_A.json data/workflow_ART_A.txt --output-dir ou
 | `python -m transform_data.gui` | GUI (direkt) |
 | `python -m transform_data.transform <json> <workflow>` | CLI (direkt) |
 | `python -m transform_data --help` | CLI-Hilfe |
-
-Erzeugt:
-
-- `out/ART_A_Transitions.xlsx`
-- `out/ART_A_IssueTimes.xlsx`
-- `out/ART_A_CFD.xlsx`
+| Doppelklick auf `start_gui.pyw` | GUI ohne Konsolenfenster |
 
 ## Workflow-Definitionsdatei
 
 Textdatei, eine Stage pro Zeile.
 
 ```
-Funnel:To Do
-Analysis
-Implementation
+Funnel:New:Open
+Analysis:In Analysis
+Implementation:In Progress
+Done:Canceled
 <First>Analysis
 <InProgress>Implementation
 <Closed>Done
-Done
 ```
 
 | Format | Bedeutung |
 |--------|-----------|
-| `Stage` | Canonical Stage Name |
+| `Stage` | Kanonischer Stage-Name |
 | `Stage:Alias1:Alias2` | Stage mit Jira-Statusnamen, die darauf gemappt werden |
 | `<First>Stage` | Diese Stage setzt das „First Date" |
-| `<InProgress>Stage` | Diese Stage setzt das „Implementation Date" |
+| `<InProgress>Stage` | Diese Stage setzt das „Implementation Date" (Standard: Stage namens „Implementation") |
 | `<Closed>Stage` | Diese Stage setzt das „Closed Date" |
+
+### Validierung der Workflow-Datei
+
+Beim Einlesen der Workflow-Datei werden folgende Prüfungen durchgeführt:
+
+| Situation | Verhalten |
+|-----------|-----------|
+| `<First>` / `<Closed>` nicht definiert | Warnung: Datumsspalte bleibt leer |
+| Stage-Name im Marker existiert nicht in der Datei | **Fehler** mit Liste der gültigen Stage-Namen |
+| Stage definiert, aber von keinem Issue erreicht | Kein Eingriff — Datumsspalte bleibt leer |
+
+### Nicht gemappte Jira-Status
+
+Enthält der Jira-Export Status, die in der Workflow-Datei nicht als Stage oder Alias definiert sind, gibt das Tool eine Warnung aus:
+
+```
+WARNUNG: 2 Status in den Daten nicht in der Workflow-Datei gemappt:
+  - To Do
+  - Unknown
+  > Zeit dieser Status wird der letzten bekannten Stage zugerechnet.
+```
+
+Die Zeit in nicht gemappten Status wird der **letzten bekannten Stage** zugerechnet (Carry-forward). Issues bleiben vollständig in allen Ausgaben erhalten.
 
 ## Ausgabedateien
 
@@ -113,6 +139,18 @@ Cumulative Flow Diagram — eine Zeile pro Kalendertag, Stage-Spalten enthalten 
 ## Stage-Zeit-Berechnung
 
 - Die Zeit von der Issue-Erstellung bis zur ersten expliziten Transition wird der initialen Stage zugerechnet.
-- Nicht gemappte Initialstatus werden auf die erste Stage in der Workflow-Definition zurückgefallen.
-- Die letzte Stage akkumuliert Zeit bis zum Ausführungszeitpunkt (`reference_dt`).
+- Nicht gemappte Initialstatus werden der ersten Stage in der Workflow-Definition zugerechnet.
+- Bei Transitionen in nicht gemappte Status läuft die Zeit in der **letzten bekannten Stage** weiter (Carry-forward).
+- Die letzte bekannte Stage akkumuliert Zeit bis zum Ausführungszeitpunkt.
 - Issues ohne Transitionen haben für alle Stages den Wert 0.
+
+## Tests
+
+```bash
+python -m pytest tests/transform_data/
+```
+
+| Testtyp | Verzeichnis | Inhalt |
+|---------|-------------|--------|
+| Unit | `tests/transform_data/unit/` | Isolierte Tests für `workflow.py` und `processor.py` mit synthetischen Fixtures |
+| Acceptance | `tests/transform_data/acceptance/` | Tests gegen den realen ART_A-Datensatz; prüfen fachliche Korrektheit |


### PR DESCRIPTION
## Summary

- Carry-forward bei nicht gemappten Status dokumentiert
- Workflow-Validierung dokumentiert (fehlende Marker, Tippfehler)
- `start_gui.pyw` in Startübersicht ergänzt
- Abschnitt Tests mit pytest-Befehl und Tabelle hinzugefügt
- Englische Übersetzung synchronisiert

🤖 Generated with [Claude Code](https://claude.com/claude-code)