### PR TITLE
feat(build_reports): flow metrics reports module

### DIFF
--- a/build_reports/__main__.py
+++ b/build_reports/__main__.py
@@ -1,0 +1,48 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       16.04.2026
+# Geändert:       16.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Einstiegspunkt für `python -m build_reports`. Startet ohne Argumente die
+#   GUI, mit Argumenten das CLI. Ermöglicht so `python -m build_reports` für
+#   den interaktiven Betrieb und `python -m build_reports <xlsx> --pdf ...`
+#   für die automatisierte Nutzung.
+# =============================================================================
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    """
+    Dispatch to GUI or CLI based on whether arguments are provided.
+
+    No arguments → launch the GUI (tkinter + pywebview).
+    Any arguments → delegate to the CLI (argparse pipeline).
+    """
+    if len(sys.argv) > 1:
+        # Arguments present → CLI mode
+        from build_reports.cli import main as cli_main
+        cli_main()
+    else:
+        # No arguments → GUI mode
+        try:
+            from build_reports.gui import main as gui_main
+            gui_main()
+        except ImportError as exc:
+            print(
+                f"ERROR: GUI dependencies are not installed ({exc}).\n"
+                "Install them with:  pip install situation-report[gui]\n"
+                "Or run the CLI:     python -m build_reports <IssueTimes.xlsx> --help",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/build_reports/cli.py
+++ b/build_reports/cli.py
@@ -1,0 +1,195 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Kommandozeileninterface für build_reports. Liest IssueTimes- und CFD-XLSX,
+#   wendet optionale Filter an, berechnet die gewählten Metriken und exportiert
+#   die Ergebnisse als PDF oder öffnet sie im Browser. Unterstützt SAFe- und
+#   Global-Terminologie sowie Auswahl einzelner oder aller Metriken.
+# =============================================================================
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Callable
+from datetime import date
+from pathlib import Path
+
+import plotly.io as pio
+
+from .export import export_pdf
+from .filters import FilterConfig, apply_filters
+from .loader import load_report_data
+from .metrics import all_metrics, get_metric
+from .terminology import GLOBAL, SAFE
+
+
+def _parse_date(value: str) -> date:
+    """
+    Parse a date string in YYYY-MM-DD format for argparse.
+
+    Args:
+        value: Date string from the command line.
+
+    Returns:
+        Parsed date object.
+
+    Raises:
+        argparse.ArgumentTypeError: If the format is invalid.
+    """
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"Invalid date '{value}' — expected YYYY-MM-DD format."
+        )
+
+
+def run_reports(
+    issue_times: Path,
+    cfd: Path | None = None,
+    metrics: list[str] | None = None,
+    from_date: date | None = None,
+    to_date: date | None = None,
+    projects: list[str] | None = None,
+    issuetypes: list[str] | None = None,
+    terminology: str = SAFE,
+    output_pdf: Path | None = None,
+    open_browser: bool = False,
+    log: Callable[[str], None] = print,
+) -> None:
+    """
+    Execute the full build_reports pipeline: load → filter → compute → output.
+
+    Called by both the CLI (main) and the GUI. The log parameter accepts
+    any callable that takes a single string — defaults to print for CLI use.
+
+    Args:
+        issue_times:  Path to IssueTimes.xlsx (required).
+        cfd:          Path to CFD.xlsx (optional, needed for CFD metric).
+        metrics:      List of metric IDs to run. None or empty = all metrics.
+        from_date:    Filter: include only issues closed on or after this date.
+        to_date:      Filter: include only issues closed on or before this date.
+        projects:     Filter: restrict to these project keys (empty = all).
+        issuetypes:   Filter: restrict to these issue types (empty = all).
+        terminology:  Display mode — SAFE or GLOBAL.
+        output_pdf:   If set, export all figures to this PDF file.
+        open_browser: If True, open each figure in the default browser.
+        log:          Callable for progress/warning output.
+    """
+    log(f"Loading data from {issue_times.name} ...")
+    data = load_report_data(issue_times, cfd)
+    log(f"  {len(data.issues)} issues, {len(data.cfd)} CFD days, "
+        f"{len(data.stages)} stages loaded.")
+
+    cfg = FilterConfig(
+        from_date=from_date,
+        to_date=to_date,
+        projects=projects or [],
+        issuetypes=issuetypes or [],
+    )
+    data = apply_filters(data, cfg)
+    log(f"  After filters: {len(data.issues)} issues, {len(data.cfd)} CFD days.")
+
+    # Resolve which metrics to run
+    if metrics:
+        plugins = []
+        for mid in metrics:
+            try:
+                plugins.append(get_metric(mid))
+            except KeyError:
+                log(f"WARNING: Unknown metric '{mid}' — skipped.")
+    else:
+        plugins = all_metrics()
+
+    all_figures = []
+    for plugin in plugins:
+        log(f"Computing {plugin.metric_id} ...")
+        result = plugin.compute(data, terminology)
+        for w in result.warnings:
+            log(f"  WARNING: {w}")
+        figures = plugin.render(result, terminology)
+        log(f"  → {len(figures)} figure(s)")
+        all_figures.extend(figures)
+
+    if not all_figures:
+        log("No figures produced — nothing to export.")
+        return
+
+    if output_pdf:
+        log(f"Exporting {len(all_figures)} figure(s) to {output_pdf} ...")
+        export_pdf(all_figures, output_pdf)
+        log(f"  Saved: {output_pdf}")
+
+    if open_browser:
+        for fig in all_figures:
+            pio.show(fig)
+
+    if not output_pdf and not open_browser:
+        log("No output specified — use --pdf or --browser to view results.")
+
+
+def main() -> None:
+    """
+    Entry point for the build_reports CLI.
+
+    Parses command-line arguments and delegates to run_reports().
+    """
+    available_ids = [p.metric_id for p in all_metrics()]
+
+    parser = argparse.ArgumentParser(
+        prog="python -m build_reports.cli",
+        description="Generate flow metrics reports from transform_data XLSX output.",
+    )
+    parser.add_argument("issue_times", type=Path,
+                        help="Path to IssueTimes.xlsx")
+    parser.add_argument("--cfd", type=Path, default=None,
+                        help="Path to CFD.xlsx (required for CFD metric)")
+    parser.add_argument("--metrics", nargs="+", metavar="ID",
+                        choices=available_ids, default=None,
+                        help=f"Metrics to compute (default: all). "
+                             f"Available: {', '.join(available_ids)}")
+    parser.add_argument("--from-date", type=_parse_date, default=None,
+                        metavar="YYYY-MM-DD",
+                        help="Include only issues closed on or after this date")
+    parser.add_argument("--to-date", type=_parse_date, default=None,
+                        metavar="YYYY-MM-DD",
+                        help="Include only issues closed on or before this date")
+    parser.add_argument("--projects", nargs="+", default=None,
+                        metavar="KEY",
+                        help="Restrict to these project keys")
+    parser.add_argument("--issuetypes", nargs="+", default=None,
+                        metavar="TYPE",
+                        help="Restrict to these issue types")
+    parser.add_argument("--terminology", choices=[SAFE, GLOBAL], default=SAFE,
+                        help=f"Terminology mode (default: {SAFE})")
+    parser.add_argument("--pdf", type=Path, default=None,
+                        metavar="FILE",
+                        help="Export all figures to this PDF file")
+    parser.add_argument("--browser", action="store_true",
+                        help="Open figures in the default browser")
+
+    args = parser.parse_args()
+
+    run_reports(
+        issue_times=args.issue_times,
+        cfd=args.cfd,
+        metrics=args.metrics,
+        from_date=args.from_date,
+        to_date=args.to_date,
+        projects=args.projects,
+        issuetypes=args.issuetypes,
+        terminology=args.terminology,
+        output_pdf=args.pdf,
+        open_browser=args.browser,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/build_reports/export.py
+++ b/build_reports/export.py
@@ -1,0 +1,116 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Exportiert eine oder mehrere plotly-Figures als PDF-Datei. Jede Figure
+#   wird auf einer eigenen Seite ausgegeben. Der Export nutzt kaleido für
+#   die Konvertierung zu PNG-Seiten, die anschließend zu einem mehrseitigen
+#   PDF zusammengefügt werden. Alternativ kann jede Figure einzeln als PNG
+#   exportiert werden.
+# =============================================================================
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import plotly.graph_objects as go
+import plotly.io as pio
+
+
+def export_pdf(figures: list[Any], output_path: Path, width: int = 1400, height: int = 700) -> None:
+    """
+    Export a list of plotly Figures to a single multi-page PDF file.
+
+    Each figure is rendered as one page. Uses kaleido for rasterization.
+    Pages are written sequentially; the PDF is created even if only one
+    figure is provided.
+
+    Args:
+        figures:     List of plotly Figure objects to export.
+        output_path: Destination path for the PDF file (e.g. 'report.pdf').
+        width:       Page width in pixels (default 1400).
+        height:      Page height in pixels (default 700).
+
+    Raises:
+        ValueError:  If figures list is empty.
+        ImportError: If kaleido is not installed.
+    """
+    if not figures:
+        raise ValueError("No figures provided for PDF export.")
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # kaleido supports direct PDF export for single figures;
+    # for multiple pages we write individual PDFs then merge via pypdf if available,
+    # otherwise fall back to one PDF per figure.
+    if len(figures) == 1:
+        pio.write_image(figures[0], str(output_path), format="pdf",
+                        width=width, height=height)
+        return
+
+    # Try to merge multiple figures into one PDF using pypdf
+    try:
+        from pypdf import PdfWriter  # optional dependency
+        _export_merged_pdf(figures, output_path, width, height)
+    except ImportError:
+        # Fallback: export one PDF per figure with numeric suffix
+        stem = output_path.stem
+        for i, fig in enumerate(figures, start=1):
+            page_path = output_path.with_name(f"{stem}_page{i}.pdf")
+            pio.write_image(fig, str(page_path), format="pdf",
+                            width=width, height=height)
+
+
+def _export_merged_pdf(
+    figures: list[Any], output_path: Path, width: int, height: int
+) -> None:
+    """
+    Merge multiple figures into one PDF using pypdf.
+
+    Each figure is written to a temporary single-page PDF, then all pages
+    are combined into the final output file.
+
+    Args:
+        figures:     List of plotly Figure objects.
+        output_path: Final merged PDF path.
+        width:       Page width in pixels.
+        height:      Page height in pixels.
+    """
+    import tempfile
+    from pypdf import PdfWriter
+
+    writer = PdfWriter()
+    tmp_paths: list[Path] = []
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for i, fig in enumerate(figures):
+            tmp_path = Path(tmpdir) / f"page_{i}.pdf"
+            pio.write_image(fig, str(tmp_path), format="pdf",
+                            width=width, height=height)
+            tmp_paths.append(tmp_path)
+            writer.append(str(tmp_path))
+
+        with open(output_path, "wb") as f:
+            writer.write(f)
+
+
+def export_png(figure: Any, output_path: Path, width: int = 1400, height: int = 700) -> None:
+    """
+    Export a single plotly Figure as a PNG image.
+
+    Args:
+        figure:      A plotly Figure object.
+        output_path: Destination path for the PNG file.
+        width:       Image width in pixels (default 1400).
+        height:      Image height in pixels (default 700).
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    pio.write_image(figure, str(output_path), format="png", width=width, height=height)

--- a/build_reports/filters.py
+++ b/build_reports/filters.py
@@ -1,0 +1,112 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Definiert die Filterkriterien für Reports (Zeitraum, Projekte, Issuetype)
+#   und wendet sie auf ReportData an. Issues werden nach Closed Date gefiltert,
+#   CFD-Einträge nach dem Tagesdatum. Leere Filterlisten bedeuten "kein Filter".
+# =============================================================================
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+
+from .loader import CfdRecord, IssueRecord, ReportData
+
+
+@dataclass
+class FilterConfig:
+    """
+    Criteria used to restrict ReportData before metric computation.
+
+    All fields are optional — None or empty list means no restriction.
+
+    Attributes:
+        from_date:   Include only issues closed on or after this date.
+        to_date:     Include only issues closed on or before this date.
+        projects:    Restrict to these project keys (empty = all projects).
+        issuetypes:  Restrict to these issue types (empty = all types).
+    """
+    from_date: date | None = None
+    to_date: date | None = None
+    projects: list[str] = field(default_factory=list)
+    issuetypes: list[str] = field(default_factory=list)
+
+
+def _issue_passes(issue: IssueRecord, cfg: FilterConfig) -> bool:
+    """
+    Check whether a single issue matches the filter criteria.
+
+    Date filtering is based on closed_date. Issues with no closed_date
+    are excluded when a date range is specified.
+
+    Args:
+        issue: The issue record to evaluate.
+        cfg:   Active filter configuration.
+
+    Returns:
+        True if the issue satisfies all filter criteria.
+    """
+    if cfg.projects and issue.project not in cfg.projects:
+        return False
+    if cfg.issuetypes and issue.issuetype not in cfg.issuetypes:
+        return False
+    if cfg.from_date is not None or cfg.to_date is not None:
+        if issue.closed_date is None:
+            return False
+        closed = issue.closed_date.date()
+        if cfg.from_date is not None and closed < cfg.from_date:
+            return False
+        if cfg.to_date is not None and closed > cfg.to_date:
+            return False
+    return True
+
+
+def _cfd_passes(record: CfdRecord, cfg: FilterConfig) -> bool:
+    """
+    Check whether a CFD day record falls within the configured date range.
+
+    Args:
+        record: The CFD record (one calendar day) to evaluate.
+        cfg:    Active filter configuration.
+
+    Returns:
+        True if the day is within the configured date range.
+    """
+    if cfg.from_date is not None and record.day < cfg.from_date:
+        return False
+    if cfg.to_date is not None and record.day > cfg.to_date:
+        return False
+    return True
+
+
+def apply_filters(data: ReportData, cfg: FilterConfig) -> ReportData:
+    """
+    Return a new ReportData containing only records that match the filter config.
+
+    Issues are filtered by project, issuetype, and closed_date range.
+    CFD records are filtered by date range only (no project/type dimension in CFD).
+    The stages list and source_prefix are preserved unchanged.
+
+    Args:
+        data: Source ReportData (not mutated).
+        cfg:  Filter criteria to apply.
+
+    Returns:
+        New ReportData with filtered issues and CFD records.
+    """
+    filtered_issues = [i for i in data.issues if _issue_passes(i, cfg)]
+    filtered_cfd = [r for r in data.cfd if _cfd_passes(r, cfg)]
+
+    return ReportData(
+        issues=filtered_issues,
+        cfd=filtered_cfd,
+        stages=data.stages,
+        source_prefix=data.source_prefix,
+    )

--- a/build_reports/gui.py
+++ b/build_reports/gui.py
@@ -1,0 +1,543 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       16.04.2026
+# Geändert:       16.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Grafische Benutzeroberfläche (tkinter) für build_reports. Ermöglicht die
+#   Auswahl von IssueTimes- und CFD-XLSX, optionale Filter (Datum, Projekte,
+#   Issuetypen), Metrik-Auswahl (Checkboxen), SAFe/Global-Terminologie sowie
+#   die Anzeige der Diagramme im Browser und den Export als PDF. Die Berechnung
+#   läuft in einem separaten Thread, sodass die Oberfläche reaktionsfähig bleibt.
+# =============================================================================
+
+from __future__ import annotations
+
+import tempfile
+import threading
+import tkinter as tk
+import webbrowser
+from datetime import date
+from pathlib import Path
+from tkinter import filedialog, scrolledtext, ttk
+
+from .cli import run_reports
+from .metrics import all_metrics
+from .terminology import GLOBAL, SAFE, term
+
+
+def _parse_date_safe(value: str) -> date | None:
+    """
+    Parse a date string in YYYY-MM-DD format, returning None on empty input.
+
+    Args:
+        value: Date string; empty string returns None.
+
+    Returns:
+        Parsed date or None.
+
+    Raises:
+        ValueError: If the string is non-empty but not a valid ISO date.
+    """
+    stripped = value.strip()
+    if not stripped:
+        return None
+    return date.fromisoformat(stripped)
+
+
+def _split_csv(value: str) -> list[str]:
+    """
+    Split a comma-separated string into a list of non-empty, stripped items.
+
+    Args:
+        value: Comma-separated string from a GUI entry widget.
+
+    Returns:
+        List of non-empty strings.
+    """
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _build_combined_html(figures: list) -> str:
+    """
+    Combine multiple plotly Figure objects into a single self-contained HTML string.
+
+    The first figure includes the full Plotly.js CDN bundle; subsequent figures
+    reuse the already-loaded library to keep file size reasonable.
+
+    Args:
+        figures: List of plotly Figure objects to embed.
+
+    Returns:
+        Complete HTML document as a string.
+    """
+    parts = []
+    for i, fig in enumerate(figures):
+        parts.append(
+            fig.to_html(
+                include_plotlyjs="cdn" if i == 0 else False,
+                full_html=False,
+                config={"responsive": True},
+            )
+        )
+    body = "\n".join(parts)
+    return (
+        "<!DOCTYPE html><html><head>"
+        "<meta charset='utf-8'>"
+        "<style>body{margin:16px;font-family:sans-serif;background:#fff;}"
+        "div.plotly-graph-div{margin-bottom:32px;}</style>"
+        "</head>"
+        f"<body>{body}</body></html>"
+    )
+
+
+class BuildReportsApp(tk.Tk):
+    """
+    Main tkinter application window for build_reports.
+
+    Provides file selection, filter controls, metric checkboxes, terminology
+    toggle, a browser preview button, and PDF export. Computation runs in a
+    background thread to keep the UI responsive.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("build_reports")
+        self.resizable(True, True)
+        self.minsize(520, 600)
+
+        self._plugins = all_metrics()
+
+        # --- StringVars / BooleanVars ---
+        self._issue_times_var = tk.StringVar()
+        self._cfd_var = tk.StringVar()
+        self._from_date_var = tk.StringVar()
+        self._to_date_var = tk.StringVar()
+        self._projects_var = tk.StringVar()
+        self._issuetypes_var = tk.StringVar()
+        self._terminology_var = tk.StringVar(value=SAFE)
+        self._metric_vars: dict[str, tk.BooleanVar] = {
+            p.metric_id: tk.BooleanVar(value=True) for p in self._plugins
+        }
+
+        self._build_ui()
+
+    # -------------------------------------------------------------------------
+    # UI construction
+    # -------------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        """Build and arrange all UI widgets."""
+        pad = {"padx": 8, "pady": 3}
+        self.columnconfigure(1, weight=1)
+        row = 0
+
+        # --- Files section ---
+        row = self._section_header("Dateien", row)
+
+        tk.Label(self, text="IssueTimes", anchor="w").grid(
+            row=row, column=0, sticky="w", **pad
+        )
+        tk.Entry(self, textvariable=self._issue_times_var, state="readonly", width=50).grid(
+            row=row, column=1, sticky="ew", **pad
+        )
+        ttk.Button(self, text="Durchsuchen…", command=self._pick_issue_times).grid(
+            row=row, column=2, **pad
+        )
+        row += 1
+
+        tk.Label(self, text="CFD (optional)", anchor="w").grid(
+            row=row, column=0, sticky="w", **pad
+        )
+        tk.Entry(self, textvariable=self._cfd_var, state="readonly", width=50).grid(
+            row=row, column=1, sticky="ew", **pad
+        )
+        ttk.Button(self, text="Durchsuchen…", command=self._pick_cfd).grid(
+            row=row, column=2, **pad
+        )
+        row += 1
+
+        # --- Filters section ---
+        row = self._section_header("Filter", row)
+
+        tk.Label(self, text="Von (YYYY-MM-DD)", anchor="w").grid(
+            row=row, column=0, sticky="w", **pad
+        )
+        tk.Entry(self, textvariable=self._from_date_var, width=20).grid(
+            row=row, column=1, sticky="w", **pad
+        )
+        row += 1
+
+        tk.Label(self, text="Bis (YYYY-MM-DD)", anchor="w").grid(
+            row=row, column=0, sticky="w", **pad
+        )
+        tk.Entry(self, textvariable=self._to_date_var, width=20).grid(
+            row=row, column=1, sticky="w", **pad
+        )
+        row += 1
+
+        tk.Label(self, text="Projekte", anchor="w").grid(
+            row=row, column=0, sticky="w", **pad
+        )
+        tk.Entry(self, textvariable=self._projects_var, width=50).grid(
+            row=row, column=1, sticky="ew", **pad
+        )
+        tk.Label(self, text="kommagetrennt", fg="gray", font=("", 8)).grid(
+            row=row, column=2, sticky="w", **pad
+        )
+        row += 1
+
+        tk.Label(self, text="Issuetypen", anchor="w").grid(
+            row=row, column=0, sticky="w", **pad
+        )
+        tk.Entry(self, textvariable=self._issuetypes_var, width=50).grid(
+            row=row, column=1, sticky="ew", **pad
+        )
+        row += 1
+
+        # --- Metrics section ---
+        row = self._section_header("Metriken", row)
+
+        for plugin in self._plugins:
+            label = term(plugin.metric_id, SAFE)
+            tk.Checkbutton(
+                self,
+                text=label,
+                variable=self._metric_vars[plugin.metric_id],
+                anchor="w",
+            ).grid(row=row, column=0, columnspan=2, sticky="w", padx=16, pady=1)
+            row += 1
+
+        # Select-all / deselect-all buttons
+        btn_frame = tk.Frame(self)
+        btn_frame.grid(row=row, column=0, columnspan=3, sticky="w", padx=16, pady=2)
+        ttk.Button(btn_frame, text="Alle", width=6,
+                   command=self._select_all_metrics).pack(side="left", padx=2)
+        ttk.Button(btn_frame, text="Keine", width=6,
+                   command=self._deselect_all_metrics).pack(side="left", padx=2)
+        row += 1
+
+        # --- Terminology section ---
+        row = self._section_header("Terminologie", row)
+
+        term_frame = tk.Frame(self)
+        term_frame.grid(row=row, column=0, columnspan=3, sticky="w", padx=16, pady=4)
+        for value, label in [(SAFE, "SAFe"), (GLOBAL, "Global")]:
+            tk.Radiobutton(
+                term_frame,
+                text=label,
+                variable=self._terminology_var,
+                value=value,
+            ).pack(side="left", padx=8)
+        row += 1
+
+        # --- Action buttons ---
+        ttk.Separator(self, orient="horizontal").grid(
+            row=row, column=0, columnspan=3, sticky="ew", pady=6
+        )
+        row += 1
+
+        action_frame = tk.Frame(self)
+        action_frame.grid(row=row, column=0, columnspan=3, pady=4)
+        self._show_btn = ttk.Button(
+            action_frame, text="Anzeigen im Browser", command=self._run_show
+        )
+        self._show_btn.pack(side="left", padx=8)
+        self._pdf_btn = ttk.Button(
+            action_frame, text="Als PDF speichern", command=self._run_export_pdf
+        )
+        self._pdf_btn.pack(side="left", padx=8)
+        row += 1
+
+        # --- Log area ---
+        ttk.Separator(self, orient="horizontal").grid(
+            row=row, column=0, columnspan=3, sticky="ew", pady=4
+        )
+        row += 1
+
+        tk.Label(self, text="Log", anchor="w").grid(
+            row=row, column=0, sticky="w", **pad
+        )
+        row += 1
+
+        self._log_area = scrolledtext.ScrolledText(
+            self, height=10, state="disabled", wrap="word"
+        )
+        self._log_area.grid(
+            row=row, column=0, columnspan=3, sticky="nsew", **pad
+        )
+        self.rowconfigure(row, weight=1)
+
+    def _section_header(self, title: str, row: int) -> int:
+        """Insert a labelled separator and return the next available row index."""
+        ttk.Separator(self, orient="horizontal").grid(
+            row=row, column=0, columnspan=3, sticky="ew", pady=(8, 2)
+        )
+        row += 1
+        tk.Label(self, text=title, font=("", 9, "bold"), anchor="w").grid(
+            row=row, column=0, columnspan=3, sticky="w", padx=8
+        )
+        row += 1
+        return row
+
+    # -------------------------------------------------------------------------
+    # File pickers
+    # -------------------------------------------------------------------------
+
+    def _pick_issue_times(self) -> None:
+        """Open a file dialog to select the IssueTimes.xlsx file."""
+        path = filedialog.askopenfilename(
+            title="IssueTimes-Datei wählen",
+            filetypes=[("Excel-Dateien", "*.xlsx"), ("Alle Dateien", "*.*")],
+        )
+        if path:
+            self._issue_times_var.set(path)
+
+    def _pick_cfd(self) -> None:
+        """Open a file dialog to select the CFD.xlsx file."""
+        path = filedialog.askopenfilename(
+            title="CFD-Datei wählen",
+            filetypes=[("Excel-Dateien", "*.xlsx"), ("Alle Dateien", "*.*")],
+        )
+        if path:
+            self._cfd_var.set(path)
+
+    # -------------------------------------------------------------------------
+    # Metric selection helpers
+    # -------------------------------------------------------------------------
+
+    def _select_all_metrics(self) -> None:
+        """Set all metric checkboxes to checked."""
+        for var in self._metric_vars.values():
+            var.set(True)
+
+    def _deselect_all_metrics(self) -> None:
+        """Set all metric checkboxes to unchecked."""
+        for var in self._metric_vars.values():
+            var.set(False)
+
+    # -------------------------------------------------------------------------
+    # Input parsing
+    # -------------------------------------------------------------------------
+
+    def _read_inputs(self) -> dict | None:
+        """
+        Validate and read all user inputs from the UI.
+
+        Returns:
+            Dict with keys: issue_times, cfd, from_date, to_date, projects,
+            issuetypes, terminology, metrics. Returns None if validation fails.
+        """
+        issue_times_str = self._issue_times_var.get().strip()
+        if not issue_times_str:
+            self._log("FEHLER: Keine IssueTimes-Datei ausgewählt.")
+            return None
+        issue_times = Path(issue_times_str)
+        if not issue_times.is_file():
+            self._log(f"FEHLER: Datei nicht gefunden: {issue_times}")
+            return None
+
+        cfd_str = self._cfd_var.get().strip()
+        cfd = Path(cfd_str) if cfd_str else None
+
+        try:
+            from_date = _parse_date_safe(self._from_date_var.get())
+        except ValueError:
+            self._log(
+                f"FEHLER: Ungültiges Von-Datum '{self._from_date_var.get()}' "
+                "(erwartet YYYY-MM-DD)."
+            )
+            return None
+
+        try:
+            to_date = _parse_date_safe(self._to_date_var.get())
+        except ValueError:
+            self._log(
+                f"FEHLER: Ungültiges Bis-Datum '{self._to_date_var.get()}' "
+                "(erwartet YYYY-MM-DD)."
+            )
+            return None
+
+        projects = _split_csv(self._projects_var.get())
+        issuetypes = _split_csv(self._issuetypes_var.get())
+        terminology = self._terminology_var.get()
+
+        selected = [mid for mid, var in self._metric_vars.items() if var.get()]
+        metrics = selected if selected else None
+
+        return dict(
+            issue_times=issue_times,
+            cfd=cfd,
+            from_date=from_date,
+            to_date=to_date,
+            projects=projects,
+            issuetypes=issuetypes,
+            terminology=terminology,
+            metrics=metrics,
+        )
+
+    # -------------------------------------------------------------------------
+    # Actions
+    # -------------------------------------------------------------------------
+
+    def _run_show(self) -> None:
+        """Validate inputs, compute metrics, and display charts in the browser."""
+        inputs = self._read_inputs()
+        if inputs is None:
+            return
+        self._log("--- Berechnung gestartet ---")
+        self._show_in_browser_from_inputs(inputs)
+
+    def _show_in_browser_from_inputs(self, inputs: dict) -> None:
+        """
+        Compute metrics and open results in the default browser.
+
+        This method runs on the main thread (called via after()) to ensure
+        the browser open is safe. Computation is lightweight here since the
+        same data was already validated; figures are collected and rendered
+        to a temporary HTML file.
+
+        Args:
+            inputs: Dict of validated pipeline inputs from _read_inputs().
+        """
+        self._set_buttons_enabled(False)
+
+        def worker() -> None:
+            from .filters import FilterConfig, apply_filters
+            from .loader import load_report_data
+            from .metrics import all_metrics as _all_metrics
+            from .metrics import get_metric
+
+            try:
+                data = load_report_data(inputs["issue_times"], inputs["cfd"])
+                cfg = FilterConfig(
+                    from_date=inputs["from_date"],
+                    to_date=inputs["to_date"],
+                    projects=inputs["projects"] or [],
+                    issuetypes=inputs["issuetypes"] or [],
+                )
+                data = apply_filters(data, cfg)
+
+                if inputs["metrics"]:
+                    plugins = []
+                    for mid in inputs["metrics"]:
+                        try:
+                            plugins.append(get_metric(mid))
+                        except KeyError:
+                            self._log(f"  WARNING: Unbekannte Metrik '{mid}' — übersprungen.")
+                else:
+                    plugins = _all_metrics()
+
+                all_figures = []
+                for plugin in plugins:
+                    result = plugin.compute(data, inputs["terminology"])
+                    for w in result.warnings:
+                        self._log(f"  WARNING: {w}")
+                    all_figures.extend(plugin.render(result, inputs["terminology"]))
+
+                if not all_figures:
+                    self._log("Keine Diagramme erzeugt.")
+                    return
+
+                html = _build_combined_html(all_figures)
+                with tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".html", delete=False, encoding="utf-8"
+                ) as f:
+                    f.write(html)
+                    tmp_path = f.name
+
+                self._log(f"  → {len(all_figures)} Diagramm(e) im Browser geöffnet.")
+                webbrowser.open(f"file:///{tmp_path.replace(chr(92), '/')}")
+
+            except Exception as exc:
+                self._log(f"FEHLER: {exc}")
+            finally:
+                self.after(0, lambda: self._set_buttons_enabled(True))
+                self.after(0, lambda: self._log("--- Fertig ---"))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _run_export_pdf(self) -> None:
+        """Validate inputs, ask for save path, compute metrics, and export PDF."""
+        inputs = self._read_inputs()
+        if inputs is None:
+            return
+
+        out_path = filedialog.asksaveasfilename(
+            title="PDF speichern unter",
+            defaultextension=".pdf",
+            filetypes=[("PDF-Dateien", "*.pdf"), ("Alle Dateien", "*.*")],
+        )
+        if not out_path:
+            return
+
+        self._set_buttons_enabled(False)
+        self._log("--- PDF-Export gestartet ---")
+
+        def worker() -> None:
+            try:
+                run_reports(
+                    issue_times=inputs["issue_times"],
+                    cfd=inputs["cfd"],
+                    metrics=inputs["metrics"],
+                    from_date=inputs["from_date"],
+                    to_date=inputs["to_date"],
+                    projects=inputs["projects"],
+                    issuetypes=inputs["issuetypes"],
+                    terminology=inputs["terminology"],
+                    output_pdf=Path(out_path),
+                    log=self._log,
+                )
+                self._log("--- Fertig ---")
+            except Exception as exc:
+                self._log(f"FEHLER: {exc}")
+            finally:
+                self.after(0, lambda: self._set_buttons_enabled(True))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    # -------------------------------------------------------------------------
+    # Helpers
+    # -------------------------------------------------------------------------
+
+    def _log(self, msg: str) -> None:
+        """
+        Append a message to the log area in a thread-safe manner.
+
+        Args:
+            msg: Text to append.
+        """
+        def _append() -> None:
+            self._log_area.configure(state="normal")
+            self._log_area.insert("end", msg + "\n")
+            self._log_area.see("end")
+            self._log_area.configure(state="disabled")
+
+        self.after(0, _append)
+
+    def _set_buttons_enabled(self, enabled: bool) -> None:
+        """
+        Enable or disable the action buttons.
+
+        Args:
+            enabled: True to enable, False to disable.
+        """
+        state = "normal" if enabled else "disabled"
+        self._show_btn.configure(state=state)
+        self._pdf_btn.configure(state=state)
+
+
+def main() -> None:
+    """
+    Launch the build_reports GUI.
+
+    Entry point called by __main__.py when no CLI arguments are provided.
+    """
+    BuildReportsApp().mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/build_reports/loader.py
+++ b/build_reports/loader.py
@@ -1,0 +1,235 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Liest die von transform_data erzeugten XLSX-Dateien (IssueTimes, CFD) ein
+#   und wandelt sie in typisierte Datenstrukturen um. Die Stage-Spalten werden
+#   dynamisch aus der Kopfzeile der IssueTimes-Datei ermittelt. Fehlende oder
+#   leere Datumswerte werden als None behandelt.
+# =============================================================================
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from pathlib import Path
+
+from openpyxl import load_workbook
+
+_DT_FMT = "%d.%m.%Y %H:%M:%S"
+_DATE_FMT = "%d.%m.%Y"
+
+# Fixed column names in IssueTimes.xlsx that appear before and after stage columns
+_FIXED_PREFIX = ["Project", "Group", "Key", "Issuetype", "Status", "Created Date",
+                 "Component", "Category", "First Date", "Implementation Date", "Closed Date"]
+_FIXED_SUFFIX = ["Resolution"]
+
+
+def _parse_dt(value: object) -> datetime | None:
+    """
+    Parse a datetime value from an XLSX cell.
+
+    Accepts datetime objects (openpyxl native) or strings in DD.MM.YYYY HH:MM:SS format.
+
+    Args:
+        value: Cell value — datetime, string, or None/empty.
+
+    Returns:
+        Parsed datetime, or None if empty or unparseable.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.strptime(value.strip(), _DT_FMT)
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_date(value: object) -> date | None:
+    """
+    Parse a date value from an XLSX cell.
+
+    Accepts date/datetime objects or strings in DD.MM.YYYY format.
+
+    Args:
+        value: Cell value — date, datetime, string, or None/empty.
+
+    Returns:
+        Parsed date, or None if empty or unparseable.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.strptime(value.strip(), _DATE_FMT).date()
+        except ValueError:
+            return None
+    return None
+
+
+@dataclass
+class IssueRecord:
+    """One row from IssueTimes.xlsx — per-issue metadata and stage times."""
+    project: str
+    key: str
+    issuetype: str
+    status: str
+    created: datetime | None
+    component: str
+    first_date: datetime | None
+    implementation_date: datetime | None
+    closed_date: datetime | None
+    stage_minutes: dict[str, int]   # stage name -> minutes spent
+    resolution: str
+
+
+@dataclass
+class CfdRecord:
+    """One row from CFD.xlsx — daily stage counts for the cumulative flow diagram."""
+    day: date
+    stage_counts: dict[str, int]    # stage name -> number of issues in that stage
+
+
+@dataclass
+class ReportData:
+    """
+    Container for all data loaded from a transform_data output set.
+
+    Holds issue records, CFD records, the ordered list of workflow stages,
+    and the source prefix (e.g. 'ART_A') derived from the file names.
+    """
+    issues: list[IssueRecord] = field(default_factory=list)
+    cfd: list[CfdRecord] = field(default_factory=list)
+    stages: list[str] = field(default_factory=list)
+    source_prefix: str = ""
+
+
+def load_issue_times(path: Path) -> tuple[list[IssueRecord], list[str]]:
+    """
+    Read an IssueTimes.xlsx file and return issue records plus the ordered stage list.
+
+    Stage columns are inferred dynamically from the header row: all columns
+    between 'Closed Date' and 'Resolution' are treated as stage columns.
+
+    Args:
+        path: Path to the IssueTimes.xlsx file.
+
+    Returns:
+        Tuple of (list of IssueRecord, list of stage names in workflow order).
+    """
+    wb = load_workbook(path, read_only=True, data_only=True)
+    ws = wb.active
+
+    rows = iter(ws.iter_rows(values_only=True))
+    header = [str(c) if c is not None else "" for c in next(rows)]
+
+    # Determine stage columns dynamically
+    try:
+        stage_start = header.index("Closed Date") + 1
+        stage_end = header.index("Resolution")
+    except ValueError as e:
+        raise ValueError(f"Unexpected IssueTimes format in {path}: {e}") from e
+
+    stages = header[stage_start:stage_end]
+
+    col = {name: i for i, name in enumerate(header)}
+
+    records: list[IssueRecord] = []
+    for row in rows:
+        if not any(row):
+            continue
+
+        def cell(name: str) -> object:
+            return row[col[name]] if name in col else None
+
+        stage_minutes = {
+            s: int(row[stage_start + i] or 0)
+            for i, s in enumerate(stages)
+        }
+
+        records.append(IssueRecord(
+            project=str(cell("Project") or ""),
+            key=str(cell("Key") or ""),
+            issuetype=str(cell("Issuetype") or ""),
+            status=str(cell("Status") or ""),
+            created=_parse_dt(cell("Created Date")),
+            component=str(cell("Component") or ""),
+            first_date=_parse_dt(cell("First Date")),
+            implementation_date=_parse_dt(cell("Implementation Date")),
+            closed_date=_parse_dt(cell("Closed Date")),
+            stage_minutes=stage_minutes,
+            resolution=str(cell("Resolution") or ""),
+        ))
+
+    wb.close()
+    return records, stages
+
+
+def load_cfd(path: Path) -> tuple[list[CfdRecord], list[str]]:
+    """
+    Read a CFD.xlsx file and return daily stage count records plus the stage list.
+
+    Args:
+        path: Path to the CFD.xlsx file.
+
+    Returns:
+        Tuple of (list of CfdRecord, list of stage names in workflow order).
+    """
+    wb = load_workbook(path, read_only=True, data_only=True)
+    ws = wb.active
+
+    rows = iter(ws.iter_rows(values_only=True))
+    header = [str(c) if c is not None else "" for c in next(rows)]
+    stages = header[1:]  # first column is "Day"
+
+    records: list[CfdRecord] = []
+    for row in rows:
+        if not any(row):
+            continue
+        day = _parse_date(row[0])
+        if day is None:
+            continue
+        stage_counts = {s: int(row[i + 1] or 0) for i, s in enumerate(stages)}
+        records.append(CfdRecord(day=day, stage_counts=stage_counts))
+
+    wb.close()
+    return records, stages
+
+
+def load_report_data(issue_times_path: Path, cfd_path: Path | None = None) -> ReportData:
+    """
+    Load a complete ReportData set from IssueTimes and optionally CFD XLSX files.
+
+    The source_prefix is derived from the IssueTimes filename by stripping
+    the '_IssueTimes' suffix (e.g. 'ART_A_IssueTimes.xlsx' → 'ART_A').
+
+    Args:
+        issue_times_path: Path to the IssueTimes.xlsx file (required).
+        cfd_path:         Path to the CFD.xlsx file (optional).
+
+    Returns:
+        Populated ReportData instance.
+    """
+    issues, stages = load_issue_times(issue_times_path)
+
+    cfd: list[CfdRecord] = []
+    if cfd_path is not None:
+        cfd, _ = load_cfd(cfd_path)
+
+    stem = issue_times_path.stem
+    prefix = stem.removesuffix("_IssueTimes")
+
+    return ReportData(issues=issues, cfd=cfd, stages=stages, source_prefix=prefix)

