### PR TITLE
feat(releases): CI build workflows, flag language switcher, release docs

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,9 +1,9 @@
-name: Build & Release
+name: Dev Build
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -67,28 +67,43 @@ jobs:
           path: ${{ matrix.zip_file }}
 
   release:
-    name: Create GitHub Release
+    name: Update Dev Release
     needs: build
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Set build metadata
+        run: |
+          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "BUILD_DATE=$(date -u +'%Y-%m-%d')" >> $GITHUB_ENV
+
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
 
-      - name: Publish GitHub Release
+      - name: Delete existing dev-latest release and tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release delete dev-latest --yes --cleanup-tag 2>/dev/null || true
+
+      - name: Publish Dev Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          prerelease: false
+          tag_name: dev-latest
+          name: Dev Build – ${{ env.BUILD_DATE }} (${{ env.SHORT_SHA }})
+          prerelease: true
           draft: false
           files: |
             SituationReport-Windows.zip
             SituationReport-macOS-ARM.zip
             SituationReport-Linux.zip
           body: |
-            ## SituationReport ${{ github.ref_name }}
+            ## Dev Build – ${{ env.BUILD_DATE }} (`${{ env.SHORT_SHA }}`)
+
+            > **Vorschau-Version** – aktueller Entwicklungsstand von `main`.
+            > Für produktiven Einsatz stabile Releases verwenden.
 
             Eigenständige GUI-App. **Kein Python oder sonstige Installation notwendig.**
 
@@ -102,26 +117,10 @@ jobs:
             ### macOS (Apple Silicon)
 
             1. `SituationReport-macOS-ARM.zip` herunterladen und entpacken
-            2. `SituationReport.app` in den Ordner *Programme* ziehen (optional)
-            3. Beim **ersten Start**: Rechtsklick → *Öffnen* → *Öffnen* bestätigen
-               *(macOS Gatekeeper-Hinweis, da die App nicht signiert ist)*
+            2. Beim **ersten Start**: Rechtsklick → *Öffnen* → *Öffnen* bestätigen
 
             ### Linux (x64)
 
             1. `SituationReport-Linux.zip` herunterladen und entpacken
             2. Im entpackten Ordner `./SituationReport` ausführen
             3. Bei Bedarf einmalig: `chmod +x SituationReport`
-
-            ---
-
-            ### Voraussetzungen
-
-            Keine – alle Abhängigkeiten (inkl. Chrome für PDF-Export) sind enthalten.
-
-            ### Datenformat
-
-            | Datei | Bedeutung |
-            |-------|-----------|
-            | `*_IssueTimes.xlsx` | Pflicht – Durchlaufzeiten pro Issue und Stage |
-            | `*_CFD.xlsx` | Optional – tägliche Stage-Zählungen für CFD |
-            | `*_Transitions.xlsx` | Optional – Transitionen für Process-Flow-Ansicht |

--- a/build_reports/gui.py
+++ b/build_reports/gui.py
@@ -201,6 +201,8 @@ _T: dict[str, dict[str, str]] = {
         "log_excl_error":    "Fehler beim Laden/Speichern der Ausschluss-Defaults: {}",
         "menu_help":         "Hilfe",
         "menu_manual":       "Manual",
+        "menu_lang_title":   "Sprache",
+        "tip_language":      "Sprache wechseln (DE / EN)",
     },
     LANG_EN: {
         "window_title":      "build_reports",
@@ -313,6 +315,8 @@ _T: dict[str, dict[str, str]] = {
         "log_excl_error":    "Error loading/saving exclusion defaults: {}",
         "menu_help":         "Help",
         "menu_manual":       "Manual",
+        "menu_lang_title":   "Language",
+        "tip_language":      "Switch language (DE / EN)",
     },
 }
 
@@ -727,6 +731,8 @@ class BuildReportsApp(tk.Tk):
         }
 
         self._progress_after_id: str | None = None
