### PR TITLE
feat(ci): portable Python distribution (replaces PyInstaller)

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -34,40 +34,151 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install tkinter (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get install -y python3-tk
-
-      - name: Install Python dependencies
-        run: pip install -e "." pyinstaller
-
-      - name: Patch PyInstaller macOS framework-bundle IndexError
-        if: runner.os == 'macOS'
+      # -----------------------------------------------------------------------
+      # Windows: embeddable Python 3.11 + tkinter + deps + Chrome + source
+      # -----------------------------------------------------------------------
+      - name: Build portable package – Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
         run: |
+          $PY_VER = "3.11.9"
+          $PY_URL = "https://www.python.org/ftp/python/$PY_VER/python-$PY_VER-embed-amd64.zip"
+          $BUNDLE = "dist\SituationReport"
+          New-Item -ItemType Directory -Force "$BUNDLE\python" | Out-Null
+
+          # --- Embeddable Python ---
+          Invoke-WebRequest -Uri $PY_URL -OutFile python_embed.zip
+          Expand-Archive python_embed.zip -DestinationPath "$BUNDLE\python"
+          Remove-Item python_embed.zip
+
+          # Patch ._pth: enable site-packages and add bundle root to sys.path
+          $pthFile = (Get-ChildItem "$BUNDLE\python\python*._pth").FullName
+          (Get-Content $pthFile) -replace '#import site', 'import site' |
+              Set-Content $pthFile -Encoding UTF8NoBOM
+          Add-Content $pthFile -Value '..' -Encoding UTF8NoBOM
+
+          # --- pip ---
+          Invoke-WebRequest -Uri "https://bootstrap.pypa.io/get-pip.py" -OutFile get-pip.py
+          & "$BUNDLE\python\python.exe" get-pip.py --no-warn-script-location
+          Remove-Item get-pip.py
+
+          # --- Python dependencies ---
+          & "$BUNDLE\python\python.exe" -m pip install `
+              openpyxl plotly kaleido pypdf tkcalendar --no-warn-script-location
+
+          # --- tkinter support (not included in embeddable, copy from CI Python) ---
+          $pyPrefix = (python -c "import sys; print(sys.prefix)").Trim()
+
+          # _tkinter.pyd extension module
+          foreach ($src in "$pyPrefix\DLLs\_tkinter.pyd", "$pyPrefix\_tkinter.pyd") {
+              if (Test-Path $src) { Copy-Item $src "$BUNDLE\python\"; break }
+          }
+          # tcl/tk runtime DLLs (try Python root, then DLLs/)
+          foreach ($dir in $pyPrefix, "$pyPrefix\DLLs") {
+              Get-ChildItem $dir -MaxDepth 1 -Filter "tcl*.dll" -ErrorAction SilentlyContinue |
+                  Copy-Item -Destination "$BUNDLE\python\"
+              Get-ChildItem $dir -MaxDepth 1 -Filter "tk*.dll" -ErrorAction SilentlyContinue |
+                  Copy-Item -Destination "$BUNDLE\python\"
+          }
+          # tcl/tk library files (needed at runtime by TCL interpreter)
+          foreach ($src in "$pyPrefix\tcl", "$pyPrefix\Lib\tcl") {
+              if (Test-Path $src) { Copy-Item -Recurse $src "$BUNDLE\python\tcl"; break }
+          }
+
+          # --- Pre-download Chrome for offline PDF export ---
+          & "$BUNDLE\python\Scripts\choreo_get_chrome.exe"
+
+          # --- Source modules ---
+          foreach ($mod in 'build_reports','transform_data','get_data','simulate','testdata_generator') {
+              if (Test-Path $mod) { Copy-Item -Recurse $mod "$BUNDLE\$mod" }
+          }
+          foreach ($f in 'version.py','pyproject.toml','README.md','LICENSE') {
+              if (Test-Path $f) { Copy-Item $f "$BUNDLE\" }
+          }
+
+          # --- Launcher batch files ---
+          # TCL_LIBRARY/TK_LIBRARY are resolved dynamically from the bundle's tcl/ directory
+          @'
+          @echo off
+          set "D=%~dp0"
+          for /d %%i in ("%D%python\tcl\tcl*") do set "TCL_LIBRARY=%%i"
+          for /d %%i in ("%D%python\tcl\tk*") do set "TK_LIBRARY=%%i"
+          start "" "%D%python\pythonw.exe" -m build_reports
+          '@ | Set-Content "$BUNDLE\SituationReport.bat" -Encoding ASCII
+
+          @'
+          @echo off
+          set "D=%~dp0"
+          for /d %%i in ("%D%python\tcl\tcl*") do set "TCL_LIBRARY=%%i"
+          for /d %%i in ("%D%python\tcl\tk*") do set "TK_LIBRARY=%%i"
+          start "" "%D%python\pythonw.exe" -m transform_data
+          '@ | Set-Content "$BUNDLE\TransformData.bat" -Encoding ASCII
+
+      # -----------------------------------------------------------------------
+      # macOS / Linux: source + first-run venv launcher scripts
+      # -----------------------------------------------------------------------
+      - name: Build portable package – macOS / Linux
+        if: runner.os != 'Windows'
+        run: |
+          BUNDLE="dist/SituationReport"
+          mkdir -p "$BUNDLE"
+
+          # Copy source modules
+          for mod in build_reports transform_data get_data simulate testdata_generator; do
+            [ -d "$mod" ] && cp -r "$mod" "$BUNDLE/"
+          done
+          for f in version.py pyproject.toml README.md LICENSE; do
+            [ -f "$f" ] && cp "$f" "$BUNDLE/"
+          done
+
+          # Write launcher scripts via Python to avoid heredoc quoting issues
           python3 - <<'PYEOF'
-          import pathlib, sys
-          osx_py = (pathlib.Path(sys.prefix) / "lib"
-                    / f"python{sys.version_info.major}.{sys.version_info.minor}"
-                    / "site-packages" / "PyInstaller" / "utils" / "osx.py")
-          lines = osx_py.read_text().splitlines(keepends=True)
-          for i, line in enumerate(lines):
-              if "dir_name = remaining_path_parts[2]" in line:
-                  indent = " " * (len(line) - len(line.lstrip()))
-                  lines.insert(i, f"{indent}if len(remaining_path_parts) < 3:\n{indent}    continue\n")
-                  osx_py.write_text("".join(lines))
-                  print(f"Patched line {i+1} of {osx_py}")
-                  break
-          else:
-              print("Pattern not found – may already be fixed upstream")
+          import os, stat, sys
+
+          BUNDLE = "dist/SituationReport"
+          IS_MACOS = sys.platform == "darwin"
+          RX = stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
+
+          def launcher(module):
+              tkcheck = 'if ! python3 -c "import tkinter" 2>/dev/null; then\n'
+              tkcheck += '    echo "FEHLER: tkinter nicht installiert."\n'
+              if not IS_MACOS:
+                  tkcheck += '    echo "  Ubuntu/Debian: sudo apt install python3-tk"\n'
+                  tkcheck += '    echo "  Fedora: sudo dnf install python3-tkinter"\n'
+              tkcheck += '    exit 1\nfi\n'
+              return (
+                  "#!/bin/bash\n"
+                  "set -e\n"
+                  'cd "$(dirname "$0")"\n'
+                  + tkcheck
+                  + 'if [ ! -d ".venv" ]; then\n'
+                  '    echo "Einmalige Einrichtung (ca. 1 Minute, Internet erforderlich)..."\n'
+                  "    python3 -m venv .venv\n"
+                  "    .venv/bin/pip install --quiet openpyxl plotly kaleido pypdf tkcalendar\n"
+                  "    .venv/bin/choreo_get_chrome\n"
+                  '    echo "Einrichtung abgeschlossen."\n'
+                  "fi\n"
+                  f'.venv/bin/python -m {module} "$@"\n'
+              )
+
+          scripts = {
+              "SituationReport.sh": launcher("build_reports"),
+              "TransformData.sh": launcher("transform_data"),
+          }
+          if IS_MACOS:
+              scripts["SituationReport.command"] = launcher("build_reports")
+              scripts["TransformData.command"] = launcher("transform_data")
+
+          for name, content in scripts.items():
+              path = os.path.join(BUNDLE, name)
+              with open(path, "w", newline="\n") as f:
+                  f.write(content)
+              os.chmod(path, RX)
           PYEOF
 
-      - name: Download bundled Chrome (kaleido PDF export)
-        run: choreo_get_chrome
-        shell: bash
-
-      - name: Build with PyInstaller
-        run: pyinstaller build_gui.spec
-
+      # -----------------------------------------------------------------------
+      # Package
+      # -----------------------------------------------------------------------
       - name: Package – Windows
         if: runner.os == 'Windows'
         shell: pwsh
@@ -75,7 +186,7 @@ jobs:
 
       - name: Package – macOS
         if: runner.os == 'macOS'
-        run: zip -r SituationReport-macOS-ARM.zip dist/SituationReport.app
+        run: zip -r SituationReport-macOS-ARM.zip dist/SituationReport
 
       - name: Package – Linux
         if: runner.os == 'Linux'
@@ -125,22 +236,38 @@ jobs:
             > **Vorschau-Version** – aktueller Entwicklungsstand von `main`.
             > Für produktiven Einsatz stabile Releases verwenden.
 
-            Eigenständige GUI-App. **Kein Python oder sonstige Installation notwendig.**
+            Portables Paket – enthält alle Quelldateien, Skripte und Konfigurationsmöglichkeiten.
 
             ---
 
             ### Windows
 
             1. `SituationReport-Windows.zip` herunterladen und entpacken
-            2. Im entpackten Ordner `SituationReport.exe` doppelklicken
+            2. `SituationReport.bat` doppelklicken → Build Reports GUI
+               `TransformData.bat` doppelklicken → Transform Data GUI
+            3. Beim ersten Start: Windows SmartScreen → **Weitere Informationen** → **Trotzdem ausführen**
+
+            > Kein Python notwendig – alles ist im Paket enthalten inkl. Chrome für PDF-Export.
 
             ### macOS (Apple Silicon)
 
             1. `SituationReport-macOS-ARM.zip` herunterladen und entpacken
-            2. Beim **ersten Start**: Rechtsklick → *Öffnen* → *Öffnen* bestätigen
+            2. Rechtsklick auf `SituationReport.command` → *Öffnen* → *Öffnen* bestätigen (Gatekeeper, einmalig)
+            3. Beim **ersten Start**: einmalige Einrichtung (~1 Min, Internet erforderlich)
 
             ### Linux (x64)
 
             1. `SituationReport-Linux.zip` herunterladen und entpacken
-            2. Im entpackten Ordner `./SituationReport` ausführen
-            3. Bei Bedarf einmalig: `chmod +x SituationReport`
+            2. Voraussetzung: `python3` und `python3-tk` installiert
+               (`sudo apt install python3-tk` auf Ubuntu/Debian)
+            3. Im entpackten Ordner: `./SituationReport.sh`
+               Beim **ersten Start**: einmalige Einrichtung (~1 Min, Internet erforderlich)
+
+            ---
+
+            ### Enthaltene Werkzeuge
+
+            | Datei | Funktion |
+            |-------|----------|
+            | `SituationReport.bat` / `.command` / `.sh` | Build Reports – Metriken und Berichte erstellen |
+            | `TransformData.bat` / `.command` / `.sh` | Transform Data – Rohdaten aufbereiten |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,40 +34,151 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install tkinter (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get install -y python3-tk
-
-      - name: Install Python dependencies
-        run: pip install -e "." pyinstaller
-
-      - name: Patch PyInstaller macOS framework-bundle IndexError
-        if: runner.os == 'macOS'
+      # -----------------------------------------------------------------------
+      # Windows: embeddable Python 3.11 + tkinter + deps + Chrome + source
+      # -----------------------------------------------------------------------
+      - name: Build portable package – Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
         run: |
+          $PY_VER = "3.11.9"
+          $PY_URL = "https://www.python.org/ftp/python/$PY_VER/python-$PY_VER-embed-amd64.zip"
+          $BUNDLE = "dist\SituationReport"
+          New-Item -ItemType Directory -Force "$BUNDLE\python" | Out-Null
+
+          # --- Embeddable Python ---
+          Invoke-WebRequest -Uri $PY_URL -OutFile python_embed.zip
+          Expand-Archive python_embed.zip -DestinationPath "$BUNDLE\python"
+          Remove-Item python_embed.zip
+
+          # Patch ._pth: enable site-packages and add bundle root to sys.path
+          $pthFile = (Get-ChildItem "$BUNDLE\python\python*._pth").FullName
+          (Get-Content $pthFile) -replace '#import site', 'import site' |
+              Set-Content $pthFile -Encoding UTF8NoBOM
+          Add-Content $pthFile -Value '..' -Encoding UTF8NoBOM
+
+          # --- pip ---
+          Invoke-WebRequest -Uri "https://bootstrap.pypa.io/get-pip.py" -OutFile get-pip.py
+          & "$BUNDLE\python\python.exe" get-pip.py --no-warn-script-location
+          Remove-Item get-pip.py
+
+          # --- Python dependencies ---
+          & "$BUNDLE\python\python.exe" -m pip install `
+              openpyxl plotly kaleido pypdf tkcalendar --no-warn-script-location
+
+          # --- tkinter support (not included in embeddable, copy from CI Python) ---
+          $pyPrefix = (python -c "import sys; print(sys.prefix)").Trim()
+
+          # _tkinter.pyd extension module
+          foreach ($src in "$pyPrefix\DLLs\_tkinter.pyd", "$pyPrefix\_tkinter.pyd") {
+              if (Test-Path $src) { Copy-Item $src "$BUNDLE\python\"; break }
+          }
+          # tcl/tk runtime DLLs (try Python root, then DLLs/)
+          foreach ($dir in $pyPrefix, "$pyPrefix\DLLs") {
+              Get-ChildItem $dir -MaxDepth 1 -Filter "tcl*.dll" -ErrorAction SilentlyContinue |
+                  Copy-Item -Destination "$BUNDLE\python\"
+              Get-ChildItem $dir -MaxDepth 1 -Filter "tk*.dll" -ErrorAction SilentlyContinue |
+                  Copy-Item -Destination "$BUNDLE\python\"
+          }
+          # tcl/tk library files (needed at runtime by TCL interpreter)
+          foreach ($src in "$pyPrefix\tcl", "$pyPrefix\Lib\tcl") {
+              if (Test-Path $src) { Copy-Item -Recurse $src "$BUNDLE\python\tcl"; break }
+          }
+
+          # --- Pre-download Chrome for offline PDF export ---
+          & "$BUNDLE\python\Scripts\choreo_get_chrome.exe"
+
+          # --- Source modules ---
+          foreach ($mod in 'build_reports','transform_data','get_data','simulate','testdata_generator') {
+              if (Test-Path $mod) { Copy-Item -Recurse $mod "$BUNDLE\$mod" }
+          }
+          foreach ($f in 'version.py','pyproject.toml','README.md','LICENSE') {
+              if (Test-Path $f) { Copy-Item $f "$BUNDLE\" }
+          }
+
+          # --- Launcher batch files ---
+          # TCL_LIBRARY/TK_LIBRARY are resolved dynamically from the bundle's tcl/ directory
+          @'
+          @echo off
+          set "D=%~dp0"
+          for /d %%i in ("%D%python\tcl\tcl*") do set "TCL_LIBRARY=%%i"
+          for /d %%i in ("%D%python\tcl\tk*") do set "TK_LIBRARY=%%i"
+          start "" "%D%python\pythonw.exe" -m build_reports
+          '@ | Set-Content "$BUNDLE\SituationReport.bat" -Encoding ASCII
+
+          @'
+          @echo off
+          set "D=%~dp0"
+          for /d %%i in ("%D%python\tcl\tcl*") do set "TCL_LIBRARY=%%i"
+          for /d %%i in ("%D%python\tcl\tk*") do set "TK_LIBRARY=%%i"
+          start "" "%D%python\pythonw.exe" -m transform_data
+          '@ | Set-Content "$BUNDLE\TransformData.bat" -Encoding ASCII
+
+      # -----------------------------------------------------------------------
+      # macOS / Linux: source + first-run venv launcher scripts
+      # -----------------------------------------------------------------------
+      - name: Build portable package – macOS / Linux
+        if: runner.os != 'Windows'
+        run: |
+          BUNDLE="dist/SituationReport"
+          mkdir -p "$BUNDLE"
+
+          # Copy source modules
+          for mod in build_reports transform_data get_data simulate testdata_generator; do
+            [ -d "$mod" ] && cp -r "$mod" "$BUNDLE/"
+          done
+          for f in version.py pyproject.toml README.md LICENSE; do
+            [ -f "$f" ] && cp "$f" "$BUNDLE/"
+          done
+
+          # Write launcher scripts via Python to avoid heredoc quoting issues
           python3 - <<'PYEOF'
-          import pathlib, sys
-          osx_py = (pathlib.Path(sys.prefix) / "lib"
-                    / f"python{sys.version_info.major}.{sys.version_info.minor}"
-                    / "site-packages" / "PyInstaller" / "utils" / "osx.py")
-          lines = osx_py.read_text().splitlines(keepends=True)
-          for i, line in enumerate(lines):
-              if "dir_name = remaining_path_parts[2]" in line:
-                  indent = " " * (len(line) - len(line.lstrip()))
-                  lines.insert(i, f"{indent}if len(remaining_path_parts) < 3:\n{indent}    continue\n")
-                  osx_py.write_text("".join(lines))
-                  print(f"Patched line {i+1} of {osx_py}")
-                  break
-          else:
-              print("Pattern not found – may already be fixed upstream")
+          import os, stat, sys
+
+          BUNDLE = "dist/SituationReport"
+          IS_MACOS = sys.platform == "darwin"
+          RX = stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
+
+          def launcher(module):
+              tkcheck = 'if ! python3 -c "import tkinter" 2>/dev/null; then\n'
+              tkcheck += '    echo "FEHLER: tkinter nicht installiert."\n'
+              if not IS_MACOS:
+                  tkcheck += '    echo "  Ubuntu/Debian: sudo apt install python3-tk"\n'
+                  tkcheck += '    echo "  Fedora: sudo dnf install python3-tkinter"\n'
+              tkcheck += '    exit 1\nfi\n'
+              return (
+                  "#!/bin/bash\n"
+                  "set -e\n"
+                  'cd "$(dirname "$0")"\n'
+                  + tkcheck
+                  + 'if [ ! -d ".venv" ]; then\n'
+                  '    echo "Einmalige Einrichtung (ca. 1 Minute, Internet erforderlich)..."\n'
+                  "    python3 -m venv .venv\n"
+                  "    .venv/bin/pip install --quiet openpyxl plotly kaleido pypdf tkcalendar\n"
+                  "    .venv/bin/choreo_get_chrome\n"
+                  '    echo "Einrichtung abgeschlossen."\n'
+                  "fi\n"
+                  f'.venv/bin/python -m {module} "$@"\n'
+              )
+
+          scripts = {
+              "SituationReport.sh": launcher("build_reports"),
+              "TransformData.sh": launcher("transform_data"),
+          }
+          if IS_MACOS:
+              scripts["SituationReport.command"] = launcher("build_reports")
+              scripts["TransformData.command"] = launcher("transform_data")
+
+          for name, content in scripts.items():
+              path = os.path.join(BUNDLE, name)
+              with open(path, "w", newline="\n") as f:
+                  f.write(content)
+              os.chmod(path, RX)
           PYEOF
 
-      - name: Download bundled Chrome (kaleido PDF export)
-        run: choreo_get_chrome
-        shell: bash
-
-      - name: Build with PyInstaller
-        run: pyinstaller build_gui.spec
-
+      # -----------------------------------------------------------------------
+      # Package
+      # -----------------------------------------------------------------------
       - name: Package – Windows
         if: runner.os == 'Windows'
         shell: pwsh
@@ -75,7 +186,7 @@ jobs:
 
       - name: Package – macOS
         if: runner.os == 'macOS'
-        run: zip -r SituationReport-macOS-ARM.zip dist/SituationReport.app
+        run: zip -r SituationReport-macOS-ARM.zip dist/SituationReport
 
       - name: Package – Linux
         if: runner.os == 'Linux'
@@ -110,33 +221,35 @@ jobs:
           body: |
             ## SituationReport ${{ github.ref_name }}
 
-            Eigenständige GUI-App. **Kein Python oder sonstige Installation notwendig.**
+            Portables Paket – enthält alle Quelldateien, Skripte und Konfigurationsmöglichkeiten.
+            Kein Python oder sonstige Installation notwendig (Windows).
 
             ---
 
             ### Windows
 
             1. `SituationReport-Windows.zip` herunterladen und entpacken
-            2. Im entpackten Ordner `SituationReport.exe` doppelklicken
+            2. `SituationReport.bat` doppelklicken → Build Reports GUI
+               `TransformData.bat` doppelklicken → Transform Data GUI
+            3. Beim ersten Start: Windows SmartScreen → **Weitere Informationen** → **Trotzdem ausführen**
+
+            > Python (3.11) und Chrome (PDF-Export) sind im Paket enthalten.
 
             ### macOS (Apple Silicon)
 
             1. `SituationReport-macOS-ARM.zip` herunterladen und entpacken
-            2. `SituationReport.app` in den Ordner *Programme* ziehen (optional)
-            3. Beim **ersten Start**: Rechtsklick → *Öffnen* → *Öffnen* bestätigen
-               *(macOS Gatekeeper-Hinweis, da die App nicht signiert ist)*
+            2. Rechtsklick auf `SituationReport.command` → *Öffnen* → *Öffnen* bestätigen (Gatekeeper, einmalig)
+            3. Beim **ersten Start**: einmalige Einrichtung (~1 Min, Internet erforderlich)
 
             ### Linux (x64)
 
             1. `SituationReport-Linux.zip` herunterladen und entpacken
-            2. Im entpackten Ordner `./SituationReport` ausführen
-            3. Bei Bedarf einmalig: `chmod +x SituationReport`
+            2. Voraussetzung: `python3` und `python3-tk` installiert
+               (`sudo apt install python3-tk` auf Ubuntu/Debian)
+            3. Im entpackten Ordner: `./SituationReport.sh`
+               Beim **ersten Start**: einmalige Einrichtung (~1 Min, Internet erforderlich)
 
             ---
-
-            ### Voraussetzungen
-
-            Keine – alle Abhängigkeiten (inkl. Chrome für PDF-Export) sind enthalten.
 
             ### Datenformat
 

--- a/docs/releases.en.md
+++ b/docs/releases.en.md
@@ -1,7 +1,7 @@
 # Releases & Installation
 
-SituationReport is distributed as a standalone desktop app – **no Python, no installation required**.
-Just download, unzip, and run.
+SituationReport is distributed as a portable package – all source files, scripts, and configuration options are included.
+Download, unzip, and run.
 
 ---
 
@@ -26,11 +26,16 @@ All available releases are on the [GitHub Releases page](https://github.com/Jaeg
 
 1. Download `SituationReport-Windows.zip`
 2. Extract the zip (right-click → *Extract All*)
-3. Open the extracted folder and double-click `SituationReport.exe`
+3. In the extracted folder:
+   - Double-click `SituationReport.bat` → Build Reports GUI
+   - Double-click `TransformData.bat` → Transform Data GUI
 
 !!! note "Windows SmartScreen"
-    On the first launch, SmartScreen may show a warning because the app is not signed.
+    On the first launch, SmartScreen may show a warning because the included files are not signed.
     Click **More info** → **Run anyway**.
+
+!!! info "Includes Python and Chrome"
+    The Windows package includes Python 3.11 and Chrome (for PDF export) – no internet or separate installation required.
 
 ---
 
@@ -38,12 +43,15 @@ All available releases are on the [GitHub Releases page](https://github.com/Jaeg
 
 1. Download `SituationReport-macOS-ARM.zip`
 2. Extract the zip
-3. Optionally move `SituationReport.app` to your *Applications* folder
-4. **First launch**: right-click the app → *Open* → confirm *Open* in the dialog
+3. Right-click `SituationReport.command` → *Open* → confirm *Open* in the dialog
 
 !!! note "macOS Gatekeeper"
-    Because the app is not notarized, macOS blocks a direct double-click on the first launch.
+    Because the scripts are not notarized, macOS blocks a direct double-click on the first launch.
     The right-click approach bypasses this protection once.
+
+!!! warning "One-time setup (first launch)"
+    On the first launch, a Python environment is set up automatically (~1 minute).
+    **Internet required.** After that, the app works offline.
 
 ---
 
@@ -51,12 +59,38 @@ All available releases are on the [GitHub Releases page](https://github.com/Jaeg
 
 1. Download `SituationReport-Linux.zip`
 2. Extract the zip
-3. Open a terminal, navigate to the extracted folder, and run:
+3. Check prerequisites:
+   ```bash
+   python3 --version           # 3.11 or newer
+   python3 -c "import tkinter" # must run without error
+   ```
+   If tkinter is missing: `sudo apt install python3-tk` (Ubuntu/Debian) or `sudo dnf install python3-tkinter` (Fedora)
+4. Run from the extracted folder:
+   ```bash
+   ./SituationReport.sh    # Build Reports GUI
+   ./TransformData.sh      # Transform Data GUI
+   ```
 
-```bash
-chmod +x SituationReport   # once only
-./SituationReport
-```
+!!! warning "One-time setup (first launch)"
+    On the first launch, a Python environment is set up automatically (~1 minute).
+    **Internet required.** After that, the app works offline.
+
+---
+
+## Package contents
+
+The package contains the full repository – source files, configurations, and examples:
+
+| File / Folder | Contents |
+|---------------|----------|
+| `build_reports/` | Metrics, GUI, CLI, and plugin mechanism |
+| `transform_data/` | Data transformation (Jira export → XLSX) |
+| `get_data/` | Data access |
+| `simulate/` | Simulation and test-data generation |
+| `testdata_generator/` | Example workflows and test data |
+| `build_reports/pi_config_example.json` | Template for PI configuration |
+| `SituationReport.bat/.command/.sh` | Launcher for Build Reports |
+| `TransformData.bat/.command/.sh` | Launcher for Transform Data |
 
 ---
 
@@ -99,8 +133,8 @@ The existing `dev-latest` release on GitHub is replaced each time.
 
 ### Supported platforms
 
-| Platform | Runner | Output |
-|----------|--------|--------|
-| Windows | `windows-latest` | `SituationReport-Windows.zip` |
-| macOS (Apple Silicon) | `macos-latest` | `SituationReport-macOS-ARM.zip` |
-| Linux x64 | `ubuntu-latest` | `SituationReport-Linux.zip` |
+| Platform | Runner | Output | Python |
+|----------|--------|--------|--------|
+| Windows | `windows-latest` | `SituationReport-Windows.zip` | Embeddable 3.11 (bundled) |
+| macOS (Apple Silicon) | `macos-latest` | `SituationReport-macOS-ARM.zip` | System Python + venv (on 1st launch) |
+| Linux x64 | `ubuntu-latest` | `SituationReport-Linux.zip` | System Python + venv (on 1st launch) |

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,7 +1,7 @@
 # Releases & Installation
 
-SituationReport wird als eigenständige Desktop-App ausgeliefert – **kein Python, keine Installation notwendig**.
-Einfach herunterladen, entpacken und starten.
+SituationReport wird als portables Paket ausgeliefert – alle Quelldateien, Skripte und Konfigurationsmöglichkeiten sind enthalten.
+Herunterladen, entpacken und starten.
 
 ---
 
@@ -26,11 +26,16 @@ Alle verfügbaren Releases sind auf der [GitHub-Releases-Seite](https://github.c
 
 1. `SituationReport-Windows.zip` herunterladen
 2. Zip-Datei entpacken (Rechtsklick → *Alle extrahieren*)
-3. Im entpackten Ordner `SituationReport.exe` doppelklicken
+3. Im entpackten Ordner:
+   - `SituationReport.bat` doppelklicken → Build Reports GUI
+   - `TransformData.bat` doppelklicken → Transform Data GUI
 
 !!! note "Windows SmartScreen"
-    Beim ersten Start erscheint möglicherweise ein SmartScreen-Hinweis, da die App nicht signiert ist.
+    Beim ersten Start erscheint möglicherweise ein SmartScreen-Hinweis, da die enthaltenen Dateien nicht signiert sind.
     Auf **Weitere Informationen** → **Trotzdem ausführen** klicken.
+
+!!! info "Enthält Python und Chrome"
+    Das Windows-Paket enthält Python 3.11 und Chrome (für PDF-Export) – kein Internet oder separate Installation notwendig.
 
 ---
 
@@ -38,12 +43,15 @@ Alle verfügbaren Releases sind auf der [GitHub-Releases-Seite](https://github.c
 
 1. `SituationReport-macOS-ARM.zip` herunterladen
 2. Zip-Datei entpacken
-3. `SituationReport.app` in den Ordner *Programme* ziehen (optional)
-4. **Ersten Start**: Rechtsklick auf die App → *Öffnen* → im Dialog erneut *Öffnen* bestätigen
+3. Rechtsklick auf `SituationReport.command` → *Öffnen* → im Dialog erneut *Öffnen* bestätigen
 
 !!! note "macOS Gatekeeper"
-    Da die App nicht notarisiert ist, blockiert macOS den ersten Start per Doppelklick.
+    Da die Skripte nicht notarisiert sind, blockiert macOS den ersten Start per Doppelklick.
     Der Rechtsklick-Weg umgeht diesen Schutz einmalig.
+
+!!! warning "Einmalige Einrichtung (erster Start)"
+    Beim ersten Start wird automatisch eine Python-Umgebung eingerichtet (~1 Minute).
+    **Internet erforderlich.** Danach funktioniert die App offline.
 
 ---
 
@@ -51,12 +59,38 @@ Alle verfügbaren Releases sind auf der [GitHub-Releases-Seite](https://github.c
 
 1. `SituationReport-Linux.zip` herunterladen
 2. Zip-Datei entpacken
-3. Terminal öffnen, in den entpackten Ordner wechseln und starten:
+3. Voraussetzung prüfen:
+   ```bash
+   python3 --version           # 3.11 oder neuer
+   python3 -c "import tkinter" # muss ohne Fehler laufen
+   ```
+   Falls tkinter fehlt: `sudo apt install python3-tk` (Ubuntu/Debian) oder `sudo dnf install python3-tkinter` (Fedora)
+4. Im entpackten Ordner starten:
+   ```bash
+   ./SituationReport.sh    # Build Reports GUI
+   ./TransformData.sh      # Transform Data GUI
+   ```
 
-```bash
-chmod +x SituationReport   # einmalig
-./SituationReport
-```
+!!! warning "Einmalige Einrichtung (erster Start)"
+    Beim ersten Start wird automatisch eine Python-Umgebung eingerichtet (~1 Minute).
+    **Internet erforderlich.** Danach funktioniert die App offline.
+
+---
+
+## Paketinhalt
+
+Das Paket enthält das gesamte Repository – Quelldateien, Konfigurationen und Beispiele:
+
+| Datei / Ordner | Inhalt |
+|----------------|--------|
+| `build_reports/` | Metriken, GUI, CLI und Plugin-Mechanismus |
+| `transform_data/` | Datenaufbereitung (Jira-Export → XLSX) |
+| `get_data/` | Datenzugriff |
+| `simulate/` | Simulation und Testdaten-Generierung |
+| `testdata_generator/` | Beispiel-Workflows und Testdaten |
+| `build_reports/pi_config_example.json` | Vorlage für PI-Konfiguration |
+| `SituationReport.bat/.command/.sh` | Starter für Build Reports |
+| `TransformData.bat/.command/.sh` | Starter für Transform Data |
 
 ---
 
@@ -99,8 +133,8 @@ Das bestehende `dev-latest`-Release auf GitHub wird dabei überschrieben.
 
 ### Unterstützte Plattformen
 
-| Plattform | Runner | Ausgabe |
-|-----------|--------|---------|
-| Windows | `windows-latest` | `SituationReport-Windows.zip` |
-| macOS (Apple Silicon) | `macos-latest` | `SituationReport-macOS-ARM.zip` |
-| Linux x64 | `ubuntu-latest` | `SituationReport-Linux.zip` |
+| Plattform | Runner | Ausgabe | Python |
+|-----------|--------|---------|--------|
+| Windows | `windows-latest` | `SituationReport-Windows.zip` | Embeddable 3.11 (im Paket) |
+| macOS (Apple Silicon) | `macos-latest` | `SituationReport-macOS-ARM.zip` | System-Python + venv (beim 1. Start) |
+| Linux x64 | `ubuntu-latest` | `SituationReport-Linux.zip` | System-Python + venv (beim 1. Start) |


### PR DESCRIPTION
## Summary

- **Windows**: embeddable Python 3.11 + tkinter files from CI + pip deps + pre-bundled Chrome; launched via `SituationReport.bat` / `TransformData.bat` (no Python required)
- **macOS**: source + `.command` and `.sh` launchers; first-run venv setup (~1 min, internet required once)
- **Linux**: source + `.sh` launchers; same first-run venv pattern

All packages now include the full repository content (`build_reports`, `transform_data`, `get_data`, `simulate`, `testdata_generator`, configs) so users can run, extend, and modify the toolchain. Fixes the three issues from bug report: (1) only `build_reports` was reachable, (2) plugin mechanism was frozen, (3) users couldn't manage their own setup.

Updated `docs/releases.md` and `docs/releases.en.md` with new installation instructions.

## Test plan

- [ ] Merge and verify dev-build CI passes on all three platforms
- [ ] Windows: extract zip, double-click `SituationReport.bat` → GUI opens without Python installed
- [ ] Windows: double-click `TransformData.bat` → GUI opens
- [ ] macOS: open `.command`, confirm Gatekeeper prompt, venv setup runs, GUI opens
- [ ] Linux: run `./SituationReport.sh`, confirm venv setup runs, GUI opens
- [ ] All three platforms: PDF export works (Chrome available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)