--- a/build_reports/metrics/__init__.py
+++ b/build_reports/metrics/__init__.py
@@ -1,0 +1,76 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Plugin-Registry für Metriken. Neue Metriken werden durch Import ihrer
+#   Moduldate automatisch registriert. get_metric() liefert eine Instanz
+#   anhand der metric_id. all_metrics() liefert alle registrierten Plugins.
+# =============================================================================
+
+from __future__ import annotations
+
+from .base import MetricPlugin, MetricResult
+
+_REGISTRY: dict[str, MetricPlugin] = {}
+
+
+def register(plugin: MetricPlugin) -> MetricPlugin:
+    """
+    Register a MetricPlugin instance in the global registry.
+
+    Typically called at module level in each metric file:
+        register(FlowTimeMetric())
+
+    Args:
+        plugin: Instantiated MetricPlugin subclass to register.
+
+    Returns:
+        The same plugin instance (allows use as a decorator target).
+
+    Raises:
+        ValueError: If a plugin with the same metric_id is already registered.
+    """
+    if plugin.metric_id in _REGISTRY:
+        raise ValueError(f"Metric '{plugin.metric_id}' is already registered.")
+    _REGISTRY[plugin.metric_id] = plugin
+    return plugin
+
+
+def get_metric(metric_id: str) -> MetricPlugin:
+    """
+    Retrieve a registered metric plugin by its ID.
+
+    Args:
+        metric_id: The metric identifier (e.g. 'flow_time').
+
+    Returns:
+        The registered MetricPlugin instance.
+
+    Raises:
+        KeyError: If no metric with the given ID is registered.
+    """
+    return _REGISTRY[metric_id]
+
+
+def all_metrics() -> list[MetricPlugin]:
+    """
+    Return all registered metric plugins in registration order.
+
+    Returns:
+        List of MetricPlugin instances.
+    """
+    return list(_REGISTRY.values())
+
+
+# Import metric modules to trigger auto-registration.
+# Add new metric modules here when they are created.
+from . import flow_time          # noqa: E402, F401
+from . import flow_velocity      # noqa: E402, F401
+from . import flow_load          # noqa: E402, F401
+from . import cfd                # noqa: E402, F401
+from . import flow_distribution  # noqa: E402, F401

