### PR TITLE
docs(readme): Roadmap-Link hinzugefügt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 Toolsuite for querying Jira issue data and processing it into flow metrics and reports.
 
 **Documentation:** https://jaegerfeld.github.io/situation-report/  
-**Architecture:** https://jaegerfeld.github.io/situation-report/architecture/
+**Architecture:** https://jaegerfeld.github.io/situation-report/architecture/  
+**Roadmap:** https://github.com/users/Jaegerfeld/projects/1
 
 ## Modules
 


### PR DESCRIPTION
## Summary

- Link zum GitHub Project \"SituationReport Roadmap\" in README eingefügt
- Project enthält 11 geplante Features, gruppiert nach Milestone v1.1 / v1.2 / v1.3

## Test plan

- [ ] README auf GitHub öffnen — Roadmap-Link sichtbar und klickbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)