### PR TITLE
transform_data: Closed Date auf letzten Eintritt umgestellt

### DIFF
--- a/docs/modules/transform_data.en.md
+++ b/docs/modules/transform_data.en.md
@@ -144,6 +144,9 @@ Cumulative Flow Diagram — one row per calendar day. Stage columns contain the 
 - The last known stage accumulates time until the execution time.
 - Issues without transitions have zero for all stages.
 
+!!! info "Closed Date"
+    The Closed Date is set on the **last** entry into the `<Closed>` stage. For issues that were reopened and closed again, the most recent closing timestamp is used.
+
 ## Tests
 
 ```bash

--- a/docs/modules/transform_data.md
+++ b/docs/modules/transform_data.md
@@ -144,6 +144,9 @@ Cumulative Flow Diagram — eine Zeile pro Kalendertag, Stage-Spalten enthalten 
 - Die letzte bekannte Stage akkumuliert Zeit bis zum Ausführungszeitpunkt.
 - Issues ohne Transitionen haben für alle Stages den Wert 0.
 
+!!! info "Closed Date"
+    Das Closed Date wird beim **letzten** Eintritt in die `<Closed>`-Stage gesetzt. Bei Issues die wiedereröffnet und erneut geschlossen wurden, zählt der jüngste Schließzeitpunkt.
+
 ## Tests
 
 ```bash

--- a/tests/transform_data/acceptance/test_transform_ata.py
+++ b/tests/transform_data/acceptance/test_transform_ata.py
@@ -173,9 +173,9 @@ class TestStageMinutes:
 # ---------------------------------------------------------------------------
 
 class TestUnmappedStatuses:
-    def test_only_known_unmapped_status(self, unmapped):
-        """Bei der original Workflow-Datei ist nur 'To Do' nicht gemappt."""
-        assert unmapped == {"To Do"}
+    def test_no_unmapped_statuses_with_complete_workflow(self, unmapped):
+        """Bei der vollstaendigen original Workflow-Datei gibt es keine nicht gemappten Status."""
+        assert unmapped == set()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/transform_data/unit/test_processor.py
+++ b/tests/transform_data/unit/test_processor.py
@@ -3,7 +3,7 @@
 # Repository:     https://github.com/Jaegerfeld/situation-report
 # KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
 # Erstellt:       14.04.2026
-# Geändert:       14.04.2026
+# Geändert:       15.04.2026
 # Lizenz:         BSD-3-Clause (siehe LICENSE)
 #
 # Fachliche Funktion:
@@ -226,6 +226,22 @@ class TestMilestoneDates:
             ],
         )])
         assert records[0].closed_date == t2
+
+    def test_closed_date_uses_last_entry_not_first(self):
+        """Issue wird wiedereröffnet und erneut geschlossen — letzter Schließzeitpunkt zählt."""
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)  # → Done (erste Schließung)
+        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=timezone.utc)  # → Funnel (Wiedereröffnung)
+        t3 = datetime(2025, 12, 1, 13, 0, tzinfo=timezone.utc)  # → Done (zweite Schließung)
+        records, _ = _process([_issue(
+            "T-1", created,
+            transitions=[
+                ("Funnel", "Done", t1),
+                ("Done", "Funnel", t2),
+                ("Funnel", "Done", t3),
+            ],
+        )])
+        assert records[0].closed_date == t3  # nicht t1
 
     def test_no_first_date_if_issue_never_reaches_first_stage(self):
         created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)

--- a/transform_data/processor.py
+++ b/transform_data/processor.py
@@ -3,7 +3,7 @@
 # Repository:     https://github.com/Jaegerfeld/situation-report
 # KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
 # Erstellt:       09.04.2026
-# Geändert:       14.04.2026
+# Geändert:       15.04.2026
 # Lizenz:         BSD-3-Clause (siehe LICENSE)
 #
 # Fachliche Funktion:
@@ -173,8 +173,8 @@ def process_issues(
                     first_date = entry_ts
                 if stage == workflow.inprogress_stage and inprogress_date is None:
                     inprogress_date = entry_ts
-                if stage == workflow.closed_stage and closed_date is None:
-                    closed_date = entry_ts
+                if stage == workflow.closed_stage:
+                    closed_date = entry_ts  # letzter Eintritt zählt
 
         records.append(IssueRecord(
             project=project,

--- a/transform_data/workflow_ART_A - original.txt
+++ b/transform_data/workflow_ART_A - original.txt
@@ -1,4 +1,4 @@
-Funnel:New:Open
+Funnel:New:Open:To Do
 Analysis:In Analysis:Estimated
 Program Backlog:Ready for Dev:Backlog
 Implementation:In Implementation:In Review:In Progress


### PR DESCRIPTION
## Summary

- `closed_date` wird jetzt beim **letzten** Eintritt in die `<Closed>`-Stage gesetzt statt beim ersten
- Neuer Unit-Test für Wiedereröffnungs-/Wiedereschließ-Szenario
- Acceptance-Test aktualisiert (Workflow-Datei mappt 'To Do' jetzt korrekt)
- Dokumentation (DE + EN) mit Info-Hinweis ergänzt

## Test plan

- [x] 45/45 Tests grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)