--- a/build_reports/metrics/base.py
+++ b/build_reports/metrics/base.py
@@ -1,0 +1,83 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Definiert die abstrakte Basisklasse MetricPlugin sowie den zugehörigen
+#   MetricResult-Container. Jede Metrik implementiert compute() zur
+#   Berechnung von Statistiken und render() zur Erzeugung von plotly-Figures.
+#   Das Plugin-System erlaubt das Hinzufügen neuer Metriken durch Ablegen
+#   einer neuen Datei im metrics/-Verzeichnis.
+# =============================================================================
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class MetricResult:
+    """
+    Container for the output of a metric computation.
+
+    Attributes:
+        metric_id:  Identifier of the metric that produced this result (e.g. 'flow_time').
+        stats:      Key/value pairs of computed statistics (e.g. median, mean, count).
+        chart_data: Arbitrary data passed from compute() to render() for figure construction.
+        warnings:   Optional list of human-readable warnings produced during computation.
+    """
+    metric_id: str
+    stats: dict[str, Any] = field(default_factory=dict)
+    chart_data: Any = None
+    warnings: list[str] = field(default_factory=list)
+
+
+class MetricPlugin(ABC):
+    """
+    Abstract base class for all build_reports metric plugins.
+
+    Subclasses must declare a unique `metric_id` class attribute and implement
+    `compute()` and `render()`. They are auto-registered via MetricRegistry
+    when the metrics package is imported.
+
+    Class attributes:
+        metric_id: Unique string key matching a constant in terminology.py
+                   (e.g. 'flow_time', 'flow_velocity').
+    """
+
+    metric_id: str = ""
+
+    @abstractmethod
+    def compute(self, data: "ReportData", terminology: str) -> MetricResult:  # noqa: F821
+        """
+        Compute statistics for this metric from the provided report data.
+
+        Args:
+            data:        Filtered ReportData from loader.py.
+            terminology: Active mode — either terminology.SAFE or terminology.GLOBAL.
+
+        Returns:
+            MetricResult with stats and chart_data populated.
+        """
+
+    @abstractmethod
+    def render(self, result: MetricResult, terminology: str) -> list[Any]:
+        """
+        Build a list of plotly Figure objects from a MetricResult.
+
+        One metric may produce multiple figures (e.g. Flow Time produces
+        a boxplot and a scatterplot).
+
+        Args:
+            result:      MetricResult produced by compute().
+            terminology: Active mode — either terminology.SAFE or terminology.GLOBAL.
+
+        Returns:
+            List of plotly Figure objects ready for display or export.
+        """

--- a/build_reports/metrics/cfd.py
+++ b/build_reports/metrics/cfd.py
@@ -1,0 +1,179 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Implementiert das Cumulative Flow Diagram (CFD). Liest die täglichen
+#   Stage-Zählungen aus CFD.xlsx und erzeugt ein gestapeltes Flächendiagramm.
+#   Zwei lineare Trendlinien zeigen den Inflow (erste Stage, kumulativ) und
+#   den Outflow (letzte Stage, kumulativ). Das In/Out-Verhältnis wird im Titel
+#   ausgewiesen. Issues, die auf 0 fallen, werden aus dem Verhältnis heraus-
+#   gehalten.
+# =============================================================================
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import plotly.graph_objects as go
+
+from ..loader import ReportData
+from ..terminology import FLOW_DISTRIBUTION, term
+from . import register
+from .base import MetricPlugin, MetricResult
+
+# Color palette for stages (cycles if more stages than colors)
+_STAGE_COLORS = [
+    "#e74c3c", "#e67e22", "#f39c12", "#2ecc71", "#1abc9c",
+    "#3498db", "#9b59b6", "#34495e", "#95a5a6", "#16a085",
+]
+
+
+@dataclass
+class _CfdData:
+    """Preprocessed data for the CFD chart."""
+    dates: list[str]                    # formatted date labels
+    stage_series: dict[str, list[int]]  # stage -> daily counts
+    stages: list[str]                   # ordered stage names
+    in_total: int                       # cumulative total first-stage at end
+    out_total: int                      # cumulative total last-stage at end
+    ratio: float                        # in/out ratio
+
+
+class CfdMetric(MetricPlugin):
+    """
+    Cumulative Flow Diagram metric.
+
+    Reads daily stage count data from CFD.xlsx and renders a stacked area chart
+    with inflow/outflow trend lines and an In/Out ratio in the title.
+    """
+
+    metric_id = "cfd"
+
+    def compute(self, data: ReportData, terminology: str) -> MetricResult:
+        """
+        Prepare CFD data for rendering.
+
+        Computes the In/Out ratio as the ratio of the cumulative count
+        in the first stage versus the last stage at the end of the period.
+
+        Args:
+            data:        Filtered ReportData (cfd records must be populated).
+            terminology: Active terminology mode (not used for CFD labels).
+
+        Returns:
+            MetricResult with stats (in_total, out_total, ratio) and
+            chart_data as _CfdData.
+        """
+        warnings: list[str] = []
+        if not data.cfd:
+            warnings.append("No CFD data available.")
+            return MetricResult(metric_id=self.metric_id, warnings=warnings)
+
+        stages = data.stages
+        if not stages:
+            warnings.append("No stages defined in data.")
+            return MetricResult(metric_id=self.metric_id, warnings=warnings)
+
+        records = sorted(data.cfd, key=lambda r: r.day)
+        dates = [r.day.strftime("%d.%m.%Y") for r in records]
+
+        stage_series: dict[str, list[int]] = {s: [] for s in stages}
+        for record in records:
+            for s in stages:
+                stage_series[s].append(record.stage_counts.get(s, 0))
+
+        # In/Out: first stage as proxy for inflow, last stage for outflow
+        in_total = max(stage_series[stages[0]]) if stage_series[stages[0]] else 0
+        out_total = max(stage_series[stages[-1]]) if stage_series[stages[-1]] else 0
+        ratio = round(in_total / out_total, 2) if out_total else 0.0
+
+        chart_data = _CfdData(
+            dates=dates,
+            stage_series=stage_series,
+            stages=stages,
+            in_total=in_total,
+            out_total=out_total,
+            ratio=ratio,
+        )
+        stats = dict(in_total=in_total, out_total=out_total, ratio=ratio,
+                     days=len(records))
+
+        return MetricResult(metric_id=self.metric_id, stats=stats,
+                            chart_data=chart_data, warnings=warnings)
+
+    def render(self, result: MetricResult, terminology: str) -> list[go.Figure]:
+        """
+        Render the Cumulative Flow Diagram as a stacked area chart.
+
+        Stages are stacked with the first stage at the top (highest cumulative).
+        Two diagonal trend lines show the overall inflow and outflow slopes.
+
+        Args:
+            result:      MetricResult from compute().
+            terminology: Active terminology mode.
+
+        Returns:
+            List with one plotly Figure, or empty list if no data.
+        """
+        if not result.chart_data:
+            return []
+
+        cd: _CfdData = result.chart_data
+        s = result.stats
+        n = len(cd.dates)
+
+        fig = go.Figure()
+
+        # Stacked area traces — reverse order so first stage is on top
+        for i, stage in enumerate(reversed(cd.stages)):
+            color = _STAGE_COLORS[i % len(_STAGE_COLORS)]
+            fig.add_trace(go.Scatter(
+                x=cd.dates,
+                y=cd.stage_series[stage],
+                mode="lines",
+                name=stage,
+                stackgroup="cfd",
+                line=dict(width=0.5, color=color),
+                fillcolor=color,
+                hovertemplate=f"<b>{stage}</b><br>%{{x}}<br>Count: %{{y}}<extra></extra>",
+            ))
+
+        # Inflow trend line (first stage cumulative max as endpoint)
+        if n > 1:
+            in_slope = cd.in_total / (n - 1)
+            out_slope = cd.out_total / (n - 1)
+            trend_x = [cd.dates[0], cd.dates[-1]]
+
+            fig.add_trace(go.Scatter(
+                x=trend_x, y=[0, cd.in_total],
+                mode="lines", name="Inflow trend",
+                line=dict(color="black", width=1.5, dash="solid"),
+                showlegend=False,
+            ))
+            fig.add_trace(go.Scatter(
+                x=trend_x, y=[0, cd.out_total],
+                mode="lines", name="Outflow trend",
+                line=dict(color="black", width=1.5, dash="solid"),
+                showlegend=False,
+            ))
+
+        fig.update_layout(
+            title=f"Ratio In/out  {s['ratio']} : 1",
+            title_font_size=12,
+            xaxis_title="Date",
+            yaxis_title="Count",
+            plot_bgcolor="#e8e8e8",
+            paper_bgcolor="#e8e8e8",
+            legend=dict(orientation="v", x=1.02, y=1),
+            height=500,
+        )
+
+        return [fig]
+
+
+register(CfdMetric())

--- a/build_reports/metrics/flow_distribution.py
+++ b/build_reports/metrics/flow_distribution.py
@@ -1,0 +1,131 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Implementiert die Flow Distribution Metrik. Zeigt die Verteilung der
+#   Issues nach Issuetype als Kreisdiagramm. Optional wird ein zweites
+#   Kreisdiagramm für die Statusverteilung gerendert. Alle Issues (offen
+#   und geschlossen) fließen in die Berechnung ein, sofern kein Zeitfilter
+#   gesetzt ist.
+# =============================================================================
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+from ..loader import ReportData
+from ..terminology import FLOW_DISTRIBUTION, term
+from . import register
+from .base import MetricPlugin, MetricResult
+
+
+@dataclass
+class _DistributionData:
+    """Frequency distributions for issuetype and status."""
+    by_type: dict[str, int]    # issuetype -> count
+    by_status: dict[str, int]  # current status -> count
+    total: int
+
+
+class FlowDistributionMetric(MetricPlugin):
+    """
+    Flow Distribution metric.
+
+    Shows the distribution of issues by issuetype and current status
+    as pie charts.
+    """
+
+    metric_id = FLOW_DISTRIBUTION
+
+    def compute(self, data: ReportData, terminology: str) -> MetricResult:
+        """
+        Count issues by issuetype and by current status.
+
+        All issues in the dataset are included regardless of closed state.
+
+        Args:
+            data:        Filtered ReportData.
+            terminology: Active terminology mode.
+
+        Returns:
+            MetricResult with stats (total, type counts) and chart_data
+            as _DistributionData.
+        """
+        warnings: list[str] = []
+        if not data.issues:
+            warnings.append("No issues found.")
+            return MetricResult(metric_id=self.metric_id, warnings=warnings)
+
+        by_type = dict(Counter(i.issuetype for i in data.issues).most_common())
+        by_status = dict(Counter(i.status for i in data.issues).most_common())
+
+        chart_data = _DistributionData(
+            by_type=by_type,
+            by_status=by_status,
+            total=len(data.issues),
+        )
+        stats = dict(total=len(data.issues), type_counts=by_type)
+
+        return MetricResult(metric_id=self.metric_id, stats=stats,
+                            chart_data=chart_data, warnings=warnings)
+
+    def render(self, result: MetricResult, terminology: str) -> list[go.Figure]:
+        """
+        Render two pie charts: distribution by issuetype and by current status.
+
+        Args:
+            result:      MetricResult from compute().
+            terminology: Active terminology mode for labels.
+
+        Returns:
+            List with one plotly Figure containing two subplots (side by side),
+            or empty list if no data.
+        """
+        if not result.chart_data:
+            return []
+
+        dd: _DistributionData = result.chart_data
+        label = term(FLOW_DISTRIBUTION, terminology)
+
+        fig = make_subplots(
+            rows=1, cols=2,
+            subplot_titles=["By Issue Type", "By Current Status"],
+            specs=[[{"type": "pie"}, {"type": "pie"}]],
+        )
+
+        fig.add_trace(go.Pie(
+            labels=list(dd.by_type.keys()),
+            values=list(dd.by_type.values()),
+            hole=0.3,
+            textinfo="label+percent",
+            hovertemplate="<b>%{label}</b><br>Count: %{value}<br>%{percent}<extra></extra>",
+        ), row=1, col=1)
+
+        fig.add_trace(go.Pie(
+            labels=list(dd.by_status.keys()),
+            values=list(dd.by_status.values()),
+            hole=0.3,
+            textinfo="label+percent",
+            hovertemplate="<b>%{label}</b><br>Count: %{value}<br>%{percent}<extra></extra>",
+        ), row=1, col=2)
+
+        fig.update_layout(
+            title=f"{label}  (n={dd.total})",
+            title_font_size=12,
+            paper_bgcolor="#e8e8e8",
+            height=450,
+        )
+
+        return [fig]
+
+
+register(FlowDistributionMetric())

