### PR TITLE
feat(build_reports): Process Flow Metrik – gerichteter Statusübergangsgraph

### DIFF
--- a/build_reports/loader.py
+++ b/build_reports/loader.py
@@ -3,14 +3,14 @@
 # Repository:     https://github.com/Jaegerfeld/situation-report
 # KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
 # Erstellt:       15.04.2026
-# Geändert:       25.04.2026
+# Geändert:       26.04.2026
 # Lizenz:         BSD-3-Clause (siehe LICENSE)
 #
 # Fachliche Funktion:
-#   Liest die von transform_data erzeugten XLSX-Dateien (IssueTimes, CFD) ein
-#   und wandelt sie in typisierte Datenstrukturen um. Die Stage-Spalten werden
-#   dynamisch aus der Kopfzeile der IssueTimes-Datei ermittelt. Fehlende oder
-#   leere Datumswerte werden als None behandelt.
+#   Liest die von transform_data erzeugten XLSX-Dateien (IssueTimes, CFD,
+#   Transitions) ein und wandelt sie in typisierte Datenstrukturen um. Die
+#   Stage-Spalten werden dynamisch aus der Kopfzeile der IssueTimes-Datei
+#   ermittelt. Fehlende oder leere Datumswerte werden als None behandelt.
 # =============================================================================
 
 from __future__ import annotations
@@ -104,17 +104,26 @@ class CfdRecord:
 
 
 @dataclass
+class TransitionEntry:
+    """One row from Transitions.xlsx — a single status transition for one issue."""
+    key: str        # issue key, e.g. 'ART_A-1'
+    label: str      # target stage / status name after the transition
+    timestamp: str  # DD.MM.YYYY HH:MM:SS (kept as string; ordering is not required here)
+
+
+@dataclass
 class ReportData:
     """
     Container for all data loaded from a transform_data output set.
 
-    Holds issue records, CFD records, the ordered list of workflow stages,
-    and the source prefix (e.g. 'ART_A') derived from the file names.
-    Optional first_stage / closed_stage mark the system entry and exit
-    boundaries from the workflow file (<First> and <Closed> markers).
+    Holds issue records, CFD records, transition entries, the ordered list of
+    workflow stages, and the source prefix (e.g. 'ART_A') derived from the
+    file names. Optional first_stage / closed_stage mark the system entry and
+    exit boundaries from the workflow file (<First> and <Closed> markers).
     """
     issues: list[IssueRecord] = field(default_factory=list)
     cfd: list[CfdRecord] = field(default_factory=list)
+    transitions: list[TransitionEntry] = field(default_factory=list)
     stages: list[str] = field(default_factory=list)
     source_prefix: str = ""
     first_stage: str | None = None   # <First> marker from workflow file
@@ -236,13 +245,45 @@ def _parse_workflow_markers(path: Path) -> tuple[str | None, str | None]:
     return first_stage, closed_stage
 
 
