### PR TITLE
fix(ci): remove -MaxDepth from Get-ChildItem

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -75,9 +75,9 @@ jobs:
           }
           # tcl/tk runtime DLLs (try Python root, then DLLs/)
           foreach ($dir in $pyPrefix, "$pyPrefix\DLLs") {
-              Get-ChildItem $dir -MaxDepth 1 -Filter "tcl*.dll" -ErrorAction SilentlyContinue |
+              Get-ChildItem $dir -Filter "tcl*.dll" -ErrorAction SilentlyContinue |
                   Copy-Item -Destination "$BUNDLE\python\"
-              Get-ChildItem $dir -MaxDepth 1 -Filter "tk*.dll" -ErrorAction SilentlyContinue |
+              Get-ChildItem $dir -Filter "tk*.dll" -ErrorAction SilentlyContinue |
                   Copy-Item -Destination "$BUNDLE\python\"
           }
           # tcl/tk library files (needed at runtime by TCL interpreter)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,9 @@ jobs:
           }
           # tcl/tk runtime DLLs (try Python root, then DLLs/)
           foreach ($dir in $pyPrefix, "$pyPrefix\DLLs") {
-              Get-ChildItem $dir -MaxDepth 1 -Filter "tcl*.dll" -ErrorAction SilentlyContinue |
+              Get-ChildItem $dir -Filter "tcl*.dll" -ErrorAction SilentlyContinue |
                   Copy-Item -Destination "$BUNDLE\python\"
-              Get-ChildItem $dir -MaxDepth 1 -Filter "tk*.dll" -ErrorAction SilentlyContinue |
+              Get-ChildItem $dir -Filter "tk*.dll" -ErrorAction SilentlyContinue |
                   Copy-Item -Destination "$BUNDLE\python\"
           }
           # tcl/tk library files (needed at runtime by TCL interpreter)


### PR DESCRIPTION
## Summary

- Removes `-MaxDepth 1` from all `Get-ChildItem` calls in the Windows portable build step
- `-MaxDepth` was introduced in PowerShell 7.3 and is not available in the version on the CI runner
- The parameter was redundant anyway: without `-Recurse`, `Get-ChildItem` already only returns top-level entries in the specified directory

## Test plan

- [ ] Merge triggers dev-latest CI build — Windows job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)