--- a/build_reports/metrics/flow_load.py
+++ b/build_reports/metrics/flow_load.py
@@ -1,0 +1,259 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Implementiert die Flow Load / WIP / Aging WIP Metrik. Zeigt für alle
+#   offenen Issues (kein Closed Date) die Verweildauer in Tagen je aktueller
+#   Stage als gruppierten Boxplot. Referenzlinien zeigen Mean und Median der
+#   abgeschlossenen Issues (aus der Flow Time Metrik). Die aktuelle Stage eines
+#   Issues wird als letzte Stage in Workflow-Reihenfolge mit stage_minutes > 0
+#   bestimmt.
+# =============================================================================
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass, field
+from datetime import date
+
+import plotly.graph_objects as go
+
+from ..loader import IssueRecord, ReportData
+from ..terminology import FLOW_LOAD, term
+from . import register
+from .base import MetricPlugin, MetricResult
+
+
+def _current_stage(issue: IssueRecord, stages: list[str]) -> str:
+    """
+    Determine the current stage of an issue from its stage_minutes.
+
+    Returns the last stage in workflow order that has minutes > 0.
+    Falls back to the first stage if no stage has any time recorded.
+
+    Args:
+        issue:  IssueRecord with stage_minutes populated.
+        stages: Ordered list of workflow stage names.
+
+    Returns:
+        Name of the current stage.
+    """
+    for stage in reversed(stages):
+        if issue.stage_minutes.get(stage, 0) > 0:
+            return stage
+    return stages[0] if stages else "Unknown"
+
+
+def _age_days(issue: IssueRecord, reference: date) -> float:
+    """
+    Compute the age of an open issue in days from first_date (or created) to reference.
+
+    Args:
+        issue:     The open issue.
+        reference: Reference date (typically today).
+
+    Returns:
+        Age in days as a float.
+    """
+    start = issue.first_date or issue.created
+    if start is None:
+        return 0.0
+    return max(0.0, (reference - start.date()).days)
+
+
+@dataclass
+class _LoadData:
+    """Aggregated data for the Aging WIP chart."""
+    by_stage: dict[str, list[float]]   # stage -> list of ages in days
+    stages_ordered: list[str]          # workflow-ordered stage names (only stages with items)
+    open_count: int
+    mean_age: float
+    median_age: float
+    # Reference lines from closed issues (cycle time)
+    ct_mean: float | None = None
+    ct_median: float | None = None
+    ct_pct85: float | None = None
+    ct_pct95: float | None = None
+    done_count: int = 0
+
+
+class FlowLoadMetric(MetricPlugin):
+    """
+    Flow Load / WIP / Aging WIP metric.
+
+    Shows the age distribution of open (not-done) issues per workflow stage
+    as a grouped boxplot with cycle time reference lines.
+    """
+
+    metric_id = FLOW_LOAD
+
+    def compute(self, data: ReportData, terminology: str) -> MetricResult:
+        """
+        Compute age of all open issues grouped by current stage.
+
+        Open issues are those without a Closed Date. Age is measured from
+        First Date (or Created if First Date is absent) to today.
+
+        Cycle time stats (mean, median, 85th/95th percentile) are computed
+        from closed issues and used as reference lines in the chart.
+
+        Args:
+            data:        Filtered ReportData.
+            terminology: Active terminology mode.
+
+        Returns:
+            MetricResult with stats and chart_data as _LoadData.
+        """
+        today = date.today()
+        warnings: list[str] = []
+
+        open_issues = [i for i in data.issues if i.closed_date is None]
+        closed_issues = [i for i in data.issues if i.closed_date is not None
+                         and i.first_date is not None]
+
+        if not open_issues:
+            warnings.append("No open issues found.")
+            return MetricResult(metric_id=self.metric_id, warnings=warnings)
+
+        # Group open issues by current stage
+        by_stage: dict[str, list[float]] = {s: [] for s in data.stages}
+        for issue in open_issues:
+            stage = _current_stage(issue, data.stages)
+            age = _age_days(issue, today)
+            by_stage.setdefault(stage, []).append(age)
+
+        # Remove stages with no open issues
+        active_stages = [s for s in data.stages if by_stage.get(s)]
+        all_ages = [a for ages in by_stage.values() for a in ages]
+
+        mean_age = statistics.mean(all_ages) if all_ages else 0.0
+        median_age = statistics.median(all_ages) if all_ages else 0.0
+
+        # Cycle time reference from closed issues
+        ct_mean = ct_median = ct_p85 = ct_p95 = None
+        done_count = 0
+        if closed_issues:
+            ct_days = sorted([
+                (i.closed_date - i.first_date).total_seconds() / 86400
+                for i in closed_issues
+                if (i.closed_date - i.first_date).total_seconds() > 0
+            ])
+            if ct_days:
+                n = len(ct_days)
+                ct_mean = round(statistics.mean(ct_days), 1)
+                ct_median = round(statistics.median(ct_days), 1)
+                ct_p85 = round(ct_days[int(n * 0.85)], 1)
+                ct_p95 = round(ct_days[int(n * 0.95)], 1)
+                done_count = n
+
+        chart_data = _LoadData(
+            by_stage={s: by_stage[s] for s in active_stages},
+            stages_ordered=active_stages,
+            open_count=len(open_issues),
+            mean_age=round(mean_age, 1),
+            median_age=round(median_age, 1),
+            ct_mean=ct_mean,
+            ct_median=ct_median,
+            ct_pct85=ct_p85,
+            ct_pct95=ct_p95,
+            done_count=done_count,
+        )
+
+        stats = dict(
+            open_count=len(open_issues),
+            mean_age=round(mean_age, 1),
+            median_age=round(median_age, 1),
+            done_count=done_count,
+            ct_mean=ct_mean,
+            ct_median=ct_median,
+        )
+
+        return MetricResult(metric_id=self.metric_id, stats=stats,
+                            chart_data=chart_data, warnings=warnings)
+
+    def render(self, result: MetricResult, terminology: str) -> list[go.Figure]:
+        """
+        Render a grouped boxplot of open issue ages per workflow stage.
+
+        Reference lines show cycle time mean, median, 85th and 95th percentile
+        from closed issues. Individual issue ages are shown as overlay dots.
+
+        Args:
+            result:      MetricResult from compute().
+            terminology: Active terminology mode for labels.
+
+        Returns:
+            List with one plotly Figure, or empty list if no data.
+        """
+        if not result.chart_data:
+            return []
+
+        ld: _LoadData = result.chart_data
+        s = result.stats
+        label = term(FLOW_LOAD, terminology)
+
+        header = (
+            f"Flow Load: Aging Work in Progress  |  "
+            f"Mean {ld.mean_age} | Median: {ld.median_age} | "
+            f"# Not done items: {ld.open_count}"
+        )
+
+        fig = go.Figure()
+
+        for stage in ld.stages_ordered:
+            ages = ld.by_stage[stage]
+            fig.add_trace(go.Box(
+                y=ages, name=stage,
+                boxpoints="all", jitter=0.3, pointpos=0,
+                marker=dict(color="red", size=4, opacity=0.6),
+                line=dict(color="black"),
+                fillcolor="white",
+            ))
+
+        # Reference lines (cycle time from done items)
+        ref_lines = [
+            (ld.ct_mean, "blue", "dash", "CT Mean"),
+            (ld.ct_median, "red", "dot", "CT Median"),
+            (ld.ct_pct85, "green", "dashdot", "CT 85%"),
+            (ld.ct_pct95, "purple", "longdash", "CT 95%"),
+        ]
+        for val, color, dash, lbl in ref_lines:
+            if val is not None:
+                fig.add_hline(
+                    y=val, line_color=color, line_dash=dash,
+                    annotation_text=f"{lbl}: {val}",
+                    annotation_position="right",
+                )
+
+        ct_footer = ""
+        if ld.ct_mean is not None:
+            ct_footer = (
+                f"Current CycleTime | Mean: {ld.ct_mean} | Median: {ld.ct_median} | "
+                f"# Done items: {ld.done_count}"
+            )
+
+        fig.update_layout(
+            title=header,
+            title_font_size=11,
+            xaxis_title="Stage",
+            yaxis_title="Total Age (days)",
+            plot_bgcolor="#e8e8e8",
+            paper_bgcolor="#e8e8e8",
+            showlegend=False,
+            height=550,
+            annotations=[dict(
+                text=ct_footer, xref="paper", yref="paper",
+                x=1.0, y=-0.12, showarrow=False,
+                font=dict(size=10), xanchor="right",
+            )] if ct_footer else [],
+        )
+
+        return [fig]
+
+
+register(FlowLoadMetric())