+def load_transitions(path: Path) -> list[TransitionEntry]:
+    """
+    Read a Transitions.xlsx file and return a list of TransitionEntry records.
+
+    Rows are returned in file order (which is chronological per issue as
+    produced by transform_data). Empty rows are skipped.
+
+    Args:
+        path: Path to the Transitions.xlsx file.
+
+    Returns:
+        List of TransitionEntry, one per data row.
+    """
+    wb = load_workbook(path, read_only=True, data_only=True)
+    ws = wb.active
+    rows = iter(ws.iter_rows(values_only=True))
+    next(rows)  # skip header (Key | Transition | Timestamp)
+    entries: list[TransitionEntry] = []
+    for row in rows:
+        if not any(row):
+            continue
+        entries.append(TransitionEntry(
+            key=str(row[0] or ""),
+            label=str(row[1] or ""),
+            timestamp=str(row[2] or ""),
+        ))
+    wb.close()
+    return entries
+
+
 def load_report_data(
     issue_times_path: Path,
     cfd_path: Path | None = None,
     workflow_path: Path | None = None,
+    transitions_path: Path | None = None,
 ) -> ReportData:
     """
-    Load a complete ReportData set from IssueTimes and optionally CFD XLSX files.
+    Load a complete ReportData set from IssueTimes and optionally CFD, workflow,
+    and Transitions XLSX files.
 
     The source_prefix is derived from the IssueTimes filename by stripping
     the '_IssueTimes' suffix (e.g. 'ART_A_IssueTimes.xlsx' → 'ART_A').
@@ -253,6 +294,7 @@ def load_report_data(
         issue_times_path: Path to the IssueTimes.xlsx file (required).
         cfd_path:         Path to the CFD.xlsx file (optional).
         workflow_path:    Path to the workflow .txt file (optional).
+        transitions_path: Path to the Transitions.xlsx file (optional).
 
     Returns:
         Populated ReportData instance.
@@ -268,12 +310,17 @@ def load_report_data(
     if workflow_path is not None:
         first_stage, closed_stage = _parse_workflow_markers(workflow_path)
 
+    transitions: list[TransitionEntry] = []
+    if transitions_path is not None:
+        transitions = load_transitions(transitions_path)
+
     stem = issue_times_path.stem
     prefix = stem.removesuffix("_IssueTimes")
 
     return ReportData(
         issues=issues,
         cfd=cfd,
+        transitions=transitions,
         stages=stages,
         source_prefix=prefix,
         first_stage=first_stage,

--- a/build_reports/metrics/__init__.py
+++ b/build_reports/metrics/__init__.py
@@ -74,3 +74,4 @@ from . import flow_velocity      # noqa: E402, F401
 from . import flow_load          # noqa: E402, F401
 from . import cfd                # noqa: E402, F401
 from . import flow_distribution  # noqa: E402, F401
+from . import process_flow       # noqa: E402, F401

--- a/build_reports/metrics/process_flow.py
+++ b/build_reports/metrics/process_flow.py
@@ -1,0 +1,523 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       26.04.2026
+# Geändert:       26.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Implementiert die Process Flow Metrik. Erzeugt einen gerichteten Graphen
+#   aller Status-Übergänge aus der Transitions.xlsx. Knoten = Status,
+#   Kanten = Übergänge mit Anzahl als Beschriftung. Kantendicke ist proportional
+#   zur relativen Häufigkeit des Übergangs. Bidirektionale Kanten werden als
+#   Kurven dargestellt, Self-Loops als kleiner Kreisbogen am Knoten.
+# =============================================================================
+
+from __future__ import annotations
+
+import math
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+
+import plotly.graph_objects as go
+
+from ..loader import ReportData
+from ..terminology import PROCESS_FLOW, term
+from . import register
+from .base import MetricPlugin, MetricResult
+
+# Graph layout constants
+_NODE_RADIUS = 0.07     # radius of node circle in data coordinates
+_CURVE_OFFSET = 0.22    # perpendicular offset for bidirectional edge curves
+_LOOP_DIST = 0.20       # distance of self-loop center from node center
+_LOOP_RADIUS = 0.10     # radius of self-loop arc
+_MAX_EDGE_WIDTH = 10.0  # maximum plotly line width for the heaviest edge
+_MIN_EDGE_WIDTH = 1.0   # minimum plotly line width
+
+_COLOR_EDGE = "#5b8db8"
+_COLOR_EDGE_BACK = "#c0392b"   # rework / backward transitions
+_COLOR_SELF_LOOP = "#e67e22"
+_COLOR_NODE_FILL = "#2c3e50"
+_COLOR_NODE_TEXT = "#ffffff"
+
+
+@dataclass
+class _Edge:
+    source: str
+    target: str
+    count: int
+    relative: float   # count / total_transitions
+    is_self_loop: bool = False
+
+
+@dataclass
+class _FlowData:
+    nodes: list[str]                  # ordered for circular layout
+    edges: list[_Edge]
+    total_transitions: int
+    issue_count: int
+    workflow_stages: list[str]        # from ReportData.stages (may be empty)
+
+
+# ---------------------------------------------------------------------------
+# Layout helpers
+# ---------------------------------------------------------------------------
+
+def _circular_positions(nodes: list[str]) -> dict[str, tuple[float, float]]:
+    """
+    Place nodes evenly on a unit circle, starting at the top (12 o'clock).
+
+    Args:
+        nodes: Ordered list of node labels.
+
+    Returns:
+        Dict mapping node label to (x, y) coordinates.
+    """
+    n = len(nodes)
+    if n == 0:
+        return {}
+    if n == 1:
+        return {nodes[0]: (0.0, 0.0)}
+    angle_step = 2 * math.pi / n
+    return {
+        node: (
+            math.sin(i * angle_step),        # x: sin starts right from top
+            math.cos(i * angle_step),        # y: cos starts at top
+        )
+        for i, node in enumerate(nodes)
+    }
+
+
+def _bezier_points(
+    p0: tuple[float, float],
+    p1: tuple[float, float],
+    p2: tuple[float, float],
+    n: int = 30,
+) -> tuple[list[float], list[float]]:
+    """
+    Sample a quadratic Bezier curve from p0 through control point p1 to p2.
+
+    Args:
+        p0: Start point (x, y).
+        p1: Control point (x, y).
+        p2: End point (x, y).
+        n:  Number of sample points.
+
+    Returns:
+        Tuple of (x_list, y_list).
+    """
+    xs, ys = [], []
+    for i in range(n + 1):
+        t = i / n
+        mt = 1 - t
+        xs.append(mt * mt * p0[0] + 2 * mt * t * p1[0] + t * t * p2[0])
+        ys.append(mt * mt * p0[1] + 2 * mt * t * p1[1] + t * t * p2[1])
+    return xs, ys
+
+
+def _edge_width(edge: _Edge, max_count: int) -> float:
+    """Map edge count to line width in [_MIN_EDGE_WIDTH, _MAX_EDGE_WIDTH]."""
+    if max_count == 0:
+        return _MIN_EDGE_WIDTH
+    ratio = edge.count / max_count
+    return _MIN_EDGE_WIDTH + ratio * (_MAX_EDGE_WIDTH - _MIN_EDGE_WIDTH)
+
+
+def _edge_color(edge: _Edge, workflow_stages: list[str]) -> str:
+    """
+    Return edge color: rework color for backward transitions (source appears
+    after target in workflow order), self-loop color for self-loops,
+    default blue otherwise.
+
+    Args:
+        edge:            The edge to color.
+        workflow_stages: Ordered list of workflow stages.
+
+    Returns:
+        CSS color string.
+    """
+    if edge.is_self_loop:
+        return _COLOR_SELF_LOOP
+    if workflow_stages:
+        idx = {s: i for i, s in enumerate(workflow_stages)}
+        src_i = idx.get(edge.source, -1)
+        tgt_i = idx.get(edge.target, -1)
+        if src_i >= 0 and tgt_i >= 0 and src_i > tgt_i:
+            return _COLOR_EDGE_BACK
+    return _COLOR_EDGE
+
+
+# ---------------------------------------------------------------------------
+# Figure building helpers
+# ---------------------------------------------------------------------------
+
+def _add_self_loop(
+    fig: go.Figure,
+    node: str,
+    pos: dict[str, tuple[float, float]],
+    edge: _Edge,
+    width: float,
+    color: str,
+) -> None:
+    """
+    Draw a small circular arc as a self-loop on a node, positioned outward
+    from the graph center.
+
+    Args:
+        fig:   Plotly Figure to add traces/annotations to.
+        node:  Node label (self-loop source = target).
+        pos:   Dict of node positions.
+        edge:  The self-loop _Edge.
+        width: Line width.
+        color: Line color.
+    """
+    nx, ny = pos[node]
+    length = math.hypot(nx, ny)
+    if length > 0:
+        dx, dy = nx / length, ny / length
+    else:
+        dx, dy = 0.0, 1.0
+
+    cx = nx + dx * _LOOP_DIST
+    cy = ny + dy * _LOOP_DIST
+
+    angles = [i * 2 * math.pi / 60 for i in range(61)]
+    lx = [cx + _LOOP_RADIUS * math.cos(a) for a in angles]
+    ly = [cy + _LOOP_RADIUS * math.sin(a) for a in angles]
+
+    fig.add_trace(go.Scatter(
+        x=lx, y=ly,
+        mode="lines",
+        line=dict(width=width, color=color),
+        hovertemplate=(
+            f"<b>{node} → {node}</b><br>"
+            f"Count: {edge.count} ({edge.relative:.1%})<extra></extra>"
+        ),
+        showlegend=False,
+    ))
+
+    # Label near the loop
+    lx_mid = cx + _LOOP_RADIUS * math.cos(math.pi / 4) + dx * 0.06
+    ly_mid = cy + _LOOP_RADIUS * math.sin(math.pi / 4) + dy * 0.06
+    fig.add_annotation(
+        x=lx_mid, y=ly_mid,
+        text=str(edge.count),
+        showarrow=False,
+        font=dict(size=9, color="#333"),
+        bgcolor="rgba(255,255,255,0.8)",
+        borderpad=2,
+    )
+
+
+def _add_edge(
+    fig: go.Figure,
+    edge: _Edge,
+    pos: dict[str, tuple[float, float]],
+    bidirectional: set[tuple[str, str]],
+    width: float,
+    color: str,
+) -> None:
+    """
+    Draw a directed edge between two nodes.
+
+    Straight edges for unidirectional connections; quadratic Bezier curves
+    for bidirectional pairs. Arrowhead drawn as annotation near the target.
+    Count label placed at the curve midpoint.
+
+    Args:
+        fig:           Plotly Figure.
+        edge:          The _Edge to draw.
+        pos:           Node positions.
+        bidirectional: Set of (u, v) pairs that also have a (v, u) counterpart.
+        width:         Line width.
+        color:         Line color.
+    """
+    x1, y1 = pos[edge.source]
+    x2, y2 = pos[edge.target]
+
+    dx, dy = x2 - x1, y2 - y1
+    length = math.hypot(dx, dy)
+    if length == 0:
+        return
+    ux, uy = dx / length, dy / length   # unit direction
+    px, py = -uy, ux                    # perpendicular (left of direction)
+
+    is_bidir = (edge.source, edge.target) in bidirectional
+    offset_sign = 1 if is_bidir else 0
+
+    # Control point for Bezier (offset only for bidirectional pairs)
+    mx, my = (x1 + x2) / 2, (y1 + y2) / 2
+    cp = (
+        mx + offset_sign * _CURVE_OFFSET * px,
+        my + offset_sign * _CURVE_OFFSET * py,
+    )
+
+    # Shorten start/end so lines don't overlap the node circles
+    t_start = _NODE_RADIUS / length
+    t_end = 1 - _NODE_RADIUS / length
+    if t_start >= t_end:
+        return
+
+    # Evaluate Bezier at t_start and t_end for actual line endpoints
+    def _bz(t: float) -> tuple[float, float]:
+        mt = 1 - t
+        bx = mt * mt * x1 + 2 * mt * t * cp[0] + t * t * x2
+        by = mt * mt * y1 + 2 * mt * t * cp[1] + t * t * y2
+        return bx, by
+
+    sx1, sy1 = _bz(t_start)
+    sx2, sy2 = _bz(t_end)
+
+    bx, by = _bezier_points((sx1, sy1), cp, (sx2, sy2))
+
+    fig.add_trace(go.Scatter(
+        x=bx, y=by,
+        mode="lines",
+        line=dict(width=width, color=color),
+        hovertemplate=(
+            f"<b>{edge.source} → {edge.target}</b><br>"
+            f"Count: {edge.count} ({edge.relative:.1%})<extra></extra>"
+        ),
+        showlegend=False,
+    ))
+
+    # Arrowhead annotation at target end
+    n = len(bx)
+    ax_tail, ay_tail = bx[n - 3], by[n - 3]
+    fig.add_annotation(
+        x=sx2, y=sy2,
+        ax=ax_tail, ay=ay_tail,
+        xref="x", yref="y", axref="x", ayref="y",
+        showarrow=True,
+        arrowhead=2, arrowsize=1.2,
+        arrowwidth=max(1.0, width * 0.6),
+        arrowcolor=color,
+    )
+
+    # Count label at curve midpoint, offset slightly outward
+    label_x = bx[n // 2] + offset_sign * px * 0.06
+    label_y = by[n // 2] + offset_sign * py * 0.06
+    fig.add_annotation(
+        x=label_x, y=label_y,
+        text=str(edge.count),
+        showarrow=False,
+        font=dict(size=9, color="#333"),
+        bgcolor="rgba(255,255,255,0.8)",
+        borderpad=2,
+    )
+
+
+def _add_nodes(
+    fig: go.Figure,
+    nodes: list[str],
+    pos: dict[str, tuple[float, float]],
+) -> None:
+    """
+    Draw all nodes as filled circles with centered label text.
+
+    Args:
+        fig:   Plotly Figure.
+        nodes: Ordered list of node labels.
+        pos:   Node positions.
+    """
+    xs = [pos[n][0] for n in nodes]
+    ys = [pos[n][1] for n in nodes]
+
+    fig.add_trace(go.Scatter(
+        x=xs, y=ys,
+        mode="markers+text",
+        marker=dict(
+            size=42,
+            color=_COLOR_NODE_FILL,
+            line=dict(color="#ffffff", width=2),
+        ),
+        text=nodes,
+        textposition="middle center",
+        textfont=dict(color=_COLOR_NODE_TEXT, size=10),
+        hovertemplate="<b>%{text}</b><extra></extra>",
+        showlegend=False,
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Metric plugin
+# ---------------------------------------------------------------------------
+
+class ProcessFlowMetric(MetricPlugin):
+    """
+    Process Flow metric.
+
+    Visualises all status transitions from Transitions.xlsx as a directed
+    graph. Nodes represent statuses; edges are labelled with transition counts.
+    Edge thickness is proportional to the relative share of that transition
+    among all transitions. Bidirectional edges are drawn as curves to keep
+    both directions visually distinct. Self-loops are shown as small arcs.
+    Backward transitions (rework) are coloured red when workflow stage order
+    is known.
+    """
+
+    metric_id = PROCESS_FLOW
+
+    def compute(self, data: ReportData, terminology: str) -> MetricResult:
+        """
+        Count all consecutive status transitions per issue and aggregate them.
+
+        Args:
+            data:        ReportData — uses data.transitions and data.stages.
+            terminology: Active terminology mode (unused here, kept for API).
+
+        Returns:
+            MetricResult with _FlowData as chart_data, or warnings if no data.
+        """
+        warnings: list[str] = []
+        if not data.transitions:
+            warnings.append("No transition data available. Load a Transitions.xlsx file.")
+            return MetricResult(metric_id=self.metric_id, warnings=warnings)
+
+        # Group labels per issue key (preserving file order = chronological)
+        by_issue: dict[str, list[str]] = defaultdict(list)
+        for t in data.transitions:
+            by_issue[t.key].append(t.label)
+
+        # Count consecutive transition pairs
+        edge_counter: Counter[tuple[str, str]] = Counter()
+        for labels in by_issue.values():
+            for i in range(len(labels) - 1):
+                edge_counter[(labels[i], labels[i + 1])] += 1
+
+        if not edge_counter:
+            warnings.append("No transitions found (each issue has at most one status entry).")
+            return MetricResult(metric_id=self.metric_id, warnings=warnings)
+
+        total = sum(edge_counter.values())
+
+        # Order nodes: workflow stages first (in order), then remaining alphabetically
+        stage_set = set(data.stages)
+        all_statuses = sorted(set(s for pair in edge_counter for s in pair))
+        ordered_nodes = (
+            [s for s in data.stages if s in all_statuses]
+            + [s for s in all_statuses if s not in stage_set]
+        )
+
+        edges = [
+            _Edge(
+                source=fr,
+                target=to,
+                count=cnt,
+                relative=cnt / total,
+                is_self_loop=(fr == to),
+            )
+            for (fr, to), cnt in sorted(edge_counter.items(), key=lambda x: -x[1])
+        ]
+
+        flow_data = _FlowData(
+            nodes=ordered_nodes,
+            edges=edges,
+            total_transitions=total,
+            issue_count=len(by_issue),
+            workflow_stages=list(data.stages),
+        )
+
+        stats = dict(
+            nodes=len(ordered_nodes),
+            edge_pairs=len(edges),
+            total_transitions=total,
+            issue_count=len(by_issue),
+            top_transition=f"{edges[0].source} → {edges[0].target} ({edges[0].count})",
+        )
+
+        return MetricResult(
+            metric_id=self.metric_id,
+            stats=stats,
+            chart_data=flow_data,
+            warnings=warnings,
+        )
+
+    def render(self, result: MetricResult, terminology: str) -> list[go.Figure]:
+        """
+        Render the process flow as a directed graph figure.
+
+        Args:
+            result:      MetricResult from compute().
+            terminology: Active terminology mode for the chart title.
+
+        Returns:
+            List with one plotly Figure, or empty list if no data.
+        """
+        if not result.chart_data:
+            return []
+
+        fd: _FlowData = result.chart_data
+        label = term(PROCESS_FLOW, terminology)
+
+        pos = _circular_positions(fd.nodes)
+        max_count = max(e.count for e in fd.edges) if fd.edges else 1
+
+        bidirectional: set[tuple[str, str]] = {
+            (e.source, e.target)
+            for e in fd.edges
+            if not e.is_self_loop
+            and any(
+                other.source == e.target and other.target == e.source
+                for other in fd.edges
+                if not other.is_self_loop
+            )
+        }
+
+        fig = go.Figure()
+
+        # Draw edges (behind nodes)
+        for edge in fd.edges:
+            width = _edge_width(edge, max_count)
+            color = _edge_color(edge, fd.workflow_stages)
+            if edge.is_self_loop:
+                _add_self_loop(fig, edge.source, pos, edge, width, color)
+            else:
+                _add_edge(fig, edge, pos, bidirectional, width, color)
+
+        # Draw nodes (on top of edges)
+        _add_nodes(fig, fd.nodes, pos)
+
+        # Legend annotations
+        legend_items = [
+            ("━", _COLOR_EDGE, "Forward transition"),
+            ("━", _COLOR_EDGE_BACK, "Backward / rework"),
+            ("━", _COLOR_SELF_LOOP, "Self-loop"),
+        ]
+        for i, (sym, col, txt) in enumerate(legend_items):
+            fig.add_annotation(
+                x=1.01, y=0.95 - i * 0.08,
+                xref="paper", yref="paper",
+                text=f'<span style="color:{col}; font-size:16px">{sym}</span> {txt}',
+                showarrow=False,
+                xanchor="left",
+                font=dict(size=11),
+            )
+
+        fig.update_layout(
+            title=(
+                f"{label}  —  {fd.issue_count} issues, "
+                f"{fd.total_transitions} transitions, "
+                f"{len(fd.edges)} unique pairs"
+            ),
+            title_font_size=12,
+            paper_bgcolor="#e8e8e8",
+            plot_bgcolor="#f5f5f5",
+            height=700,
+            margin=dict(l=20, r=160, t=50, b=20),
+            xaxis=dict(
+                showgrid=False, zeroline=False, showticklabels=False,
+                range=[-1.4, 1.4],
+            ),
+            yaxis=dict(
+                showgrid=False, zeroline=False, showticklabels=False,
+                range=[-1.4, 1.4],
+                scaleanchor="x", scaleratio=1,
+            ),
+        )
+
+        return [fig]
+
+
+register(ProcessFlowMetric())

--- a/build_reports/terminology.py
+++ b/build_reports/terminology.py
@@ -26,6 +26,7 @@ FLOW_LOAD = "flow_load"
 FLOW_DISTRIBUTION = "flow_distribution"
 FLOW_PREDICTABILITY = "flow_predictability"
 CFD = "cfd"
+PROCESS_FLOW = "process_flow"
 
 _TERMS: dict[str, dict[str, str]] = {
     SAFE: {
@@ -35,6 +36,7 @@ _TERMS: dict[str, dict[str, str]] = {
         FLOW_DISTRIBUTION: "Flow Distribution",
         FLOW_PREDICTABILITY: "Flow Predictability",
         CFD: "Cumulative Flow Diagram",
+        PROCESS_FLOW: "Process Flow",
     },
     GLOBAL: {
         FLOW_TIME: "Cycle Time",
@@ -43,6 +45,7 @@ _TERMS: dict[str, dict[str, str]] = {
         FLOW_DISTRIBUTION: "Flow Distribution",
         FLOW_PREDICTABILITY: "Flow Predictability",
         CFD: "Cumulative Flow Diagram",
+        PROCESS_FLOW: "Process Flow",
     },
 }
 

--- a/tests/build_reports/acceptance/test_process_flow_acceptance.py
+++ b/tests/build_reports/acceptance/test_process_flow_acceptance.py
@@ -1,0 +1,144 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       26.04.2026
+# Geändert:       26.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Acceptance-Tests für die Process Flow Metrik auf Basis des realen
+#   ART_E-Datensatzes (feedback/Ideen/ART_E_Transitions.xlsx). Prüft
+#   fachliche Korrektheit: Anzahl Knoten, Übergänge, Top-Transition,
+#   Erkennung bidirektionaler Kanten und korrekte Darstellbarkeit der Figure.
+# =============================================================================
+
+"""Acceptance tests for ProcessFlowMetric using the real ART_E dataset."""
+
+from pathlib import Path
+
+import pytest
+
+from build_reports.loader import load_transitions, ReportData
+from build_reports.metrics.process_flow import ProcessFlowMetric, _FlowData
+from build_reports.terminology import SAFE
+
+ART_E_TRANSITIONS = (
+    Path(__file__).parent.parent.parent.parent
+    / "feedback" / "Ideen" / "ART_E_Transitions.xlsx"
+)
+
+
+@pytest.fixture(scope="module")
+def art_e_data() -> ReportData:
+    """Load ART_E Transitions.xlsx once for all acceptance tests."""
+    return ReportData(transitions=load_transitions(ART_E_TRANSITIONS))
+
+
+@pytest.fixture(scope="module")
+def art_e_result(art_e_data):
+    """Compute ProcessFlowMetric on ART_E data."""
+    return ProcessFlowMetric().compute(art_e_data, SAFE)
+
+
+@pytest.fixture(scope="module")
+def art_e_flow(art_e_result) -> _FlowData:
+    return art_e_result.chart_data
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+class TestArtELoading:
+
+    def test_transitions_file_loads(self, art_e_data):
+        assert len(art_e_data.transitions) == 1137  # 1138 rows - 1 header
+
+    def test_all_entries_have_key_and_label(self, art_e_data):
+        assert all(t.key and t.label for t in art_e_data.transitions)
+
+    def test_issue_count_matches_expected(self, art_e_result):
+        assert art_e_result.stats["issue_count"] == 341
+
+
+# ---------------------------------------------------------------------------
+# Computed graph structure
+# ---------------------------------------------------------------------------
+
+class TestArtEGraphStructure:
+
+    def test_nine_unique_statuses_as_nodes(self, art_e_flow):
+        assert art_e_flow.nodes is not None
+        assert len(art_e_flow.nodes) == 9
+
+    def test_expected_statuses_present(self, art_e_flow):
+        expected = {
+            "Backlog", "Completed", "Created", "Done",
+            "Funnel", "In Analysis", "In Implementation", "Monitoring", "On Hold",
+        }
+        assert set(art_e_flow.nodes) == expected
+
+    def test_thirty_unique_transition_pairs(self, art_e_flow):
+        assert len(art_e_flow.edges) == 30
+
+    def test_total_transitions_count(self, art_e_result):
+        assert art_e_result.stats["total_transitions"] == 796
+
+    def test_no_compute_warnings(self, art_e_result):
+        assert art_e_result.warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Top transitions (domain correctness)
+# ---------------------------------------------------------------------------
+
+class TestArtETopTransitions:
+
+    def test_top_transition_is_backlog_to_in_implementation(self, art_e_flow):
+        top = art_e_flow.edges[0]
+        assert top.source == "Backlog"
+        assert top.target == "In Implementation"
+        assert top.count == 148
+
+    def test_created_to_in_analysis_second(self, art_e_flow):
+        counts = {(e.source, e.target): e.count for e in art_e_flow.edges}
+        assert counts[("Created", "In Analysis")] == 136
+
+    def test_bidirectional_pair_in_analysis_funnel(self, art_e_flow):
+        """Both In Analysis→Funnel and Funnel→In Analysis must exist."""
+        pairs = {(e.source, e.target) for e in art_e_flow.edges}
+        assert ("In Analysis", "Funnel") in pairs
+        assert ("Funnel", "In Analysis") in pairs
+
+    def test_self_loop_funnel_to_funnel(self, art_e_flow):
+        self_loops = [e for e in art_e_flow.edges if e.is_self_loop]
+        assert any(e.source == "Funnel" for e in self_loops)
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+class TestArtERender:
+
+    def test_render_returns_one_figure(self, art_e_result):
+        figs = ProcessFlowMetric().render(art_e_result, SAFE)
+        assert len(figs) == 1
+
+    def test_figure_title_contains_issue_count(self, art_e_result):
+        figs = ProcessFlowMetric().render(art_e_result, SAFE)
+        assert "341 issues" in figs[0].layout.title.text
+
+    def test_figure_title_contains_transition_count(self, art_e_result):
+        figs = ProcessFlowMetric().render(art_e_result, SAFE)
+        assert "796 transitions" in figs[0].layout.title.text
+
+    def test_figure_has_node_and_edge_traces(self, art_e_result):
+        figs = ProcessFlowMetric().render(art_e_result, SAFE)
+        # edges (30) + 1 node trace + self-loop traces
+        assert len(figs[0].data) >= 31
+
+    def test_figure_has_annotations_for_counts(self, art_e_result):
+        figs = ProcessFlowMetric().render(art_e_result, SAFE)
+        assert len(figs[0].layout.annotations) > 30

--- a/tests/build_reports/unit/test_process_flow.py
+++ b/tests/build_reports/unit/test_process_flow.py
@@ -1,0 +1,229 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       26.04.2026
+# Geändert:       26.04.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für build_reports.metrics.process_flow. Prüft Kantenzählung,
+#   Knotenreihenfolge (Workflow-Stages zuerst), Self-Loop-Erkennung,
+#   Rückwärts-Transitionen, fehlende Daten-Warnungen sowie das Rendering
+#   (Traces, Annotations).
+# =============================================================================
+
+"""Unit tests for build_reports.metrics.process_flow."""
+
+import pytest
+
+from build_reports.loader import ReportData, TransitionEntry
+from build_reports.metrics.process_flow import (
+    ProcessFlowMetric,
+    _circular_positions,
+    _edge_width,
+    _Edge,
+)
+from build_reports.terminology import PROCESS_FLOW, SAFE
+
+
+def _entry(key: str, label: str) -> TransitionEntry:
+    return TransitionEntry(key=key, label=label, timestamp="01.01.2025 09:00:00")
+
+
+def _make_data(transitions: list[TransitionEntry], stages: list[str] | None = None) -> ReportData:
+    return ReportData(transitions=transitions, stages=stages or [])
+
+
+@pytest.fixture
+def metric() -> ProcessFlowMetric:
+    return ProcessFlowMetric()
+
+
+# ---------------------------------------------------------------------------
+# compute — edge counting
+# ---------------------------------------------------------------------------
+
+class TestComputeEdgeCounting:
+
+    def test_single_issue_two_transitions_produces_one_edge(self, metric):
+        data = _make_data([_entry("A-1", "Funnel"), _entry("A-1", "Analysis")])
+        result = metric.compute(data, SAFE)
+        assert result.stats["edge_pairs"] == 1
+        assert result.stats["total_transitions"] == 1
+
+    def test_edge_count_aggregated_across_issues(self, metric):
+        """Same transition in two issues → count = 2."""
+        t = [
+            _entry("A-1", "Funnel"), _entry("A-1", "Analysis"),
+            _entry("A-2", "Funnel"), _entry("A-2", "Analysis"),
+        ]
+        result = metric.compute(_make_data(t), SAFE)
+        fd = result.chart_data
+        edge = next(e for e in fd.edges if e.source == "Funnel" and e.target == "Analysis")
+        assert edge.count == 2
+
+    def test_relative_sums_to_one(self, metric):
+        t = [
+            _entry("A-1", "Funnel"), _entry("A-1", "Analysis"),
+            _entry("A-1", "Analysis"), _entry("A-1", "Done"),
+        ]
+        result = metric.compute(_make_data(t), SAFE)
+        total_relative = sum(e.relative for e in result.chart_data.edges)
+        assert abs(total_relative - 1.0) < 1e-9
+
+    def test_self_loop_detected(self, metric):
+        t = [_entry("A-1", "Funnel"), _entry("A-1", "Funnel")]
+        result = metric.compute(_make_data(t), SAFE)
+        assert any(e.is_self_loop for e in result.chart_data.edges)
+
+    def test_single_entry_per_issue_produces_no_edges(self, metric):
+        t = [_entry("A-1", "Funnel")]
+        result = metric.compute(_make_data(t), SAFE)
+        assert result.chart_data is None or result.chart_data.edges == [] or result.warnings
+
+    def test_issue_count_correct(self, metric):
+        t = [
+            _entry("A-1", "Funnel"), _entry("A-1", "Analysis"),
+            _entry("A-2", "Funnel"), _entry("A-2", "Done"),
+        ]
+        result = metric.compute(_make_data(t), SAFE)
+        assert result.stats["issue_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# compute — node ordering
+# ---------------------------------------------------------------------------
+
+class TestComputeNodeOrdering:
+
+    def test_workflow_stages_come_first(self, metric):
+        t = [
+            _entry("A-1", "Created"), _entry("A-1", "Funnel"),
+            _entry("A-1", "Funnel"), _entry("A-1", "Analysis"),
+        ]
+        data = _make_data(t, stages=["Funnel", "Analysis"])
+        result = metric.compute(data, SAFE)
+        nodes = result.chart_data.nodes
+        funnel_idx = nodes.index("Funnel")
+        analysis_idx = nodes.index("Analysis")
+        created_idx = nodes.index("Created")
+        assert funnel_idx < created_idx
+        assert analysis_idx < created_idx
+
+    def test_extra_statuses_appended_alphabetically(self, metric):
+        t = [
+            _entry("A-1", "Zebra"), _entry("A-1", "Apple"),
+            _entry("A-1", "Apple"), _entry("A-1", "Mango"),
+        ]
+        data = _make_data(t, stages=[])
+        result = metric.compute(data, SAFE)
+        nodes = result.chart_data.nodes
+        assert nodes == sorted(nodes)
+
+
+# ---------------------------------------------------------------------------
+# compute — missing data
+# ---------------------------------------------------------------------------
+
+class TestComputeWarnings:
+
+    def test_empty_transitions_returns_warning(self, metric):
+        result = metric.compute(_make_data([]), SAFE)
+        assert result.chart_data is None
+        assert result.warnings
+
+    def test_no_chart_data_when_no_transitions(self, metric):
+        result = metric.compute(ReportData(), SAFE)
+        assert result.chart_data is None
+
+
+# ---------------------------------------------------------------------------
+# layout helpers
+# ---------------------------------------------------------------------------
+
+class TestCircularPositions:
+
+    def test_single_node_at_origin(self):
+        pos = _circular_positions(["A"])
+        assert pos["A"] == (0.0, 0.0)
+
+    def test_all_nodes_on_unit_circle(self):
+        nodes = ["A", "B", "C", "D", "E"]
+        pos = _circular_positions(nodes)
+        for n in nodes:
+            x, y = pos[n]
+            r = (x ** 2 + y ** 2) ** 0.5
+            assert abs(r - 1.0) < 1e-9
+
+    def test_nodes_evenly_spaced(self):
+        import math
+        nodes = ["A", "B", "C"]
+        pos = _circular_positions(nodes)
+        coords = list(pos.values())
+        dists = []
+        for i in range(len(coords)):
+            j = (i + 1) % len(coords)
+            dx = coords[j][0] - coords[i][0]
+            dy = coords[j][1] - coords[i][1]
+            dists.append(math.hypot(dx, dy))
+        assert max(dists) - min(dists) < 1e-9
+
+
+class TestEdgeWidth:
+
+    def test_max_edge_gets_max_width(self):
+        edge = _Edge("A", "B", count=100, relative=1.0)
+        w = _edge_width(edge, max_count=100)
+        assert w == pytest.approx(10.0)
+
+    def test_zero_max_count_returns_min_width(self):
+        edge = _Edge("A", "B", count=0, relative=0.0)
+        w = _edge_width(edge, max_count=0)
+        assert w == pytest.approx(1.0)
+
+    def test_half_count_gives_midrange_width(self):
+        edge = _Edge("A", "B", count=50, relative=0.5)
+        w = _edge_width(edge, max_count=100)
+        assert w == pytest.approx(5.5)
+
+
+# ---------------------------------------------------------------------------
+# render
+# ---------------------------------------------------------------------------
+
+class TestRender:
+
+    def _result_with_data(self, metric):
+        t = [
+            _entry("A-1", "Funnel"), _entry("A-1", "Analysis"),
+            _entry("A-2", "Analysis"), _entry("A-2", "Funnel"),  # bidirectional
+            _entry("A-3", "Funnel"), _entry("A-3", "Funnel"),    # self-loop
+        ]
+        return metric.compute(_make_data(t, stages=["Funnel", "Analysis"]), SAFE)
+
+    def test_returns_one_figure(self, metric):
+        figs = metric.render(self._result_with_data(metric), SAFE)
+        assert len(figs) == 1
+
+    def test_empty_result_returns_no_figures(self, metric):
+        result = metric.compute(_make_data([]), SAFE)
+        figs = metric.render(result, SAFE)
+        assert figs == []
+
+    def test_node_trace_present(self, metric):
+        figs = metric.render(self._result_with_data(metric), SAFE)
+        # Last trace is the node scatter (markers+text)
+        node_trace = figs[0].data[-1]
+        assert "markers" in node_trace.mode
+
+    def test_figure_has_annotations(self, metric):
+        figs = metric.render(self._result_with_data(metric), SAFE)
+        assert len(figs[0].layout.annotations) > 0
+
+    def test_title_contains_issue_count(self, metric):
+        figs = metric.render(self._result_with_data(metric), SAFE)
+        assert "3 issues" in figs[0].layout.title.text
+
+    def test_metric_id_is_process_flow(self, metric):
+        assert metric.metric_id == PROCESS_FLOW


### PR DESCRIPTION
## Summary

Neue Metrik `process_flow` für `build_reports`: visualisiert alle Status-Übergänge aus der `Transitions.xlsx` als interaktiven gerichteten Graphen.

**Funktionsweise:**
- Knoten = Jira-Status (kreisförmig angeordnet, Workflow-Stages zuerst)
- Kanten = Übergänge zwischen Status, beschriftet mit der Anzahl
- Kantendicke proportional zur relativen Häufigkeit
- **Bidirektionale Kanten** (z.B. Analysis↔Funnel) als Bezier-Kurven, visuell getrennt
- **Self-Loops** (z.B. Funnel→Funnel) als kleiner Kreisbogen
- **Rückwärts-Transitionen** (Rework) in Rot, wenn Workflow-Reihenfolge bekannt
- Hover zeigt Anzahl und prozentualen Anteil

**Änderungen:**
- `loader.py`: `TransitionEntry` Dataclass + `load_transitions()` + `transitions` Feld in `ReportData` + `transitions_path` Parameter in `load_report_data()`
- `terminology.py`: `PROCESS_FLOW` Konstante
- `metrics/process_flow.py`: neue Metrik (neu)
- `metrics/__init__.py`: Registrierung

**Tests:** 39 neue Tests (22 Unit + 17 Acceptance gegen echten ART_E-Datensatz mit 341 Issues, 796 Übergängen, 9 Status, 30 eindeutigen Übergangspfaden)

## Test plan

- [ ] `python -m pytest` — 506 Tests, alle grün
- [ ] Acceptance Tests prüfen fachliche Korrektheit: Top-Transition `Backlog→In Implementation` (148×), bidirektionales Paar `In Analysis↔Funnel`, Self-Loop `Funnel→Funnel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)