### PR TITLE
fix(ci): exclude Chrome from macOS PyInstaller bundle

### DIFF
--- a/build_gui.spec
+++ b/build_gui.spec
@@ -30,6 +30,13 @@ kaleido_datas, kaleido_binaries, kaleido_hiddenimports = collect_all("kaleido")
 # collect_all captures both the Python sources and the native binaries
 choreo_datas, choreo_binaries, choreo_hiddenimports = collect_all("choreographer")
 
+# On macOS, exclude the pre-downloaded Chrome app bundle from the PyInstaller bundle.
+# Google Chrome for Testing is already signed by Google; PyInstaller's ad-hoc codesign
+# step fails on it. Choreographer downloads Chrome at runtime on first use instead.
+if sys.platform == "darwin":
+    choreo_binaries = [(s, d) for s, d in choreo_binaries if "browser_exe" not in s]
+    choreo_datas    = [(s, d) for s, d in choreo_datas    if "browser_exe" not in s]
+
 all_datas = plotly_datas + openpyxl_datas + kaleido_datas + choreo_datas
 all_binaries = kaleido_binaries + choreo_binaries
 all_hiddenimports = (


### PR DESCRIPTION
## Problem

PyInstaller versucht `Google Chrome for Testing.app` auf macOS per `codesign -s -` ad-hoc zu signieren — schlägt fehl, weil Chrome bereits von Google signiert ist und `--force` auf fremde Signaturen nicht angewendet werden kann.

## Fix

In `build_gui.spec`: auf macOS werden `browser_exe`-Einträge aus `choreo_binaries` und `choreo_datas` herausgefiltert. Chrome wird **nicht** ins Bundle gepackt. Choreographer lädt Chrome beim ersten PDF-Export automatisch in einen User-Cache nach.

**Konsequenz für macOS-User:** Erster PDF-Export benötigt eine Internetverbindung (~120 MB Download, einmalig). Danach lokal gecacht.

## Test plan

- [ ] macOS-Build in GitHub Actions grün
- [ ] `.app` öffnet sich und zeigt Metriken im Browser
- [ ] PDF-Export auf macOS funktioniert (Chrome-Download beim ersten Mal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)