### PR TITLE
fix(ci): patch PyInstaller osx.py at runtime for macOS build

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -39,7 +39,27 @@ jobs:
         run: sudo apt-get install -y python3-tk
 
       - name: Install Python dependencies
-        run: pip install -e "." "pyinstaller>=6.0,<6.20"
+        run: pip install -e "." pyinstaller
+
+      - name: Patch PyInstaller macOS framework-bundle IndexError
+        if: runner.os == 'macOS'
+        run: |
+          python3 - <<'PYEOF'
+          import pathlib, sys
+          osx_py = (pathlib.Path(sys.prefix) / "lib"
+                    / f"python{sys.version_info.major}.{sys.version_info.minor}"
+                    / "site-packages" / "PyInstaller" / "utils" / "osx.py")
+          lines = osx_py.read_text().splitlines(keepends=True)
+          for i, line in enumerate(lines):
+              if "dir_name = remaining_path_parts[2]" in line:
+                  indent = " " * (len(line) - len(line.lstrip()))
+                  lines.insert(i, f"{indent}if len(remaining_path_parts) < 3:\n{indent}    continue\n")
+                  osx_py.write_text("".join(lines))
+                  print(f"Patched line {i+1} of {osx_py}")
+                  break
+          else:
+              print("Pattern not found – may already be fixed upstream")
+          PYEOF
 
       - name: Download bundled Chrome (kaleido PDF export)
         run: choreo_get_chrome

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,27 @@ jobs:
         run: sudo apt-get install -y python3-tk
 
       - name: Install Python dependencies
-        run: pip install -e "." "pyinstaller>=6.0,<6.20"
+        run: pip install -e "." pyinstaller
+
+      - name: Patch PyInstaller macOS framework-bundle IndexError
+        if: runner.os == 'macOS'
+        run: |
+          python3 - <<'PYEOF'
+          import pathlib, sys
+          osx_py = (pathlib.Path(sys.prefix) / "lib"
+                    / f"python{sys.version_info.major}.{sys.version_info.minor}"
+                    / "site-packages" / "PyInstaller" / "utils" / "osx.py")
+          lines = osx_py.read_text().splitlines(keepends=True)
+          for i, line in enumerate(lines):
+              if "dir_name = remaining_path_parts[2]" in line:
+                  indent = " " * (len(line) - len(line.lstrip()))
+                  lines.insert(i, f"{indent}if len(remaining_path_parts) < 3:\n{indent}    continue\n")
+                  osx_py.write_text("".join(lines))
+                  print(f"Patched line {i+1} of {osx_py}")
+                  break
+          else:
+              print("Pattern not found – may already be fixed upstream")
+          PYEOF
 
       - name: Download bundled Chrome (kaleido PDF export)
         run: choreo_get_chrome


### PR DESCRIPTION
## Problem

`collect_files_from_framework_bundles()` in PyInstaller's `osx.py` schlägt mit `IndexError: tuple index out of range` fehl, wenn Chrome (über choreographer/kaleido gebündelt) `.framework`-Pfade mitbringt, die nicht der Standard-macOS-Struktur (`Versions/X/Binary`) folgen.

Versionspinning hilft nicht — der Bug existiert in 6.19.0 und 6.20.0 gleichermaßen.

## Fix

Ein Python-Inline-Skript patcht `osx.py` direkt auf dem Runner nach der Installation von PyInstaller. Der Patch fügt einen `len()`-Guard vor der fehlschlagenden Zeile ein:

```python
if len(remaining_path_parts) < 3:
    continue
dir_name = remaining_path_parts[2]
```

- Nur macOS (`if: runner.os == 'macOS'`)
- Idempotent: gibt `"Pattern not found"` aus, falls PyInstaller upstream den Fix bereits liefert

## Test plan

- [ ] macOS-Build in GitHub Actions grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)