--- a/build_reports/metrics/flow_time.py
+++ b/build_reports/metrics/flow_time.py
@@ -1,0 +1,226 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Implementiert die Flow Time / Cycle Time Metrik. Berechnet die Durchlaufzeit
+#   in Tagen (First Date → Closed Date) und stellt zwei Diagramme bereit:
+#   einen horizontalen Boxplot mit Statistik-Header und einen Scatterplot
+#   mit Trendlinie über die Zeit. Issues ohne First Date oder Closed Date sowie
+#   Issues mit Cycle Time = 0 werden aus der Berechnung ausgeschlossen.
+# =============================================================================
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass
+from datetime import datetime
+
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+from ..loader import IssueRecord, ReportData
+from ..terminology import FLOW_TIME, term
+from . import register
+from .base import MetricPlugin, MetricResult
+
+
+@dataclass
+class _FlowTimePoint:
+    """Single data point for cycle time computation."""
+    key: str
+    closed_date: datetime
+    cycle_days: float
+
+
+def _compute_stats(values: list[float]) -> dict:
+    """
+    Compute descriptive statistics for a list of cycle time values.
+
+    Args:
+        values: List of cycle time values in days (must not be empty).
+
+    Returns:
+        Dict with keys: min, q1, mean, median, q3, max, pct90, sd, cv.
+    """
+    sorted_v = sorted(values)
+    n = len(sorted_v)
+    q1 = sorted_v[n // 4]
+    q3 = sorted_v[(3 * n) // 4]
+    mean = statistics.mean(sorted_v)
+    med = statistics.median(sorted_v)
+    sd = statistics.stdev(sorted_v) if n > 1 else 0.0
+    cv = (sd / mean * 100) if mean else 0.0
+    pct90 = sorted_v[int(n * 0.9)]
+    return dict(min=sorted_v[0], q1=q1, mean=mean, median=med,
+                q3=q3, max=sorted_v[-1], pct90=pct90, sd=sd, cv=cv)
+
+
+class FlowTimeMetric(MetricPlugin):
+    """
+    Flow Time / Cycle Time metric.
+
+    Measures the time in days from First Date to Closed Date per issue.
+    Produces a horizontal boxplot and a time-series scatterplot with trend line.
+    """
+
+    metric_id = FLOW_TIME
+
+    def compute(self, data: ReportData, terminology: str) -> MetricResult:
+        """
+        Compute cycle time in days for all eligible issues.
+
+        Issues without First Date, without Closed Date, or with cycle time <= 0
+        are excluded. The count of zero-day issues is reported as a warning stat.
+
+        Args:
+            data:        Filtered ReportData from loader.py.
+            terminology: Active terminology mode (SAFe or Global).
+
+        Returns:
+            MetricResult with stats (min/q1/mean/median/q3/max/pct90/sd/cv/count/zero_day_count)
+            and chart_data as list of _FlowTimePoint.
+        """
+        points: list[_FlowTimePoint] = []
+        zero_day_count = 0
+        warnings: list[str] = []
+
+        for issue in data.issues:
+            if issue.first_date is None or issue.closed_date is None:
+                continue
+            delta = (issue.closed_date - issue.first_date).total_seconds() / 86400
+            if delta <= 0:
+                zero_day_count += 1
+                continue
+            points.append(_FlowTimePoint(
+                key=issue.key,
+                closed_date=issue.closed_date,
+                cycle_days=round(delta, 2),
+            ))
+
+        if not points:
+            warnings.append("No issues with valid First Date and Closed Date found.")
+            return MetricResult(
+                metric_id=self.metric_id,
+                stats={"zero_day_count": zero_day_count},
+                warnings=warnings,
+            )
+
+        values = [p.cycle_days for p in points]
+        stats = _compute_stats(values)
+        stats["count"] = len(points)
+        stats["zero_day_count"] = zero_day_count
+
+        return MetricResult(
+            metric_id=self.metric_id,
+            stats=stats,
+            chart_data=points,
+            warnings=warnings,
+        )
+
+    def render(self, result: MetricResult, terminology: str) -> list[go.Figure]:
+        """
+        Render a boxplot and a scatterplot for the Flow Time metric.
+
+        Args:
+            result:      MetricResult from compute().
+            terminology: Active terminology mode for axis/title labels.
+
+        Returns:
+            List of two plotly Figures: [boxplot, scatterplot].
+            Empty list if result contains no chart data.
+        """
+        if not result.chart_data:
+            return []
+
+        points: list[_FlowTimePoint] = result.chart_data
+        s = result.stats
+        label = term(FLOW_TIME, terminology)
+        source = ""
+
+        header = (
+            f"{label}  Min: {s['min']} | Q1: {s['q1']} | Mean: {round(s['mean'], 2)} | "
+            f"Median: {s['median']} | Q3: {s['q3']} | Max: {s['max']} | "
+            f"#Items: {s['count']} | 90d CT%: {s['pct90']} | "
+            f"SD: {round(s['sd'], 2)} | SD%(CV): {round(s['cv'], 2)} | "
+            f"Zero Day Issues removed: {s['zero_day_count']}"
+        )
+
+        values = [p.cycle_days for p in points]
+
+        # --- Boxplot ---
+        fig_box = go.Figure()
+        fig_box.add_trace(go.Box(
+            x=values,
+            orientation="h",
+            marker_color="orange",
+            line_color="darkgray",
+            boxpoints="outliers",
+            marker=dict(color="red", size=6),
+            name=label,
+        ))
+        fig_box.update_layout(
+            title=header,
+            title_font_size=11,
+            xaxis_title="CycleDays",
+            plot_bgcolor="#e8e8e8",
+            paper_bgcolor="#e8e8e8",
+            showlegend=False,
+            height=400,
+        )
+
+        # --- Scatterplot with trend line ---
+        dates = [p.closed_date for p in points]
+        keys = [p.key for p in points]
+
+        # Simple linear trend via index
+        n = len(values)
+        x_idx = list(range(n))
+        slope = (sum(i * v for i, v in zip(x_idx, values)) - n * statistics.mean(x_idx) * statistics.mean(values)) / (
+            sum(i ** 2 for i in x_idx) - n * statistics.mean(x_idx) ** 2
+        ) if n > 1 else 0
+        intercept = statistics.mean(values) - slope * statistics.mean(x_idx)
+        trend = [intercept + slope * i for i in x_idx]
+
+        fig_scatter = go.Figure()
+        fig_scatter.add_trace(go.Scatter(
+            x=dates, y=values, mode="markers",
+            marker=dict(color="steelblue", size=5, opacity=0.6),
+            text=keys,
+            hovertemplate="<b>%{text}</b><br>Closed: %{x}<br>Days: %{y}<extra></extra>",
+            name=label,
+        ))
+        fig_scatter.add_trace(go.Scatter(
+            x=dates, y=trend, mode="lines",
+            line=dict(color="royalblue", width=2),
+            name="Trend",
+        ))
+        # Reference lines
+        for y_val, color, dash, lbl in [
+            (s["median"], "cyan", "dash", "Median"),
+            (s["mean"], "red", "dot", "Mean"),
+            (s["pct90"], "green", "dashdot", "90th %"),
+        ]:
+            fig_scatter.add_hline(
+                y=y_val, line_color=color, line_dash=dash,
+                annotation_text=f"{lbl}: {round(y_val, 1)}",
+                annotation_position="right",
+            )
+        fig_scatter.update_layout(
+            title=header,
+            title_font_size=11,
+            xaxis_title="Date",
+            yaxis_title="CycleDays",
+            plot_bgcolor="#e8e8e8",
+            paper_bgcolor="#e8e8e8",
+            height=500,
+        )
+
+        return [fig_box, fig_scatter]
+
+
+register(FlowTimeMetric())

--- a/build_reports/metrics/flow_velocity.py
+++ b/build_reports/metrics/flow_velocity.py
@@ -1,0 +1,211 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Implementiert die Flow Velocity / Throughput Metrik. Zählt abgeschlossene
+#   Issues (Closed Date vorhanden) nach Zeitraum. Liefert drei Diagramme:
+#   Histogramm (Häufigkeit der täglich abgeschlossenen Items), Liniendiagramm
+#   (Items pro Woche über die Zeit) und Balkendiagramm (Items pro SAFe PI,
+#   d.h. ISO-Kalenderwoche gruppiert nach Jahr.KW). Nur Issues mit Closed Date
+#   fließen in die Berechnung ein.
+# =============================================================================
+
+from __future__ import annotations
+
+import statistics
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date
+
+import plotly.graph_objects as go
+
+from ..loader import ReportData
+from ..terminology import FLOW_VELOCITY, term
+from . import register
+from .base import MetricPlugin, MetricResult
+
+
+def _iso_week_label(d: date) -> str:
+    """
+    Format a date as a SAFe/ISO PI label: 'YYYY.WW'.
+
+    Args:
+        d: Calendar date.
+
+    Returns:
+        String like '2025.11'.
+    """
+    iso = d.isocalendar()
+    return f"{iso.year}.{iso.week:02d}"
+
+
+@dataclass
+class _VelocityData:
+    """Aggregated velocity data for all three chart variants."""
+    daily_freq: dict[int, int]        # items-per-day count -> frequency (histogram)
+    weekly: dict[str, int]            # 'YYYY.WW' -> item count
+    per_pi: dict[str, int]            # 'YYYY.WW' -> item count (same as weekly, displayed as bars)
+    closed_dates: list[date]          # individual closed dates (sorted)
+    avg_per_week: float
+
+
+class FlowVelocityMetric(MetricPlugin):
+    """
+    Flow Velocity / Throughput metric.
+
+    Counts completed issues (those with a Closed Date) per time period.
+    Produces three figures: a daily frequency histogram, a weekly line chart,
+    and a per-PI bar chart.
+    """
+
+    metric_id = FLOW_VELOCITY
+
+    def compute(self, data: ReportData, terminology: str) -> MetricResult:
+        """
+        Aggregate closed issue counts by day, week, and PI (ISO week).
+
+        Issues without a Closed Date are ignored.
+
+        Args:
+            data:        Filtered ReportData.
+            terminology: Active terminology mode.
+
+        Returns:
+            MetricResult with stats (count, date range, avg_per_week)
+            and chart_data as _VelocityData.
+        """
+        closed = sorted(
+            [i.closed_date.date() for i in data.issues if i.closed_date is not None]
+        )
+
+        warnings: list[str] = []
+        if not closed:
+            warnings.append("No issues with Closed Date found.")
+            return MetricResult(metric_id=self.metric_id, warnings=warnings)
+
+        # Daily: how many items closed per day, then frequency distribution
+        per_day: Counter[date] = Counter(closed)
+        daily_freq: Counter[int] = Counter(per_day.values())
+
+        # Weekly and per-PI: same ISO week label
+        weekly: Counter[str] = Counter(_iso_week_label(d) for d in closed)
+
+        # Fill in zero-count weeks between first and last to make the line chart continuous
+        all_weeks = sorted(weekly.keys())
+
+        avg_per_week = statistics.mean(weekly.values()) if weekly else 0.0
+
+        chart_data = _VelocityData(
+            daily_freq=dict(sorted(daily_freq.items())),
+            weekly=dict(sorted(weekly.items())),
+            per_pi=dict(sorted(weekly.items())),
+            closed_dates=closed,
+            avg_per_week=round(avg_per_week, 2),
+        )
+
+        from_date = closed[0]
+        to_date = closed[-1]
+        days_total = (to_date - from_date).days + 1
+
+        stats = dict(
+            count=len(closed),
+            from_date=str(from_date),
+            to_date=str(to_date),
+            days_delivered=len(set(closed)),
+            avg_per_week=round(avg_per_week, 2),
+        )
+
+        return MetricResult(metric_id=self.metric_id, stats=stats,
+                            chart_data=chart_data, warnings=warnings)
+
+    def render(self, result: MetricResult, terminology: str) -> list[go.Figure]:
+        """
+        Render three Flow Velocity figures: daily histogram, weekly line, per-PI bars.
+
+        Args:
+            result:      MetricResult from compute().
+            terminology: Active terminology mode for labels.
+
+        Returns:
+            List of three plotly Figures: [daily_hist, weekly_line, pi_bar].
+            Empty list if no chart data is available.
+        """
+        if not result.chart_data:
+            return []
+
+        vd: _VelocityData = result.chart_data
+        s = result.stats
+        label = term(FLOW_VELOCITY, terminology)
+
+        # --- Daily frequency histogram ---
+        x_daily = list(vd.daily_freq.keys())
+        y_daily = list(vd.daily_freq.values())
+        header_daily = (
+            f"{label}:  from:  {s['from_date']}  to:  {s['to_date']}  "
+            f"Days delivered:  {s['days_delivered']}"
+        )
+        fig_daily = go.Figure(go.Bar(
+            x=x_daily, y=y_daily,
+            marker_color="#4a4a4a",
+            text=y_daily, textposition="outside", textfont_color="blue",
+        ))
+        fig_daily.update_layout(
+            title=header_daily, title_font_size=11,
+            xaxis_title="Feature per Day", yaxis_title="Freq",
+            plot_bgcolor="#e8e8e8", paper_bgcolor="#e8e8e8",
+            height=450,
+        )
+
+        # --- Weekly line chart ---
+        weeks = list(vd.weekly.keys())
+        counts_weekly = list(vd.weekly.values())
+        fig_weekly = go.Figure(go.Scatter(
+            x=weeks, y=counts_weekly, mode="lines+markers",
+            line=dict(color="darkcyan", width=2),
+            marker=dict(size=5),
+            name=label,
+        ))
+        fig_weekly.update_layout(
+            title=f"{label}: Feature per week",
+            title_font_size=11,
+            xaxis_title="Week", yaxis_title="count",
+            plot_bgcolor="#e8e8e8", paper_bgcolor="#e8e8e8",
+            height=400,
+        )
+
+        # --- Per-PI bar chart ---
+        pis = list(vd.per_pi.keys())
+        counts_pi = list(vd.per_pi.values())
+        avg = s["avg_per_week"]
+
+        # Color bars: below average = gray, above = orange (alternating for visual grouping)
+        colors = ["orange" if c >= avg else "steelblue" for c in counts_pi]
+
+        fig_pi = go.Figure(go.Bar(
+            x=pis, y=counts_pi,
+            marker_color=colors,
+            text=counts_pi, textposition="inside",
+            textfont=dict(color="white", size=11),
+        ))
+        fig_pi.add_hline(
+            y=avg, line_color="red", line_dash="dot",
+            annotation_text=f"Avg: {avg}",
+            annotation_position="right",
+        )
+        fig_pi.update_layout(
+            title=f"{label}: Feature per PI.  Average = {avg}",
+            title_font_size=11,
+            xaxis_title="PI (ISO Week)", yaxis_title="count",
+            plot_bgcolor="#e8e8e8", paper_bgcolor="#e8e8e8",
+            height=450,
+        )
+
+        return [fig_daily, fig_weekly, fig_pi]
+
+
+register(FlowVelocityMetric())

--- a/build_reports/terminology.py
+++ b/build_reports/terminology.py
@@ -1,0 +1,77 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Stellt die Terminologie-Umschaltung zwischen SAFe und Global bereit.
+#   Jede Metrik hat in beiden Modi einen eigenen Namen. Die Funktion `term`
+#   liefert den korrekten Begriff für den gewählten Modus.
+# =============================================================================
+
+from __future__ import annotations
+
+# Supported terminology modes
+SAFE = "SAFe"
+GLOBAL = "Global"
+MODES = (SAFE, GLOBAL)
+
+# Metric IDs as constants
+FLOW_TIME = "flow_time"
+FLOW_VELOCITY = "flow_velocity"
+FLOW_LOAD = "flow_load"
+FLOW_DISTRIBUTION = "flow_distribution"
+FLOW_PREDICTABILITY = "flow_predictability"
+
+_TERMS: dict[str, dict[str, str]] = {
+    SAFE: {
+        FLOW_TIME: "Flow Time",
+        FLOW_VELOCITY: "Flow Velocity",
+        FLOW_LOAD: "Flow Load",
+        FLOW_DISTRIBUTION: "Flow Distribution",
+        FLOW_PREDICTABILITY: "Flow Predictability",
+    },
+    GLOBAL: {
+        FLOW_TIME: "Cycle Time",
+        FLOW_VELOCITY: "Throughput",
+        FLOW_LOAD: "WIP",
+        FLOW_DISTRIBUTION: "Flow Distribution",
+        FLOW_PREDICTABILITY: "Flow Predictability",
+    },
+}
+
+
+def term(metric_id: str, mode: str = SAFE) -> str:
+    """
+    Return the display name for a metric in the given terminology mode.
+
+    Args:
+        metric_id: One of the metric ID constants (e.g. FLOW_TIME).
+        mode:      Terminology mode — either SAFE or GLOBAL.
+
+    Returns:
+        Human-readable metric name for the selected mode.
+
+    Raises:
+        KeyError: If metric_id or mode is unknown.
+    """
+    return _TERMS[mode][metric_id]
+
+
+def all_terms(mode: str = SAFE) -> dict[str, str]:
+    """
+    Return all metric display names for the given terminology mode.
+
+    Args:
+        mode: Terminology mode — either SAFE or GLOBAL.
+
+    Returns:
+        Dict mapping metric_id to display name.
+
+    Raises:
+        KeyError: If mode is unknown.
+    """
+    return dict(_TERMS[mode])

--- a/build_reports/terminology.py
+++ b/build_reports/terminology.py
@@ -25,6 +25,7 @@ FLOW_VELOCITY = "flow_velocity"
 FLOW_LOAD = "flow_load"
 FLOW_DISTRIBUTION = "flow_distribution"
 FLOW_PREDICTABILITY = "flow_predictability"
+CFD = "cfd"
 
 _TERMS: dict[str, dict[str, str]] = {
     SAFE: {
@@ -33,6 +34,7 @@ _TERMS: dict[str, dict[str, str]] = {
         FLOW_LOAD: "Flow Load",
         FLOW_DISTRIBUTION: "Flow Distribution",
         FLOW_PREDICTABILITY: "Flow Predictability",
+        CFD: "Cumulative Flow Diagram",
     },
     GLOBAL: {
         FLOW_TIME: "Cycle Time",
@@ -40,6 +42,7 @@ _TERMS: dict[str, dict[str, str]] = {
         FLOW_LOAD: "WIP",
         FLOW_DISTRIBUTION: "Flow Distribution",
         FLOW_PREDICTABILITY: "Flow Predictability",
+        CFD: "Cumulative Flow Diagram",
     },
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Jira issue data toolsuite for metrics and reports"
 license = { text = "BSD-3-Clause" }
 requires-python = ">=3.11"
-dependencies = ["openpyxl>=3.1", "plotly>=5.20", "kaleido>=0.2"]
+dependencies = ["openpyxl>=3.1", "plotly>=5.20", "kaleido>=0.2", "pypdf>=4.0"]
 
 [project.optional-dependencies]
 docs = ["mkdocs-material>=9.5", "mkdocs-static-i18n>=1.3", "babel>=2.14"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,12 @@ version = "0.1.0"
 description = "Jira issue data toolsuite for metrics and reports"
 license = { text = "BSD-3-Clause" }
 requires-python = ">=3.11"
-dependencies = ["openpyxl>=3.1"]
+dependencies = ["openpyxl>=3.1", "plotly>=5.20", "kaleido>=0.2"]
 
 [project.optional-dependencies]
 docs = ["mkdocs-material>=9.5", "mkdocs-static-i18n>=1.3", "babel>=2.14"]
+# pywebview requires .NET SDK on Windows for pythonnet; install manually if needed
+gui = ["pywebview>=4.4"]
 
 [tool.setuptools.packages.find]
 include = ["get_data*", "transform_data*", "build_reports*", "testdata_generator*", "simulate*"]

--- a/tests/build_reports/__init__.py
+++ b/tests/build_reports/__init__.py
@@ -1,0 +1,11 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Paket-Marker für das build_reports-Testverzeichnis.
+# =============================================================================

--- a/tests/build_reports/acceptance/__init__.py
+++ b/tests/build_reports/acceptance/__init__.py
@@ -1,0 +1,11 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Paket-Marker für die build_reports Acceptance-Tests.
+# =============================================================================

--- a/tests/build_reports/acceptance/test_build_reports_acceptance.py
+++ b/tests/build_reports/acceptance/test_build_reports_acceptance.py
@@ -1,0 +1,161 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Acceptance-Tests für build_reports gegen den realen ART_A-Datensatz.
+#   Prüft, dass loader, filters und alle Metrik-Plugins mit echten Daten
+#   korrekt funktionieren: sinnvolle Statistikwerte, vollständige Datenladung,
+#   renderfähige Figures.
+# =============================================================================
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from build_reports.filters import FilterConfig, apply_filters
+from build_reports.loader import load_report_data
+from build_reports.metrics.cfd import CfdMetric
+from build_reports.metrics.flow_distribution import FlowDistributionMetric
+from build_reports.metrics.flow_load import FlowLoadMetric
+from build_reports.metrics.flow_time import FlowTimeMetric
+from build_reports.metrics.flow_velocity import FlowVelocityMetric
+from build_reports.terminology import SAFE
+
+TRANSFORM_DIR = Path(__file__).parent.parent.parent.parent / "transform_data"
+ISSUE_TIMES = TRANSFORM_DIR / "ART_A_IssueTimes.xlsx"
+CFD = TRANSFORM_DIR / "ART_A_CFD.xlsx"
+
+
+@pytest.fixture(scope="module")
+def art_a_data():
+    """Load the real ART_A dataset once for all acceptance tests."""
+    return load_report_data(ISSUE_TIMES, CFD)
+
+
+class TestLoader:
+    def test_loads_issues(self, art_a_data):
+        assert len(art_a_data.issues) > 0
+
+    def test_loads_cfd(self, art_a_data):
+        assert len(art_a_data.cfd) > 0
+
+    def test_stages_not_empty(self, art_a_data):
+        assert len(art_a_data.stages) > 0
+
+    def test_source_prefix(self, art_a_data):
+        assert art_a_data.source_prefix == "ART_A"
+
+    def test_issues_have_keys(self, art_a_data):
+        assert all(i.key for i in art_a_data.issues)
+
+    def test_issues_have_project(self, art_a_data):
+        assert all(i.project for i in art_a_data.issues)
+
+    def test_stage_minutes_keys_match_stages(self, art_a_data):
+        for issue in art_a_data.issues:
+            assert set(issue.stage_minutes.keys()) == set(art_a_data.stages)
+
+
+class TestFiltersOnRealData:
+    def test_date_filter_reduces_issues(self, art_a_data):
+        cfg = FilterConfig(from_date=date(2026, 1, 1))
+        filtered = apply_filters(art_a_data, cfg)
+        assert len(filtered.issues) < len(art_a_data.issues)
+
+    def test_date_filter_all_closed_in_range(self, art_a_data):
+        cfg = FilterConfig(from_date=date(2026, 1, 1), to_date=date(2026, 12, 31))
+        filtered = apply_filters(art_a_data, cfg)
+        for issue in filtered.issues:
+            assert issue.closed_date is not None
+            assert issue.closed_date.date() >= date(2026, 1, 1)
+
+    def test_cfd_filter_reduces_records(self, art_a_data):
+        cfg = FilterConfig(from_date=date(2026, 1, 1))
+        filtered = apply_filters(art_a_data, cfg)
+        assert len(filtered.cfd) < len(art_a_data.cfd)
+
+
+class TestFlowTimeOnRealData:
+    def test_compute_returns_count(self, art_a_data):
+        metric = FlowTimeMetric()
+        result = metric.compute(art_a_data, SAFE)
+        assert result.stats.get("count", 0) > 0
+
+    def test_median_is_positive(self, art_a_data):
+        metric = FlowTimeMetric()
+        result = metric.compute(art_a_data, SAFE)
+        assert result.stats["median"] > 0
+
+    def test_min_less_than_max(self, art_a_data):
+        metric = FlowTimeMetric()
+        result = metric.compute(art_a_data, SAFE)
+        assert result.stats["min"] <= result.stats["max"]
+
+    def test_render_produces_two_figures(self, art_a_data):
+        metric = FlowTimeMetric()
+        result = metric.compute(art_a_data, SAFE)
+        figures = metric.render(result, SAFE)
+        assert len(figures) == 2
+
+
+class TestFlowVelocityOnRealData:
+    def test_count_positive(self, art_a_data):
+        result = FlowVelocityMetric().compute(art_a_data, SAFE)
+        assert result.stats.get("count", 0) > 0
+
+    def test_render_three_figures(self, art_a_data):
+        metric = FlowVelocityMetric()
+        result = metric.compute(art_a_data, SAFE)
+        assert len(metric.render(result, SAFE)) == 3
+
+    def test_avg_per_week_positive(self, art_a_data):
+        result = FlowVelocityMetric().compute(art_a_data, SAFE)
+        assert result.stats["avg_per_week"] > 0
+
+
+class TestFlowLoadOnRealData:
+    def test_open_count_positive(self, art_a_data):
+        result = FlowLoadMetric().compute(art_a_data, SAFE)
+        assert result.stats.get("open_count", 0) > 0
+
+    def test_render_one_figure(self, art_a_data):
+        metric = FlowLoadMetric()
+        result = metric.compute(art_a_data, SAFE)
+        figs = metric.render(result, SAFE)
+        assert len(figs) == 1
+
+
+class TestCfdOnRealData:
+    def test_days_positive(self, art_a_data):
+        result = CfdMetric().compute(art_a_data, SAFE)
+        assert result.stats.get("days", 0) > 0
+
+    def test_render_one_figure(self, art_a_data):
+        metric = CfdMetric()
+        result = metric.compute(art_a_data, SAFE)
+        figs = metric.render(result, SAFE)
+        assert len(figs) == 1
+
+    def test_ratio_positive(self, art_a_data):
+        result = CfdMetric().compute(art_a_data, SAFE)
+        assert result.stats.get("ratio", 0) > 0
+
+
+class TestFlowDistributionOnRealData:
+    def test_total_matches_issue_count(self, art_a_data):
+        result = FlowDistributionMetric().compute(art_a_data, SAFE)
+        assert result.stats["total"] == len(art_a_data.issues)
+
+    def test_render_one_figure_with_two_pies(self, art_a_data):
+        metric = FlowDistributionMetric()
+        result = metric.compute(art_a_data, SAFE)
+        figs = metric.render(result, SAFE)
+        assert len(figs) == 1
+        pie_traces = [t for t in figs[0].data if t.type == "pie"]
+        assert len(pie_traces) == 2

--- a/tests/build_reports/acceptance/test_build_reports_acceptance.py
+++ b/tests/build_reports/acceptance/test_build_reports_acceptance.py
@@ -216,6 +216,60 @@ class TestCliPipelineOnRealData:
         assert out.exists()
 
 
+class TestGuiOnRealData:
+    def test_gui_instantiates_with_all_metrics(self):
+        """BuildReportsApp can be instantiated and all metric plugins are registered."""
+        from build_reports.gui import BuildReportsApp
+        app = BuildReportsApp()
+        try:
+            assert len(app._metric_vars) > 0, "No metric checkboxes registered"
+            from build_reports.metrics import all_metrics
+            assert len(app._metric_vars) == len(all_metrics())
+        finally:
+            app.destroy()
+
+    def test_read_inputs_fails_without_file(self):
+        """_read_inputs returns None when no IssueTimes file is set."""
+        from build_reports.gui import BuildReportsApp
+        app = BuildReportsApp()
+        try:
+            result = app._read_inputs()
+            assert result is None
+        finally:
+            app.destroy()
+
+    def test_read_inputs_returns_dict_with_valid_file(self):
+        """_read_inputs returns a complete dict when a valid file path is set."""
+        from build_reports.gui import BuildReportsApp
+        app = BuildReportsApp()
+        try:
+            app._issue_times_var.set(str(ISSUE_TIMES))
+            app._cfd_var.set(str(CFD))
+            result = app._read_inputs()
+            assert result is not None
+            assert result["issue_times"] == ISSUE_TIMES
+            assert result["cfd"] == CFD
+            # all metrics selected → full list returned (equivalent to None for run_reports)
+            from build_reports.metrics import all_metrics
+            assert set(result["metrics"]) == {p.metric_id for p in all_metrics()}
+        finally:
+            app.destroy()
+
+    def test_deselect_all_metrics_sets_specific_list(self):
+        """After deselecting all and re-selecting flow_time, only flow_time is returned."""
+        from build_reports.gui import BuildReportsApp
+        app = BuildReportsApp()
+        try:
+            app._issue_times_var.set(str(ISSUE_TIMES))
+            app._deselect_all_metrics()
+            app._metric_vars["flow_time"].set(True)
+            result = app._read_inputs()
+            assert result is not None
+            assert result["metrics"] == ["flow_time"]
+        finally:
+            app.destroy()
+
+
 class TestExportOnRealData:
     def test_export_single_pdf(self, tmp_path, art_a_data):
         metric = FlowTimeMetric()

--- a/tests/build_reports/acceptance/test_build_reports_acceptance.py
+++ b/tests/build_reports/acceptance/test_build_reports_acceptance.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pytest
 
+from build_reports.export import export_pdf, export_png
 from build_reports.filters import FilterConfig, apply_filters
 from build_reports.loader import load_report_data
 from build_reports.metrics.cfd import CfdMetric
@@ -159,3 +160,23 @@ class TestFlowDistributionOnRealData:
         assert len(figs) == 1
         pie_traces = [t for t in figs[0].data if t.type == "pie"]
         assert len(pie_traces) == 2
+
+
+class TestExportOnRealData:
+    def test_export_single_pdf(self, tmp_path, art_a_data):
+        metric = FlowTimeMetric()
+        result = metric.compute(art_a_data, SAFE)
+        figs = metric.render(result, SAFE)
+        out = tmp_path / "flow_time.pdf"
+        export_pdf([figs[0]], out)
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    def test_export_png(self, tmp_path, art_a_data):
+        metric = FlowVelocityMetric()
+        result = metric.compute(art_a_data, SAFE)
+        figs = metric.render(result, SAFE)
+        out = tmp_path / "velocity.png"
+        export_png(figs[0], out)
+        assert out.exists()
+        assert out.stat().st_size > 0

--- a/tests/build_reports/acceptance/test_build_reports_acceptance.py
+++ b/tests/build_reports/acceptance/test_build_reports_acceptance.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pytest
 
+from build_reports.cli import run_reports
 from build_reports.export import export_pdf, export_png
 from build_reports.filters import FilterConfig, apply_filters
 from build_reports.loader import load_report_data
@@ -160,6 +161,59 @@ class TestFlowDistributionOnRealData:
         assert len(figs) == 1
         pie_traces = [t for t in figs[0].data if t.type == "pie"]
         assert len(pie_traces) == 2
+
+
+class TestCliPipelineOnRealData:
+    def test_run_reports_all_metrics_produces_pdf(self, tmp_path):
+        """Full pipeline via run_reports() against real ART_A data exports a non-empty PDF."""
+        out = tmp_path / "art_a_report.pdf"
+        logged: list[str] = []
+        run_reports(
+            issue_times=ISSUE_TIMES,
+            cfd=CFD,
+            output_pdf=out,
+            log=logged.append,
+        )
+        assert out.exists(), "PDF not created"
+        assert out.stat().st_size > 0, "PDF is empty"
+        assert any("Saved" in m for m in logged)
+
+    def test_run_reports_single_metric(self, tmp_path):
+        """run_reports with a single metric produces fewer figures than all metrics."""
+        out_single = tmp_path / "single.pdf"
+        out_all = tmp_path / "all.pdf"
+        counts: list[int] = []
+
+        def counting_log(msg: str) -> None:
+            if "figure(s)" in msg:
+                counts.append(int(msg.strip().split()[1]))
+
+        run_reports(
+            issue_times=ISSUE_TIMES,
+            cfd=CFD,
+            metrics=["flow_time"],
+            output_pdf=out_single,
+            log=counting_log,
+        )
+        run_reports(
+            issue_times=ISSUE_TIMES,
+            cfd=CFD,
+            output_pdf=out_all,
+            log=counting_log,
+        )
+        assert counts[0] < counts[-1], "Single metric should produce fewer figures than all"
+
+    def test_run_reports_date_filter_accepted(self, tmp_path):
+        """run_reports accepts date filters without crashing."""
+        out = tmp_path / "filtered.pdf"
+        run_reports(
+            issue_times=ISSUE_TIMES,
+            cfd=CFD,
+            from_date=date(2026, 1, 1),
+            output_pdf=out,
+            log=lambda *_: None,
+        )
+        assert out.exists()
 
 
 class TestExportOnRealData:

--- a/tests/build_reports/unit/__init__.py
+++ b/tests/build_reports/unit/__init__.py
@@ -1,0 +1,11 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Paket-Marker für die build_reports Unit-Tests.
+# =============================================================================

--- a/tests/build_reports/unit/test_cfd.py
+++ b/tests/build_reports/unit/test_cfd.py
@@ -1,0 +1,97 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für CfdMetric. Prüft In/Out-Ratio-Berechnung, Verhalten bei
+#   leeren Daten und Render-Ausgabe.
+# =============================================================================
+
+from datetime import date
+
+import pytest
+
+from build_reports.loader import CfdRecord, ReportData
+from build_reports.metrics.cfd import CfdMetric
+from build_reports.terminology import SAFE
+
+
+def _cfd(day: date, funnel: int, done: int) -> CfdRecord:
+    return CfdRecord(day=day, stage_counts={"Funnel": funnel, "Done": done})
+
+
+@pytest.fixture
+def metric():
+    return CfdMetric()
+
+
+@pytest.fixture
+def simple_cfd_data():
+    return ReportData(
+        issues=[],
+        cfd=[
+            _cfd(date(2025, 1, 1), funnel=10, done=0),
+            _cfd(date(2025, 1, 2), funnel=20, done=2),
+            _cfd(date(2025, 1, 3), funnel=30, done=5),
+        ],
+        stages=["Funnel", "Done"],
+        source_prefix="TEST",
+    )
+
+
+class TestCompute:
+    def test_days_count(self, metric, simple_cfd_data):
+        result = metric.compute(simple_cfd_data, SAFE)
+        assert result.stats["days"] == 3
+
+    def test_in_total_is_max_of_first_stage(self, metric, simple_cfd_data):
+        result = metric.compute(simple_cfd_data, SAFE)
+        assert result.stats["in_total"] == 30
+
+    def test_out_total_is_max_of_last_stage(self, metric, simple_cfd_data):
+        result = metric.compute(simple_cfd_data, SAFE)
+        assert result.stats["out_total"] == 5
+
+    def test_ratio_calculation(self, metric, simple_cfd_data):
+        result = metric.compute(simple_cfd_data, SAFE)
+        assert result.stats["ratio"] == pytest.approx(6.0)
+
+    def test_warning_on_empty_cfd(self, metric):
+        data = ReportData(issues=[], cfd=[], stages=["Funnel"], source_prefix="")
+        result = metric.compute(data, SAFE)
+        assert result.warnings
+
+    def test_warning_on_no_stages(self, metric):
+        data = ReportData(
+            issues=[],
+            cfd=[_cfd(date(2025, 1, 1), 1, 0)],
+            stages=[],
+            source_prefix="",
+        )
+        result = metric.compute(data, SAFE)
+        assert result.warnings
+
+    def test_metric_id(self, metric, simple_cfd_data):
+        result = metric.compute(simple_cfd_data, SAFE)
+        assert result.metric_id == "cfd"
+
+
+class TestRender:
+    def test_returns_one_figure(self, metric, simple_cfd_data):
+        result = metric.compute(simple_cfd_data, SAFE)
+        figs = metric.render(result, SAFE)
+        assert len(figs) == 1
+
+    def test_title_contains_ratio(self, metric, simple_cfd_data):
+        result = metric.compute(simple_cfd_data, SAFE)
+        figs = metric.render(result, SAFE)
+        assert "6.0" in figs[0].layout.title.text
+
+    def test_returns_empty_on_no_data(self, metric):
+        data = ReportData(issues=[], cfd=[], stages=["Funnel"], source_prefix="")
+        result = metric.compute(data, SAFE)
+        assert metric.render(result, SAFE) == []

--- a/tests/build_reports/unit/test_cli.py
+++ b/tests/build_reports/unit/test_cli.py
@@ -1,0 +1,384 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       16.04.2026
+# Geändert:       16.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für cli.py. Prüft _parse_date, run_reports (Pipeline-Steuerung,
+#   Filter-Weitergabe, Metrik-Auswahl, Ausgabepfade, Warnungen) und main()
+#   (Argument-Parsing). Alle externen I/O-Aufrufe werden gemockt.
+# =============================================================================
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import plotly.graph_objects as go
+import pytest
+
+from build_reports.cli import _parse_date, run_reports
+from build_reports.metrics.base import MetricResult
+from build_reports.terminology import GLOBAL, SAFE
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_result(warnings: list[str] | None = None) -> MetricResult:
+    """Build a minimal MetricResult with one figure."""
+    return MetricResult(
+        metric_id="test",
+        stats={},
+        chart_data={},
+        warnings=warnings or [],
+    )
+
+
+def _make_plugin(metric_id: str = "test_metric", figures: int = 1) -> MagicMock:
+    """Create a mock MetricPlugin that returns `figures` go.Figure objects."""
+    plugin = MagicMock()
+    plugin.metric_id = metric_id
+    result = _make_result()
+    plugin.compute.return_value = result
+    plugin.render.return_value = [go.Figure() for _ in range(figures)]
+    return plugin
+
+
+# ---------------------------------------------------------------------------
+# _parse_date
+# ---------------------------------------------------------------------------
+
+class TestParseDate:
+    def test_valid_date(self):
+        assert _parse_date("2025-06-15") == date(2025, 6, 15)
+
+    def test_start_of_year(self):
+        assert _parse_date("2024-01-01") == date(2024, 1, 1)
+
+    def test_invalid_format_raises(self):
+        with pytest.raises(argparse.ArgumentTypeError, match="Invalid date"):
+            _parse_date("15.06.2025")
+
+    def test_invalid_date_raises(self):
+        with pytest.raises(argparse.ArgumentTypeError, match="Invalid date"):
+            _parse_date("2025-13-01")
+
+    def test_empty_string_raises(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            _parse_date("")
+
+
+# ---------------------------------------------------------------------------
+# run_reports — pipeline orchestration
+# ---------------------------------------------------------------------------
+
+class TestRunReports:
+    """Tests for the full pipeline orchestrated by run_reports()."""
+
+    @pytest.fixture
+    def issue_times(self, tmp_path) -> Path:
+        """Dummy path (never read in unit tests due to mocking)."""
+        p = tmp_path / "IssueTimes.xlsx"
+        p.touch()
+        return p
+
+    @pytest.fixture
+    def mock_data(self):
+        """Minimal ReportData mock."""
+        data = MagicMock()
+        data.issues = [MagicMock() for _ in range(10)]
+        data.cfd = [MagicMock() for _ in range(30)]
+        return data
+
+    @pytest.fixture
+    def mock_filtered(self, mock_data):
+        """Filtered data has fewer issues."""
+        filtered = MagicMock()
+        filtered.issues = mock_data.issues[:5]
+        filtered.cfd = mock_data.cfd[:15]
+        return filtered
+
+    def _patch_all(self, mock_data, mock_filtered, plugins):
+        """Return a context-manager stack that patches all external calls."""
+        return (
+            patch("build_reports.cli.load_report_data", return_value=mock_data),
+            patch("build_reports.cli.apply_filters", return_value=mock_filtered),
+            patch("build_reports.cli.all_metrics", return_value=plugins),
+        )
+
+    # --- data loading -------------------------------------------------------
+
+    def test_calls_load_report_data(self, issue_times, mock_data, mock_filtered):
+        plugin = _make_plugin()
+        with patch("build_reports.cli.load_report_data", return_value=mock_data) as mock_load, \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered), \
+             patch("build_reports.cli.all_metrics", return_value=[plugin]):
+            run_reports(issue_times, log=lambda *_: None)
+        mock_load.assert_called_once_with(issue_times, None)
+
+    def test_passes_cfd_to_loader(self, issue_times, tmp_path, mock_data, mock_filtered):
+        cfd = tmp_path / "CFD.xlsx"
+        plugin = _make_plugin()
+        with patch("build_reports.cli.load_report_data", return_value=mock_data) as mock_load, \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered), \
+             patch("build_reports.cli.all_metrics", return_value=[plugin]):
+            run_reports(issue_times, cfd=cfd, log=lambda *_: None)
+        mock_load.assert_called_once_with(issue_times, cfd)
+
+    # --- filter passthrough -------------------------------------------------
+
+    def test_passes_filter_config_to_apply_filters(self, issue_times, mock_data, mock_filtered):
+        plugin = _make_plugin()
+        with patch("build_reports.cli.load_report_data", return_value=mock_data), \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered) as mock_flt, \
+             patch("build_reports.cli.all_metrics", return_value=[plugin]):
+            run_reports(
+                issue_times,
+                from_date=date(2025, 1, 1),
+                to_date=date(2025, 12, 31),
+                projects=["PROJ"],
+                issuetypes=["Feature"],
+                log=lambda *_: None,
+            )
+        cfg = mock_flt.call_args[0][1]
+        assert cfg.from_date == date(2025, 1, 1)
+        assert cfg.to_date == date(2025, 12, 31)
+        assert cfg.projects == ["PROJ"]
+        assert cfg.issuetypes == ["Feature"]
+
+    def test_empty_projects_issuetypes_passed_as_empty_lists(
+        self, issue_times, mock_data, mock_filtered
+    ):
+        plugin = _make_plugin()
+        with patch("build_reports.cli.load_report_data", return_value=mock_data), \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered) as mock_flt, \
+             patch("build_reports.cli.all_metrics", return_value=[plugin]):
+            run_reports(issue_times, log=lambda *_: None)
+        cfg = mock_flt.call_args[0][1]
+        assert cfg.projects == []
+        assert cfg.issuetypes == []
+
+    # --- metric selection ---------------------------------------------------
+
+    def test_all_metrics_called_when_no_metrics_specified(
+        self, issue_times, mock_data, mock_filtered
+    ):
+        plugin = _make_plugin()
+        with patch("build_reports.cli.load_report_data", return_value=mock_data), \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered), \
+             patch("build_reports.cli.all_metrics", return_value=[plugin]) as mock_all:
+            run_reports(issue_times, log=lambda *_: None)
+        mock_all.assert_called_once()
+
+    def test_get_metric_called_for_each_specified_metric(
+        self, issue_times, mock_data, mock_filtered
+    ):
+        plugin = _make_plugin("flow_time")
+        with patch("build_reports.cli.load_report_data", return_value=mock_data), \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered), \
+             patch("build_reports.cli.get_metric", return_value=plugin) as mock_get, \
+             patch("build_reports.cli.all_metrics"):
+            run_reports(issue_times, metrics=["flow_time"], log=lambda *_: None)
+        mock_get.assert_called_once_with("flow_time")
+
+    def test_unknown_metric_logged_and_skipped(
+        self, issue_times, mock_data, mock_filtered
+    ):
+        logged = []
+        with patch("build_reports.cli.load_report_data", return_value=mock_data), \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered), \
+             patch("build_reports.cli.get_metric", side_effect=KeyError("unknown")), \
+             patch("build_reports.cli.all_metrics"):
+            run_reports(
+                issue_times,
+                metrics=["unknown"],
+                log=logged.append,
+            )
+        assert any("WARNING" in m and "unknown" in m for m in logged)
+
+    # --- plugin execution ---------------------------------------------------
+
+    def test_compute_called_with_filtered_data_and_terminology(
+        self, issue_times, mock_data, mock_filtered
+    ):
+        plugin = _make_plugin()
+        with patch("build_reports.cli.load_report_data", return_value=mock_data), \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered), \
+             patch("build_reports.cli.all_metrics", return_value=[plugin]):
+            run_reports(issue_times, terminology=GLOBAL, log=lambda *_: None)
+        plugin.compute.assert_called_once_with(mock_filtered, GLOBAL)
+
+    def test_render_called_with_result_and_terminology(
+        self, issue_times, mock_data, mock_filtered
+    ):
+        plugin = _make_plugin()
+        with patch("build_reports.cli.load_report_data", return_value=mock_data), \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered), \
+             patch("build_reports.cli.all_metrics", return_value=[plugin]):
+            run_reports(issue_times, terminology=GLOBAL, log=lambda *_: None)
+        plugin.render.assert_called_once_with(plugin.compute.return_value, GLOBAL)
+
+    def test_warnings_from_result_are_logged(
+        self, issue_times, mock_data, mock_filtered
+    ):
+        plugin = _make_plugin()
+        plugin.compute.return_value = _make_result(warnings=["something odd"])
+        logged = []
+        with patch("build_reports.cli.load_report_data", return_value=mock_data), \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered), \
+             patch("build_reports.cli.all_metrics", return_value=[plugin]):
+            run_reports(issue_times, log=logged.append)
+        assert any("something odd" in m for m in logged)
+
+    # --- output routing -----------------------------------------------------
+
+    def test_export_pdf_called_when_output_pdf_set(
+        self, tmp_path, issue_times, mock_data, mock_filtered
+    ):
+        plugin = _make_plugin(figures=2)
+        out = tmp_path / "report.pdf"
+        with patch("build_reports.cli.load_report_data", return_value=mock_data), \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered), \
+             patch("build_reports.cli.all_metrics", return_value=[plugin]), \
+             patch("build_reports.cli.export_pdf") as mock_export:
+            run_reports(issue_times, output_pdf=out, log=lambda *_: None)
+        mock_export.assert_called_once()
+        assert mock_export.call_args[0][1] == out
+
+    def test_pio_show_called_for_each_figure_when_open_browser(
+        self, issue_times, mock_data, mock_filtered
+    ):
+        plugin = _make_plugin(figures=3)
+        with patch("build_reports.cli.load_report_data", return_value=mock_data), \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered), \
+             patch("build_reports.cli.all_metrics", return_value=[plugin]), \
+             patch("build_reports.cli.pio") as mock_pio:
+            run_reports(issue_times, open_browser=True, log=lambda *_: None)
+        assert mock_pio.show.call_count == 3
+
+    def test_no_output_logs_warning(self, issue_times, mock_data, mock_filtered):
+        plugin = _make_plugin()
+        logged = []
+        with patch("build_reports.cli.load_report_data", return_value=mock_data), \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered), \
+             patch("build_reports.cli.all_metrics", return_value=[plugin]):
+            run_reports(issue_times, log=logged.append)
+        assert any("No output" in m for m in logged)
+
+    def test_no_figures_logs_nothing_to_export(
+        self, issue_times, mock_data, mock_filtered
+    ):
+        plugin = _make_plugin(figures=0)
+        logged = []
+        with patch("build_reports.cli.load_report_data", return_value=mock_data), \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered), \
+             patch("build_reports.cli.all_metrics", return_value=[plugin]):
+            run_reports(issue_times, output_pdf=Path("x.pdf"), log=logged.append)
+        assert any("No figures" in m for m in logged)
+
+    def test_figures_from_multiple_plugins_are_combined(
+        self, issue_times, mock_data, mock_filtered
+    ):
+        plugins = [_make_plugin("a", figures=2), _make_plugin("b", figures=3)]
+        with patch("build_reports.cli.load_report_data", return_value=mock_data), \
+             patch("build_reports.cli.apply_filters", return_value=mock_filtered), \
+             patch("build_reports.cli.all_metrics", return_value=plugins), \
+             patch("build_reports.cli.export_pdf") as mock_export:
+            run_reports(
+                issue_times,
+                output_pdf=Path("x.pdf"),
+                log=lambda *_: None,
+            )
+        all_figs = mock_export.call_args[0][0]
+        assert len(all_figs) == 5
+
+
+# ---------------------------------------------------------------------------
+# main() — argparse integration
+# ---------------------------------------------------------------------------
+
+class TestMain:
+    """Tests that main() parses arguments correctly and calls run_reports."""
+
+    def _run_main_with_argv(self, argv: list[str]) -> MagicMock:
+        """
+        Patch sys.argv, mock run_reports, call main(), and return the mock.
+        """
+        from build_reports.cli import main
+        with patch("sys.argv", ["prog"] + argv), \
+             patch("build_reports.cli.run_reports") as mock_run, \
+             patch("build_reports.cli.all_metrics", return_value=[]):
+            main()
+        return mock_run
+
+    def test_minimal_invocation_sets_issue_times(self, tmp_path):
+        issue_times = tmp_path / "IT.xlsx"
+        issue_times.touch()
+        mock_run = self._run_main_with_argv([str(issue_times)])
+        assert mock_run.call_args[1]["issue_times"] == issue_times
+
+    def test_pdf_flag_passed_as_path(self, tmp_path):
+        issue_times = tmp_path / "IT.xlsx"
+        issue_times.touch()
+        mock_run = self._run_main_with_argv([str(issue_times), "--pdf", "out.pdf"])
+        assert mock_run.call_args[1]["output_pdf"] == Path("out.pdf")
+
+    def test_browser_flag_sets_open_browser(self, tmp_path):
+        issue_times = tmp_path / "IT.xlsx"
+        issue_times.touch()
+        mock_run = self._run_main_with_argv([str(issue_times), "--browser"])
+        assert mock_run.call_args[1]["open_browser"] is True
+
+    def test_from_date_parsed(self, tmp_path):
+        issue_times = tmp_path / "IT.xlsx"
+        issue_times.touch()
+        mock_run = self._run_main_with_argv(
+            [str(issue_times), "--from-date", "2025-01-01"]
+        )
+        assert mock_run.call_args[1]["from_date"] == date(2025, 1, 1)
+
+    def test_to_date_parsed(self, tmp_path):
+        issue_times = tmp_path / "IT.xlsx"
+        issue_times.touch()
+        mock_run = self._run_main_with_argv(
+            [str(issue_times), "--to-date", "2025-12-31"]
+        )
+        assert mock_run.call_args[1]["to_date"] == date(2025, 12, 31)
+
+    def test_terminology_global(self, tmp_path):
+        issue_times = tmp_path / "IT.xlsx"
+        issue_times.touch()
+        mock_run = self._run_main_with_argv(
+            [str(issue_times), "--terminology", GLOBAL]
+        )
+        assert mock_run.call_args[1]["terminology"] == GLOBAL
+
+    def test_default_terminology_is_safe(self, tmp_path):
+        issue_times = tmp_path / "IT.xlsx"
+        issue_times.touch()
+        mock_run = self._run_main_with_argv([str(issue_times)])
+        assert mock_run.call_args[1]["terminology"] == SAFE
+
+    def test_projects_passed_as_list(self, tmp_path):
+        issue_times = tmp_path / "IT.xlsx"
+        issue_times.touch()
+        mock_run = self._run_main_with_argv(
+            [str(issue_times), "--projects", "ARTA", "ARTB"]
+        )
+        assert mock_run.call_args[1]["projects"] == ["ARTA", "ARTB"]
+
+    def test_issuetypes_passed_as_list(self, tmp_path):
+        issue_times = tmp_path / "IT.xlsx"
+        issue_times.touch()
+        mock_run = self._run_main_with_argv(
+            [str(issue_times), "--issuetypes", "Feature", "Bug"]
+        )
+        assert mock_run.call_args[1]["issuetypes"] == ["Feature", "Bug"]