+        self._flag_imgs: dict[str, tk.PhotoImage] = {}
+        self._flag_btn: tk.Button | None = None
 
         # Translatable widget references: list of (widget, tr_key)
         self._i18n: list[tuple[Any, str]] = []
@@ -739,6 +745,7 @@ class BuildReportsApp(tk.Tk):
         self._lang_var.trace_add("write", lambda *_: self._apply_language())
         self._terminology_var.trace_add("write", lambda *_: self._apply_terminology())
 
+        self._create_flag_imgs()
         self._build_menubar()
         self._build_ui()
         self._apply_language()  # set initial titles / labels
@@ -776,6 +783,12 @@ class BuildReportsApp(tk.Tk):
             menu=self._build_terminology_menu(options_menu),
         )
 
+        # Language submenu (under Options)
+        lang_menu = tk.Menu(options_menu, tearoff=0)
+        options_menu.add_cascade(label=self._tr("menu_lang_title"), menu=lang_menu)
+        lang_menu.add_radiobutton(label="🇩🇪  Deutsch", variable=self._lang_var, value=LANG_DE)
+        lang_menu.add_radiobutton(label="🇬🇧  English", variable=self._lang_var, value=LANG_EN)
+
         # Templates menu
         tpl_menu = tk.Menu(menubar, tearoff=0)
         menubar.add_cascade(label=self._tr("menu_template"), menu=tpl_menu)
@@ -790,12 +803,6 @@ class BuildReportsApp(tk.Tk):
         menubar.add_cascade(label=self._tr("menu_help"), menu=help_menu)
         help_menu.add_command(label=self._tr("menu_manual"), command=self._open_manual)
 
-        # Language flag (rightmost)
-        lang_menu = tk.Menu(menubar, tearoff=0)
-        lang_menu.add_radiobutton(label="🇩🇪  Deutsch", variable=self._lang_var, value=LANG_DE)
-        lang_menu.add_radiobutton(label="🇬🇧  English", variable=self._lang_var, value=LANG_EN)
-        menubar.add_cascade(label=_LANG_FLAGS[self._lang_var.get()], menu=lang_menu)
-
         self.config(menu=menubar)
 
     def _build_terminology_menu(self, parent: tk.Menu) -> tk.Menu:
@@ -809,6 +816,47 @@ class BuildReportsApp(tk.Tk):
         """Open the language-appropriate user manual PDF on GitHub Pages."""
         webbrowser.open(_MANUAL_URLS.get(self._lang_var.get(), _MANUAL_URLS[LANG_DE]))
 