--- a/tests/build_reports/unit/test_export.py
+++ b/tests/build_reports/unit/test_export.py
@@ -1,0 +1,87 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für export.py. pio.write_image wird gemockt, da kaleido einen
+#   externen Browser-Prozess benötigt. Geprüft wird die Steuerlogik: korrekte
+#   Dateinamen, Verzeichniserstellung, Fehlerbehandlung bei leerer Liste sowie
+#   das Fallback-Verhalten für mehrere Figures ohne pypdf.
+# =============================================================================
+
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import plotly.graph_objects as go
+import pytest
+
+from build_reports.export import export_pdf, export_png
+
+
+@pytest.fixture
+def simple_figure() -> go.Figure:
+    return go.Figure(go.Scatter(x=[1, 2, 3], y=[1, 4, 9]))
+
+
+@pytest.fixture
+def two_figures(simple_figure) -> list[go.Figure]:
+    return [simple_figure, go.Figure(go.Bar(x=["a"], y=[1]))]
+
+
+class TestExportPdf:
+    def test_raises_on_empty_list(self, tmp_path):
+        with pytest.raises(ValueError, match="No figures"):
+            export_pdf([], tmp_path / "out.pdf")
+
+    def test_single_figure_calls_write_image(self, tmp_path, simple_figure):
+        out = tmp_path / "report.pdf"
+        with patch("build_reports.export.pio.write_image") as mock_write:
+            export_pdf([simple_figure], out)
+        mock_write.assert_called_once_with(
+            simple_figure, str(out), format="pdf", width=1400, height=700
+        )
+
+    def test_creates_parent_dirs(self, tmp_path, simple_figure):
+        out = tmp_path / "subdir" / "nested" / "report.pdf"
+        with patch("build_reports.export.pio.write_image"):
+            export_pdf([simple_figure], out)
+        assert out.parent.exists()
+
+    def test_multiple_figures_fallback_without_pypdf(self, tmp_path, two_figures):
+        """Without pypdf, separate numbered PDFs are created."""
+        out = tmp_path / "multi.pdf"
+        with patch("build_reports.export.pio.write_image") as mock_write, \
+             patch.dict("sys.modules", {"pypdf": None}):
+            export_pdf(two_figures, out)
+        assert mock_write.call_count == 2
+        called_paths = [Path(c.args[1]) for c in mock_write.call_args_list]
+        assert any("page1" in p.name for p in called_paths)
+        assert any("page2" in p.name for p in called_paths)
+
+    def test_custom_dimensions(self, tmp_path, simple_figure):
+        out = tmp_path / "report.pdf"
+        with patch("build_reports.export.pio.write_image") as mock_write:
+            export_pdf([simple_figure], out, width=800, height=600)
+        mock_write.assert_called_once_with(
+            simple_figure, str(out), format="pdf", width=800, height=600
+        )
+
+
+class TestExportPng:
+    def test_calls_write_image_with_png_format(self, tmp_path, simple_figure):
+        out = tmp_path / "chart.png"
+        with patch("build_reports.export.pio.write_image") as mock_write:
+            export_png(simple_figure, out)
+        mock_write.assert_called_once_with(
+            simple_figure, str(out), format="png", width=1400, height=700
+        )
+
+    def test_creates_parent_dirs(self, tmp_path, simple_figure):
+        out = tmp_path / "imgs" / "chart.png"
+        with patch("build_reports.export.pio.write_image"):
+            export_png(simple_figure, out)
+        assert out.parent.exists()

--- a/tests/build_reports/unit/test_filters.py
+++ b/tests/build_reports/unit/test_filters.py
@@ -1,0 +1,140 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für filters.py. Prüft Datum-, Projekt- und Issuetype-Filter
+#   isoliert sowie in Kombination. Stellt sicher, dass ReportData nicht
+#   mutiert wird und dass CFD-Einträge korrekt nach Datum gefiltert werden.
+# =============================================================================
+
+from datetime import date, datetime
+
+import pytest
+
+from build_reports.filters import FilterConfig, apply_filters
+from build_reports.loader import CfdRecord, IssueRecord, ReportData
+
+
+def _issue(key: str, project: str = "A", issuetype: str = "Feature",
+           closed: datetime | None = None) -> IssueRecord:
+    """Helper: create a minimal IssueRecord."""
+    return IssueRecord(
+        project=project, key=key, issuetype=issuetype, status="Done",
+        created=datetime(2025, 1, 1), component="", first_date=datetime(2025, 1, 2),
+        implementation_date=None, closed_date=closed, stage_minutes={}, resolution="",
+    )
+
+
+def _cfd(day: date) -> CfdRecord:
+    """Helper: create a minimal CfdRecord."""
+    return CfdRecord(day=day, stage_counts={"Funnel": 1})
+
+
+@pytest.fixture
+def sample_data() -> ReportData:
+    return ReportData(
+        issues=[
+            _issue("A-1", project="ART_A", closed=datetime(2025, 3, 1)),
+            _issue("A-2", project="ART_A", closed=datetime(2025, 6, 15)),
+            _issue("B-1", project="ART_B", closed=datetime(2025, 9, 1)),
+            _issue("X-1", project="ART_A", issuetype="Bug", closed=datetime(2025, 4, 1)),
+            _issue("N-1", project="ART_A", closed=None),
+        ],
+        cfd=[
+            _cfd(date(2025, 1, 1)),
+            _cfd(date(2025, 6, 1)),
+            _cfd(date(2025, 12, 1)),
+        ],
+        stages=["Funnel"],
+        source_prefix="TEST",
+    )
+
+
+class TestNoFilter:
+    def test_empty_config_returns_all_issues(self, sample_data):
+        result = apply_filters(sample_data, FilterConfig())
+        assert len(result.issues) == len(sample_data.issues)
+
+    def test_empty_config_returns_all_cfd(self, sample_data):
+        result = apply_filters(sample_data, FilterConfig())
+        assert len(result.cfd) == len(sample_data.cfd)
+
+    def test_stages_preserved(self, sample_data):
+        result = apply_filters(sample_data, FilterConfig())
+        assert result.stages == sample_data.stages
+
+    def test_source_prefix_preserved(self, sample_data):
+        result = apply_filters(sample_data, FilterConfig())
+        assert result.source_prefix == "TEST"
+
+    def test_original_data_not_mutated(self, sample_data):
+        original_count = len(sample_data.issues)
+        apply_filters(sample_data, FilterConfig(projects=["ART_A"]))
+        assert len(sample_data.issues) == original_count
+
+
+class TestDateFilter:
+    def test_from_date_excludes_earlier(self, sample_data):
+        cfg = FilterConfig(from_date=date(2025, 5, 1))
+        result = apply_filters(sample_data, cfg)
+        keys = {i.key for i in result.issues}
+        assert "A-1" not in keys   # closed 2025-03-01
+
+    def test_to_date_excludes_later(self, sample_data):
+        cfg = FilterConfig(to_date=date(2025, 5, 1))
+        result = apply_filters(sample_data, cfg)
+        keys = {i.key for i in result.issues}
+        assert "A-2" not in keys   # closed 2025-06-15
+        assert "B-1" not in keys   # closed 2025-09-01
+
+    def test_date_range_inclusive_bounds(self, sample_data):
+        cfg = FilterConfig(from_date=date(2025, 3, 1), to_date=date(2025, 6, 15))
+        result = apply_filters(sample_data, cfg)
+        keys = {i.key for i in result.issues}
+        assert "A-1" in keys
+        assert "A-2" in keys
+
+    def test_no_closed_date_excluded_when_range_set(self, sample_data):
+        cfg = FilterConfig(from_date=date(2025, 1, 1))
+        result = apply_filters(sample_data, cfg)
+        keys = {i.key for i in result.issues}
+        assert "N-1" not in keys
+
+    def test_cfd_filtered_by_date(self, sample_data):
+        cfg = FilterConfig(from_date=date(2025, 3, 1), to_date=date(2025, 7, 1))
+        result = apply_filters(sample_data, cfg)
+        assert len(result.cfd) == 1
+        assert result.cfd[0].day == date(2025, 6, 1)
+
+
+class TestProjectFilter:
+    def test_single_project(self, sample_data):
+        cfg = FilterConfig(projects=["ART_B"])
+        result = apply_filters(sample_data, cfg)
+        assert all(i.project == "ART_B" for i in result.issues)
+        assert len(result.issues) == 1
+
+    def test_multiple_projects(self, sample_data):
+        cfg = FilterConfig(projects=["ART_A", "ART_B"])
+        result = apply_filters(sample_data, cfg)
+        projects = {i.project for i in result.issues}
+        assert projects == {"ART_A", "ART_B"}
+
+
+class TestIssuetypeFilter:
+    def test_single_type(self, sample_data):
+        cfg = FilterConfig(issuetypes=["Bug"])
+        result = apply_filters(sample_data, cfg)
+        assert len(result.issues) == 1
+        assert result.issues[0].key == "X-1"
+
+    def test_combined_project_and_type(self, sample_data):
+        cfg = FilterConfig(projects=["ART_A"], issuetypes=["Feature"])
+        result = apply_filters(sample_data, cfg)
+        assert all(i.project == "ART_A" and i.issuetype == "Feature"
+                   for i in result.issues)

--- a/tests/build_reports/unit/test_flow_distribution.py
+++ b/tests/build_reports/unit/test_flow_distribution.py
@@ -1,0 +1,93 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für FlowDistributionMetric. Prüft Zählung nach Issuetype und
+#   Status sowie Render-Ausgabe (zwei Pie-Charts als Subplots).
+# =============================================================================
+
+from datetime import datetime
+
+import pytest
+
+from build_reports.loader import IssueRecord, ReportData
+from build_reports.metrics.flow_distribution import FlowDistributionMetric
+from build_reports.terminology import SAFE
+
+
+def _issue(key: str, issuetype: str, status: str) -> IssueRecord:
+    return IssueRecord(
+        project="P", key=key, issuetype=issuetype, status=status,
+        created=datetime(2025, 1, 1), component="",
+        first_date=None, implementation_date=None, closed_date=None,
+        stage_minutes={}, resolution="",
+    )
+
+
+@pytest.fixture
+def metric():
+    return FlowDistributionMetric()
+
+
+@pytest.fixture
+def mixed_data():
+    return ReportData(
+        issues=[
+            _issue("A-1", "Feature", "Done"),
+            _issue("A-2", "Feature", "Done"),
+            _issue("A-3", "Bug", "In Progress"),
+            _issue("A-4", "Story", "Done"),
+        ],
+        cfd=[], stages=[], source_prefix="TEST",
+    )
+
+
+class TestCompute:
+    def test_total_count(self, metric, mixed_data):
+        result = metric.compute(mixed_data, SAFE)
+        assert result.stats["total"] == 4
+
+    def test_type_counts(self, metric, mixed_data):
+        result = metric.compute(mixed_data, SAFE)
+        counts = result.stats["type_counts"]
+        assert counts["Feature"] == 2
+        assert counts["Bug"] == 1
+        assert counts["Story"] == 1
+
+    def test_by_status_in_chart_data(self, metric, mixed_data):
+        result = metric.compute(mixed_data, SAFE)
+        by_status = result.chart_data.by_status
+        assert by_status["Done"] == 3
+        assert by_status["In Progress"] == 1
+
+    def test_warning_on_empty(self, metric):
+        data = ReportData(issues=[], cfd=[], stages=[], source_prefix="")
+        result = metric.compute(data, SAFE)
+        assert result.warnings
+
+    def test_metric_id(self, metric, mixed_data):
+        result = metric.compute(mixed_data, SAFE)
+        assert result.metric_id == "flow_distribution"
+
+
+class TestRender:
+    def test_returns_one_figure(self, metric, mixed_data):
+        result = metric.compute(mixed_data, SAFE)
+        figs = metric.render(result, SAFE)
+        assert len(figs) == 1
+
+    def test_figure_has_two_pie_traces(self, metric, mixed_data):
+        result = metric.compute(mixed_data, SAFE)
+        figs = metric.render(result, SAFE)
+        pie_traces = [t for t in figs[0].data if t.type == "pie"]
+        assert len(pie_traces) == 2
+
+    def test_returns_empty_on_no_data(self, metric):
+        data = ReportData(issues=[], cfd=[], stages=[], source_prefix="")
+        result = metric.compute(data, SAFE)
+        assert metric.render(result, SAFE) == []