+    def _create_flag_imgs(self) -> None:
+        """
+        Build PhotoImage objects for the DE and GB flags using inline pixel drawing.
+
+        Images are generated programmatically (no external files) so they work
+        inside a PyInstaller bundle without any resource-path handling.
+        The images are stored in self._flag_imgs and must not be garbage-collected.
+        """
+        W, H = 32, 20
+
+        # German flag: three equal horizontal stripes (black / red / gold)
+        de = tk.PhotoImage(width=W, height=H)
+        stripe_colors = ["#000000", "#DD0000", "#FFCC00"]
+        for y in range(H):
+            color = stripe_colors[y * 3 // H]
+            de.put("{" + " ".join([color] * W) + "}", to=(0, y))
+
+        # UK flag: simplified Union Jack (blue + white cross + red cross + white X)
+        gb = tk.PhotoImage(width=W, height=H)
+        for y in range(H):
+            row: list[str] = []
+            for x in range(W):
+                cx = abs(x - (W - 1) / 2)
+                cy = abs(y - (H - 1) / 2)
+                nx, ny = x / (W - 1), y / (H - 1)
+                if cx < W * 0.13 or cy < H * 0.13:        # red cross (St George)
+                    row.append("#C8102E")
+                elif cx < W * 0.24 or cy < H * 0.24:      # white cross border
+                    row.append("#FFFFFF")
+                elif abs(nx - ny) < 0.16 or abs(nx - (1 - ny)) < 0.16:  # white X
+                    row.append("#FFFFFF")
+                else:
+                    row.append("#012169")                  # blue background
+            gb.put("{" + " ".join(row) + "}", to=(0, y))
+
+        self._flag_imgs = {LANG_DE: de, LANG_EN: gb}
+
+    def _toggle_language(self) -> None:
+        """Toggle the UI language between DE and EN."""
+        self._lang_var.set(LANG_EN if self._lang_var.get() == LANG_DE else LANG_DE)
+
     # -------------------------------------------------------------------------
     # UI construction
     # -------------------------------------------------------------------------
@@ -818,6 +866,23 @@ class BuildReportsApp(tk.Tk):
         pad = {"padx": 8, "pady": 3}
         self.columnconfigure(1, weight=1)
         row = 0
+
+        # --- Language flag button (top-right) ---
+        flag_frame = tk.Frame(self)
+        flag_frame.grid(row=row, column=0, columnspan=3, sticky="e", padx=6, pady=(4, 0))
+        self._flag_btn = tk.Button(
+            flag_frame,
+            image=self._flag_imgs[self._lang_var.get()],
+            command=self._toggle_language,
+            relief="flat",
+            cursor="hand2",
+            bd=0,
+            padx=4,
+            pady=2,
+        )
+        self._flag_btn.pack()
+        self._tips.append((_ToolTip(self._flag_btn, self._tr("tip_language")), "tip_language"))
+        row += 1
 
         # --- Files ---
         row = self._section_header("sec_files", row)
@@ -1139,6 +1204,8 @@ class BuildReportsApp(tk.Tk):
         for tip, key in self._tips:
             tip.update_text(self._tr(key))
         self._build_menubar()
+        if self._flag_btn is not None:
+            self._flag_btn.configure(image=self._flag_imgs[self._lang_var.get()])
 
     def _apply_terminology(self) -> None:
         """Update metric checkbutton labels to reflect the current terminology."""

--- a/docs/releases.en.md
+++ b/docs/releases.en.md
@@ -1,0 +1,106 @@
+# Releases & Installation
+
+SituationReport is distributed as a standalone desktop app – **no Python, no installation required**.
+Just download, unzip, and run.
+
+---
+
+## Download
+
+All available releases are on the [GitHub Releases page](https://github.com/Jaegerfeld/situation-report/releases).
+
+| Release type | Description | When available |
+|--------------|-------------|----------------|
+| **Stable release** (e.g. `v0.6.0`) | Tested, production-ready build | After each version tag |
+| **Dev Build** (`dev-latest`) | Latest development state of `main` | After each merge to `main` |
+
+!!! tip "Which version should I use?"
+    For regular use, always pick the **latest stable release**.
+    Dev Builds are intended for testing new features and may contain incomplete functionality.
+
+---
+
+## Installation
+
+### Windows
+
+1. Download `SituationReport-Windows.zip`
+2. Extract the zip (right-click → *Extract All*)
+3. Open the extracted folder and double-click `SituationReport.exe`
+
+!!! note "Windows SmartScreen"
+    On the first launch, SmartScreen may show a warning because the app is not signed.
+    Click **More info** → **Run anyway**.
+
+---
+
+### macOS (Apple Silicon)
+
+1. Download `SituationReport-macOS-ARM.zip`
+2. Extract the zip
+3. Optionally move `SituationReport.app` to your *Applications* folder
+4. **First launch**: right-click the app → *Open* → confirm *Open* in the dialog
+
+!!! note "macOS Gatekeeper"
+    Because the app is not notarized, macOS blocks a direct double-click on the first launch.
+    The right-click approach bypasses this protection once.
+
+---
+
+### Linux (x64)
+
+1. Download `SituationReport-Linux.zip`
+2. Extract the zip
+3. Open a terminal, navigate to the extracted folder, and run:
+
+```bash
+chmod +x SituationReport   # once only
+./SituationReport
+```
+
+---
+
+## Release process (for developers)
+
+### Publishing a stable release
+
+A stable release is triggered by pushing a **version tag** on `main`:
+
+```bash
+# Update version in version.py, commit and push, then:
+git tag v0.6.0
+git push origin v0.6.0
+```
+
+GitHub Actions will automatically build all three platforms and publish the release with the ZIP files attached.
+
+Tag naming follows `vMAJOR.MINOR.PATCH` per [SemVer](https://semver.org/).
+
+| Version bump | When |
+|--------------|------|
+| `PATCH` (`v0.5.0` → `v0.5.1`) | Bug fix |
+| `MINOR` (`v0.5.1` → `v0.6.0`) | New feature |
+| `MAJOR` (`v0.6.0` → `v1.0.0`) | Breaking change (new file format, etc.) |
+
+### Dev Build
+
+The Dev Build is triggered **automatically** after every merge to `main` – no manual action needed.
+The existing `dev-latest` release on GitHub is replaced each time.
+
+---
+
+## GitHub Actions workflows
+
+| Workflow | File | Trigger |
+|----------|------|---------|
+| Build & Release | `.github/workflows/release.yml` | Push of a `v*` tag |
+| Dev Build | `.github/workflows/dev-build.yml` | Merge to `main` |
+| Deploy Docs | `.github/workflows/docs.yml` | Changes in `docs/` or `mkdocs.yml` |
+
+### Supported platforms
+
+| Platform | Runner | Output |
+|----------|--------|--------|
+| Windows | `windows-latest` | `SituationReport-Windows.zip` |
+| macOS (Apple Silicon) | `macos-latest` | `SituationReport-macOS-ARM.zip` |
+| Linux x64 | `ubuntu-latest` | `SituationReport-Linux.zip` |

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,106 @@
+# Releases & Installation
+
+SituationReport wird als eigenständige Desktop-App ausgeliefert – **kein Python, keine Installation notwendig**.
+Einfach herunterladen, entpacken und starten.
+
+---
+
+## Download
+
+Alle verfügbaren Releases sind auf der [GitHub-Releases-Seite](https://github.com/Jaegerfeld/situation-report/releases) zu finden.
+
+| Release-Typ | Beschreibung | Wann verfügbar |
+|-------------|-------------|----------------|
+| **Stabile Version** (z. B. `v0.6.0`) | Getesteter, produktionsreifer Stand | Nach jedem Versions-Tag |
+| **Dev Build** (`dev-latest`) | Aktuellster Entwicklungsstand von `main` | Nach jedem Merge auf `main` |
+
+!!! tip "Welche Version nehmen?"
+    Für den normalen Einsatz immer die **neueste stabile Version** verwenden.
+    Dev Builds sind für das Testen neuer Features gedacht und können unfertige Funktionen enthalten.
+
+---
+
+## Installation
+
+### Windows
+
+1. `SituationReport-Windows.zip` herunterladen
+2. Zip-Datei entpacken (Rechtsklick → *Alle extrahieren*)
+3. Im entpackten Ordner `SituationReport.exe` doppelklicken
+
+!!! note "Windows SmartScreen"
+    Beim ersten Start erscheint möglicherweise ein SmartScreen-Hinweis, da die App nicht signiert ist.
+    Auf **Weitere Informationen** → **Trotzdem ausführen** klicken.
+
+---
+
+### macOS (Apple Silicon)
+
+1. `SituationReport-macOS-ARM.zip` herunterladen
+2. Zip-Datei entpacken
+3. `SituationReport.app` in den Ordner *Programme* ziehen (optional)
+4. **Ersten Start**: Rechtsklick auf die App → *Öffnen* → im Dialog erneut *Öffnen* bestätigen
+
+!!! note "macOS Gatekeeper"
+    Da die App nicht notarisiert ist, blockiert macOS den ersten Start per Doppelklick.
+    Der Rechtsklick-Weg umgeht diesen Schutz einmalig.
+
+---
+
+### Linux (x64)
+
+1. `SituationReport-Linux.zip` herunterladen
+2. Zip-Datei entpacken
+3. Terminal öffnen, in den entpackten Ordner wechseln und starten:
+
+```bash
+chmod +x SituationReport   # einmalig
+./SituationReport
+```
+
+---
+
+## Release-Prozess (für Entwickler)
+
+### Stabiles Release veröffentlichen
+
+Ein stabiles Release wird durch einen **Version-Tag** auf `main` ausgelöst:
+
+```bash
+# Version in version.py aktualisieren, committen und pushen
+git tag v0.6.0
+git push origin v0.6.0
+```
+
+GitHub Actions baut daraufhin automatisch alle drei Plattformen und veröffentlicht das Release mit den ZIP-Dateien als Anhang.
+
+Namensschema: `vMAJOR.MINOR.PATCH` gemäß [SemVer](https://semver.org/lang/de/).
+
+| Versionssprung | Wann |
+|----------------|------|
+| `PATCH` (`v0.5.0` → `v0.5.1`) | Bugfix |
+| `MINOR` (`v0.5.1` → `v0.6.0`) | Neues Feature |
+| `MAJOR` (`v0.6.0` → `v1.0.0`) | Brechende Änderung (neues Dateiformat o. Ä.) |
+
+### Dev Build
+
+Der Dev Build wird **automatisch** nach jedem Merge auf `main` ausgelöst – kein manuelles Eingreifen notwendig.
+Das bestehende `dev-latest`-Release auf GitHub wird dabei überschrieben.
+
+---
+
+## GitHub Actions Workflows
+
+| Workflow | Datei | Trigger |
+|----------|-------|---------|
+| Build & Release | `.github/workflows/release.yml` | Push eines `v*`-Tags |
+| Dev Build | `.github/workflows/dev-build.yml` | Merge auf `main` |
+| Deploy Docs | `.github/workflows/docs.yml` | Änderungen in `docs/` oder `mkdocs.yml` |
+
+### Unterstützte Plattformen
+
+| Plattform | Runner | Ausgabe |
+|-----------|--------|---------|
+| Windows | `windows-latest` | `SituationReport-Windows.zip` |
+| macOS (Apple Silicon) | `macos-latest` | `SituationReport-macOS-ARM.zip` |
+| Linux x64 | `ubuntu-latest` | `SituationReport-Linux.zip` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,3 +66,4 @@ nav:
     - simulate: modules/simulate.md
   - Architektur: architecture.md
   - Entwicklung: development.md
+  - Releases: releases.md


### PR DESCRIPTION
## Summary

- **CI Workflows**: neuer `dev-build.yml` (automatischer Prerelease bei jedem Merge auf `main`, Windows + macOS ARM + Linux x64); `release.yml` auf Tag-Trigger `v*` umgestellt und Linux-Runner ergänzt
- **GUI**: Sprach-Cascade aus der Menüleiste entfernt, stattdessen kleiner Flag-Button oben rechts im Fenster — Flags werden programmatisch via `PhotoImage.put()` gezeichnet (keine externen Dateien, funktioniert im PyInstaller-Bundle)
- **Docs**: neue Seiten `releases.md` / `releases.en.md` mit Installationsanleitung für End-User und Release-Prozess für Entwickler; Nav-Eintrag in `mkdocs.yml`

## Test plan

- [ ] `python -m pytest` lokal grün (64 GUI-Tests bestanden)
- [ ] GUI starten und Flag-Button prüfen: Klick wechselt DE ↔ EN, Bild aktualisiert sich
- [ ] Sprache über `Optionen → Sprache` als Fallback testen
- [ ] Nach Merge: Dev Build in GitHub Actions beobachten

🤖 Generated with [Claude Code](https://claude.com/claude-code)