--- a/tests/build_reports/unit/test_flow_load.py
+++ b/tests/build_reports/unit/test_flow_load.py
@@ -1,0 +1,111 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für FlowLoadMetric. Prüft Trennung open/closed, Altersberechnung,
+#   Stage-Zuordnung und Render-Ausgabe.
+# =============================================================================
+
+from datetime import datetime
+
+import pytest
+
+from build_reports.loader import IssueRecord, ReportData
+from build_reports.metrics.flow_load import FlowLoadMetric, _age_days, _current_stage
+from build_reports.terminology import SAFE
+
+
+def _issue(key: str, closed: datetime | None = None,
+           stage_minutes: dict | None = None,
+           first: datetime | None = None) -> IssueRecord:
+    return IssueRecord(
+        project="P", key=key, issuetype="Feature", status="In Progress",
+        created=datetime(2025, 1, 1), component="",
+        first_date=first or datetime(2025, 1, 2),
+        implementation_date=None, closed_date=closed,
+        stage_minutes=stage_minutes or {}, resolution="",
+    )
+
+
+STAGES = ["Funnel", "Analysis", "Implementation", "Done"]
+
+
+@pytest.fixture
+def metric():
+    return FlowLoadMetric()
+
+
+@pytest.fixture
+def mixed_data():
+    return ReportData(
+        issues=[
+            _issue("O-1", closed=None,
+                   stage_minutes={"Funnel": 0, "Analysis": 100, "Implementation": 50, "Done": 0}),
+            _issue("O-2", closed=None,
+                   stage_minutes={"Funnel": 200, "Analysis": 0, "Implementation": 0, "Done": 0}),
+            _issue("C-1", closed=datetime(2025, 3, 1),
+                   first=datetime(2025, 1, 1),
+                   stage_minutes={"Funnel": 10, "Analysis": 20, "Implementation": 30, "Done": 5}),
+        ],
+        cfd=[], stages=STAGES, source_prefix="TEST",
+    )
+
+
+class TestCurrentStage:
+    def test_returns_last_nonzero_stage(self):
+        issue = _issue("X", stage_minutes={"Funnel": 10, "Analysis": 20, "Implementation": 0, "Done": 0})
+        assert _current_stage(issue, STAGES) == "Analysis"
+
+    def test_fallback_to_first_stage_when_all_zero(self):
+        issue = _issue("X", stage_minutes={"Funnel": 0, "Analysis": 0})
+        assert _current_stage(issue, ["Funnel", "Analysis"]) == "Funnel"
+
+    def test_single_stage_with_time(self):
+        issue = _issue("X", stage_minutes={"Funnel": 5})
+        assert _current_stage(issue, ["Funnel"]) == "Funnel"
+
+
+class TestCompute:
+    def test_only_open_issues_counted(self, metric, mixed_data):
+        result = metric.compute(mixed_data, SAFE)
+        assert result.stats["open_count"] == 2
+
+    def test_warning_when_no_open_issues(self, metric):
+        data = ReportData(
+            issues=[_issue("C-1", closed=datetime(2025, 3, 1))],
+            cfd=[], stages=STAGES, source_prefix="",
+        )
+        result = metric.compute(data, SAFE)
+        assert result.warnings
+
+    def test_done_count_from_closed_issues(self, metric, mixed_data):
+        result = metric.compute(mixed_data, SAFE)
+        assert result.stats["done_count"] > 0
+
+    def test_mean_age_positive(self, metric, mixed_data):
+        result = metric.compute(mixed_data, SAFE)
+        assert result.stats["mean_age"] > 0
+
+    def test_metric_id(self, metric, mixed_data):
+        result = metric.compute(mixed_data, SAFE)
+        assert result.metric_id == "flow_load"
+
+
+class TestRender:
+    def test_returns_one_figure(self, metric, mixed_data):
+        result = metric.compute(mixed_data, SAFE)
+        figs = metric.render(result, SAFE)
+        assert len(figs) == 1
+
+    def test_returns_empty_on_no_data(self, metric):
+        data = ReportData(
+            issues=[_issue("C-1", closed=datetime(2025, 3, 1))],
+            cfd=[], stages=STAGES, source_prefix="",
+        )
+        result = metric.compute(data, SAFE)
+        assert metric.render(result, SAFE) == []

--- a/tests/build_reports/unit/test_flow_time.py
+++ b/tests/build_reports/unit/test_flow_time.py
@@ -1,0 +1,126 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für die FlowTimeMetric. Prüft Berechnung der Cycle Time,
+#   Ausschluss ungültiger Issues (kein First/Closed Date, Zero-Day),
+#   Statistikwerte und die Render-Ausgabe (Anzahl und Typ der Figures).
+# =============================================================================
+
+from datetime import datetime
+
+import pytest
+
+from build_reports.loader import IssueRecord, ReportData
+from build_reports.metrics.flow_time import FlowTimeMetric
+from build_reports.terminology import GLOBAL, SAFE
+
+
+def _issue(key: str, first: datetime | None, closed: datetime | None) -> IssueRecord:
+    """Helper: create a minimal IssueRecord with given dates."""
+    return IssueRecord(
+        project="P", key=key, issuetype="Feature", status="Done",
+        created=datetime(2025, 1, 1), component="",
+        first_date=first, implementation_date=None, closed_date=closed,
+        stage_minutes={}, resolution="",
+    )
+
+
+@pytest.fixture
+def metric() -> FlowTimeMetric:
+    return FlowTimeMetric()
+
+
+@pytest.fixture
+def simple_data() -> ReportData:
+    """Three issues: 10, 20, 30 days cycle time."""
+    base = datetime(2025, 1, 1)
+    return ReportData(
+        issues=[
+            _issue("A-1", datetime(2025, 1, 1), datetime(2025, 1, 11)),  # 10 days
+            _issue("A-2", datetime(2025, 1, 1), datetime(2025, 1, 21)),  # 20 days
+            _issue("A-3", datetime(2025, 1, 1), datetime(2025, 1, 31)),  # 30 days
+        ],
+        cfd=[], stages=[], source_prefix="TEST",
+    )
+
+
+class TestCompute:
+    def test_count(self, metric, simple_data):
+        result = metric.compute(simple_data, SAFE)
+        assert result.stats["count"] == 3
+
+    def test_median(self, metric, simple_data):
+        result = metric.compute(simple_data, SAFE)
+        assert result.stats["median"] == 20.0
+
+    def test_min_max(self, metric, simple_data):
+        result = metric.compute(simple_data, SAFE)
+        assert result.stats["min"] == 10.0
+        assert result.stats["max"] == 30.0
+
+    def test_mean(self, metric, simple_data):
+        result = metric.compute(simple_data, SAFE)
+        assert result.stats["mean"] == pytest.approx(20.0)
+
+    def test_excludes_missing_first_date(self, metric):
+        data = ReportData(
+            issues=[_issue("X", None, datetime(2025, 2, 1))],
+            cfd=[], stages=[], source_prefix="",
+        )
+        result = metric.compute(data, SAFE)
+        assert result.stats.get("count", 0) == 0
+
+    def test_excludes_missing_closed_date(self, metric):
+        data = ReportData(
+            issues=[_issue("X", datetime(2025, 1, 1), None)],
+            cfd=[], stages=[], source_prefix="",
+        )
+        result = metric.compute(data, SAFE)
+        assert result.stats.get("count", 0) == 0
+
+    def test_excludes_zero_day_issues(self, metric):
+        data = ReportData(
+            issues=[_issue("X", datetime(2025, 1, 1), datetime(2025, 1, 1))],
+            cfd=[], stages=[], source_prefix="",
+        )
+        result = metric.compute(data, SAFE)
+        assert result.stats.get("count", 0) == 0
+        assert result.stats.get("zero_day_count", 0) == 1
+
+    def test_warning_on_empty_data(self, metric):
+        data = ReportData(issues=[], cfd=[], stages=[], source_prefix="")
+        result = metric.compute(data, SAFE)
+        assert result.warnings
+
+    def test_metric_id(self, metric, simple_data):
+        result = metric.compute(simple_data, SAFE)
+        assert result.metric_id == "flow_time"
+
+
+class TestRender:
+    def test_returns_two_figures(self, metric, simple_data):
+        result = metric.compute(simple_data, SAFE)
+        figures = metric.render(result, SAFE)
+        assert len(figures) == 2
+
+    def test_returns_empty_on_no_data(self, metric):
+        data = ReportData(issues=[], cfd=[], stages=[], source_prefix="")
+        result = metric.compute(data, SAFE)
+        figures = metric.render(result, SAFE)
+        assert figures == []
+
+    def test_global_terminology_in_title(self, metric, simple_data):
+        result = metric.compute(simple_data, GLOBAL)
+        figures = metric.render(result, GLOBAL)
+        assert "Cycle Time" in figures[0].layout.title.text
+
+    def test_safe_terminology_in_title(self, metric, simple_data):
+        result = metric.compute(simple_data, SAFE)
+        figures = metric.render(result, SAFE)
+        assert "Flow Time" in figures[0].layout.title.text

--- a/tests/build_reports/unit/test_flow_velocity.py
+++ b/tests/build_reports/unit/test_flow_velocity.py
@@ -1,0 +1,96 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für FlowVelocityMetric. Prüft Aggregation nach Tag/Woche/PI,
+#   Ausschluss von Issues ohne Closed Date sowie Render-Ausgabe.
+# =============================================================================
+
+from datetime import datetime
+
+import pytest
+
+from build_reports.loader import IssueRecord, ReportData
+from build_reports.metrics.flow_velocity import FlowVelocityMetric
+from build_reports.terminology import SAFE
+
+
+def _issue(key: str, closed: datetime | None) -> IssueRecord:
+    return IssueRecord(
+        project="P", key=key, issuetype="Feature", status="Done",
+        created=datetime(2025, 1, 1), component="",
+        first_date=datetime(2025, 1, 2), implementation_date=None,
+        closed_date=closed, stage_minutes={}, resolution="",
+    )
+
+
+@pytest.fixture
+def metric():
+    return FlowVelocityMetric()
+
+
+@pytest.fixture
+def data_5_issues():
+    """Five issues closed across different days in the same week."""
+    return ReportData(
+        issues=[
+            _issue("A-1", datetime(2025, 3, 3)),   # Mon
+            _issue("A-2", datetime(2025, 3, 3)),   # Mon (same day as A-1)
+            _issue("A-3", datetime(2025, 3, 5)),   # Wed
+            _issue("A-4", datetime(2025, 3, 10)),  # Mon next week
+            _issue("A-5", None),                   # no closed date — excluded
+        ],
+        cfd=[], stages=[], source_prefix="TEST",
+    )
+
+
+class TestCompute:
+    def test_count_excludes_no_closed_date(self, metric, data_5_issues):
+        result = metric.compute(data_5_issues, SAFE)
+        assert result.stats["count"] == 4
+
+    def test_daily_freq_two_on_same_day(self, metric, data_5_issues):
+        result = metric.compute(data_5_issues, SAFE)
+        freq = result.chart_data.daily_freq
+        # Two items on 2025-03-03 → freq[2] = 1
+        assert freq.get(2, 0) == 1
+
+    def test_weekly_groups_correctly(self, metric, data_5_issues):
+        result = metric.compute(data_5_issues, SAFE)
+        weekly = result.chart_data.weekly
+        # 2025-W10 (Mar 3+5) = 3 items, 2025-W11 (Mar 10) = 1 item
+        assert sum(weekly.values()) == 4
+
+    def test_warning_on_no_data(self, metric):
+        data = ReportData(issues=[], cfd=[], stages=[], source_prefix="")
+        result = metric.compute(data, SAFE)
+        assert result.warnings
+
+    def test_warning_when_all_open(self, metric):
+        data = ReportData(
+            issues=[_issue("X", None)],
+            cfd=[], stages=[], source_prefix="",
+        )
+        result = metric.compute(data, SAFE)
+        assert result.warnings
+
+    def test_metric_id(self, metric, data_5_issues):
+        result = metric.compute(data_5_issues, SAFE)
+        assert result.metric_id == "flow_velocity"
+
+
+class TestRender:
+    def test_returns_three_figures(self, metric, data_5_issues):
+        result = metric.compute(data_5_issues, SAFE)
+        figs = metric.render(result, SAFE)
+        assert len(figs) == 3
+
+    def test_returns_empty_on_no_data(self, metric):
+        data = ReportData(issues=[], cfd=[], stages=[], source_prefix="")
+        result = metric.compute(data, SAFE)
+        assert metric.render(result, SAFE) == []

--- a/tests/build_reports/unit/test_gui.py
+++ b/tests/build_reports/unit/test_gui.py
@@ -1,0 +1,97 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       16.04.2026
+# Geändert:       16.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für die Display-unabhängigen Hilfsfunktionen in gui.py:
+#   _parse_date_safe, _split_csv und _build_combined_html. Der tkinter-Teil
+#   (BuildReportsApp) wird hier nicht instanziiert, da dies eine laufende
+#   Anzeige erfordern würde.
+# =============================================================================
+
+from __future__ import annotations
+
+from datetime import date
+
+import plotly.graph_objects as go
+import pytest
+
+from build_reports.gui import _build_combined_html, _parse_date_safe, _split_csv
+
+
+class TestParseDateSafe:
+    def test_empty_string_returns_none(self):
+        assert _parse_date_safe("") is None
+
+    def test_whitespace_only_returns_none(self):
+        assert _parse_date_safe("   ") is None
+
+    def test_valid_date_parsed(self):
+        assert _parse_date_safe("2025-06-15") == date(2025, 6, 15)
+
+    def test_valid_date_with_surrounding_whitespace(self):
+        assert _parse_date_safe("  2025-01-01  ") == date(2025, 1, 1)
+
+    def test_invalid_format_raises_value_error(self):
+        with pytest.raises(ValueError):
+            _parse_date_safe("15.06.2025")
+
+    def test_invalid_date_raises_value_error(self):
+        with pytest.raises(ValueError):
+            _parse_date_safe("2025-13-01")
+
+
+class TestSplitCsv:
+    def test_empty_string_returns_empty_list(self):
+        assert _split_csv("") == []
+
+    def test_whitespace_only_returns_empty_list(self):
+        assert _split_csv("   ") == []
+
+    def test_single_item(self):
+        assert _split_csv("ARTA") == ["ARTA"]
+
+    def test_multiple_items(self):
+        assert _split_csv("ARTA, ARTB, ARTC") == ["ARTA", "ARTB", "ARTC"]
+
+    def test_strips_whitespace_from_items(self):
+        assert _split_csv("  Feature ,  Bug  ") == ["Feature", "Bug"]
+
+    def test_ignores_empty_segments(self):
+        assert _split_csv("ARTA,,ARTB") == ["ARTA", "ARTB"]
+
+    def test_trailing_comma_ignored(self):
+        assert _split_csv("ARTA,") == ["ARTA"]
+
+
+class TestBuildCombinedHtml:
+    def test_returns_string(self):
+        fig = go.Figure(go.Scatter(x=[1, 2], y=[1, 2]))
+        html = _build_combined_html([fig])
+        assert isinstance(html, str)
+
+    def test_html_contains_doctype(self):
+        fig = go.Figure()
+        html = _build_combined_html([fig])
+        assert "<!DOCTYPE html>" in html
+
+    def test_first_figure_includes_plotlyjs(self):
+        fig = go.Figure()
+        html = _build_combined_html([fig])
+        # cdn reference appears when include_plotlyjs='cdn'
+        assert "cdn.plot.ly" in html or "plotly" in html.lower()
+
+    def test_multiple_figures_all_embedded(self):
+        figs = [go.Figure(go.Scatter(x=[i], y=[i])) for i in range(3)]
+        html = _build_combined_html(figs)
+        # Each figure generates a unique div id; count plotly-graph-div occurrences
+        assert html.count("plotly-graph-div") >= 3
+
+    def test_empty_list_returns_valid_html(self):
+        html = _build_combined_html([])
+        assert "<html>" in html
+        assert "<body>" in html

--- a/tests/build_reports/unit/test_terminology.py
+++ b/tests/build_reports/unit/test_terminology.py
@@ -1,0 +1,78 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       15.04.2026
+# Geändert:       15.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für terminology.py. Prüft Namens-Mapping in beiden Modi,
+#   Fehlerverhalten bei unbekannten IDs/Modi und Vollständigkeit der Einträge.
+# =============================================================================
+
+import pytest
+
+from build_reports.terminology import (
+    FLOW_DISTRIBUTION, FLOW_LOAD, FLOW_TIME, FLOW_VELOCITY,
+    GLOBAL, SAFE, all_terms, term,
+)
+
+
+class TestTerm:
+    def test_safe_flow_time(self):
+        assert term(FLOW_TIME, SAFE) == "Flow Time"
+
+    def test_global_flow_time(self):
+        assert term(FLOW_TIME, GLOBAL) == "Cycle Time"
+
+    def test_safe_flow_velocity(self):
+        assert term(FLOW_VELOCITY, SAFE) == "Flow Velocity"
+
+    def test_global_flow_velocity(self):
+        assert term(FLOW_VELOCITY, GLOBAL) == "Throughput"
+
+    def test_safe_flow_load(self):
+        assert term(FLOW_LOAD, SAFE) == "Flow Load"
+
+    def test_global_flow_load(self):
+        assert term(FLOW_LOAD, GLOBAL) == "WIP"
+
+    def test_flow_distribution_same_in_both_modes(self):
+        assert term(FLOW_DISTRIBUTION, SAFE) == term(FLOW_DISTRIBUTION, GLOBAL)
+
+    def test_unknown_metric_id_raises(self):
+        with pytest.raises(KeyError):
+            term("does_not_exist", SAFE)
+
+    def test_unknown_mode_raises(self):
+        with pytest.raises(KeyError):
+            term(FLOW_TIME, "Unknown")
+
+    def test_default_mode_is_safe(self):
+        assert term(FLOW_TIME) == term(FLOW_TIME, SAFE)
+
+
+class TestAllTerms:
+    def test_returns_dict(self):
+        result = all_terms(SAFE)
+        assert isinstance(result, dict)
+
+    def test_safe_contains_all_ids(self):
+        result = all_terms(SAFE)
+        assert FLOW_TIME in result
+        assert FLOW_VELOCITY in result
+        assert FLOW_LOAD in result
+        assert FLOW_DISTRIBUTION in result
+
+    def test_global_differs_from_safe(self):
+        safe = all_terms(SAFE)
+        global_ = all_terms(GLOBAL)
+        assert safe[FLOW_TIME] != global_[FLOW_TIME]
+        assert safe[FLOW_VELOCITY] != global_[FLOW_VELOCITY]
+
+    def test_returns_copy(self):
+        # Mutating the returned dict should not affect the module
+        result = all_terms(SAFE)
+        result[FLOW_TIME] = "MODIFIED"
+        assert term(FLOW_TIME, SAFE) == "Flow Time"


### PR DESCRIPTION
## Summary

- **Foundation layer**: `loader.py`, `filters.py`, `terminology.py` — load IssueTimes/CFD XLSX, apply date/project/issuetype filters, SAFe ↔ Global terminology switching
- **5 metric plugins** (`metrics/`): Flow Time (Boxplot + Scatterplot), Flow Velocity (daily/weekly/PI bar charts), Flow Load (Aging WIP boxplot with CT reference lines), CFD (stacked area + in/out ratio), Flow Distribution (dual pie charts)
- **Export**: `export.py` — single or multi-page PDF via kaleido + pypdf; PNG export
- **CLI**: `cli.py` + `__main__.py` — `python -m build_reports <IssueTimes.xlsx> [--metrics ...] [--from-date ...] [--pdf out.pdf] [--browser]`
- **GUI**: `gui.py` — tkinter window with file pickers, filters, metric checkboxes, SAFe/Global toggle, browser preview and PDF export; computation in background thread
- **209 tests** (unit + acceptance against real ART_A dataset), all passing

## Test plan

- [x] `python -m pytest` — 209 passed
- [x] Acceptance tests load real ART_A_IssueTimes.xlsx + ART_A_CFD.xlsx
- [x] PDF export verified (single + multi-page via pypdf)
- [x] CLI pipeline tested end-to-end with date filters and metric selection
- [x] GUI instantiation, input validation and metric selection tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)