### PR TITLE
rename: SituationReport.bat/.sh/.command → BuildReports.*

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -134,7 +134,7 @@ jobs:
               echo Fehler beim Starten. Bitte den roten Text oben notieren.
               pause
           )
-          '@ | Set-Content "$BUNDLE\SituationReport.bat" -Encoding ASCII
+          '@ | Set-Content "$BUNDLE\BuildReports.bat" -Encoding ASCII
 
           @'
           @echo off
@@ -197,11 +197,11 @@ jobs:
               )
 
           scripts = {
-              "SituationReport.sh": launcher("build_reports"),
+              "BuildReports.sh": launcher("build_reports"),
               "TransformData.sh": launcher("transform_data"),
           }
           if IS_MACOS:
-              scripts["SituationReport.command"] = launcher("build_reports")
+              scripts["BuildReports.command"] = launcher("build_reports")
               scripts["TransformData.command"] = launcher("transform_data")
 
           for name, content in scripts.items():
@@ -278,7 +278,7 @@ jobs:
             ### Windows
 
             1. `SituationReport-Windows.zip` herunterladen und entpacken
-            2. `SituationReport.bat` doppelklicken → Build Reports GUI
+            2. `BuildReports.bat` doppelklicken → Build Reports GUI
                `TransformData.bat` doppelklicken → Transform Data GUI
             3. Beim ersten Start: Windows SmartScreen → **Weitere Informationen** → **Trotzdem ausführen**
 
@@ -287,7 +287,7 @@ jobs:
             ### macOS (Apple Silicon)
 
             1. `SituationReport-macOS-ARM.zip` herunterladen und entpacken
-            2. Rechtsklick auf `SituationReport.command` → *Öffnen* → *Öffnen* bestätigen (Gatekeeper, einmalig)
+            2. Rechtsklick auf `BuildReports.command` → *Öffnen* → *Öffnen* bestätigen (Gatekeeper, einmalig)
             3. Beim **ersten Start**: einmalige Einrichtung (~1 Min, Internet erforderlich)
 
             ### Linux (x64)
@@ -295,7 +295,7 @@ jobs:
             1. `SituationReport-Linux.zip` herunterladen und entpacken
             2. Voraussetzung: `python3` und `python3-tk` installiert
                (`sudo apt install python3-tk` auf Ubuntu/Debian)
-            3. Im entpackten Ordner: `./SituationReport.sh`
+            3. Im entpackten Ordner: `./BuildReports.sh`
                Beim **ersten Start**: einmalige Einrichtung (~1 Min, Internet erforderlich)
 
             ---
@@ -304,5 +304,5 @@ jobs:
 
             | Datei | Funktion |
             |-------|----------|
-            | `SituationReport.bat` / `.command` / `.sh` | Build Reports – Metriken und Berichte erstellen |
+            | `BuildReports.bat` / `.command` / `.sh` | Build Reports – Metriken und Berichte erstellen |
             | `TransformData.bat` / `.command` / `.sh` | Transform Data – Rohdaten aufbereiten |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
               echo Fehler beim Starten. Bitte den roten Text oben notieren.
               pause
           )
-          '@ | Set-Content "$BUNDLE\SituationReport.bat" -Encoding ASCII
+          '@ | Set-Content "$BUNDLE\BuildReports.bat" -Encoding ASCII
 
           @'
           @echo off
@@ -197,11 +197,11 @@ jobs:
               )
 
           scripts = {
-              "SituationReport.sh": launcher("build_reports"),
+              "BuildReports.sh": launcher("build_reports"),
               "TransformData.sh": launcher("transform_data"),
           }
           if IS_MACOS:
-              scripts["SituationReport.command"] = launcher("build_reports")
+              scripts["BuildReports.command"] = launcher("build_reports")
               scripts["TransformData.command"] = launcher("transform_data")
 
           for name, content in scripts.items():
@@ -264,7 +264,7 @@ jobs:
             ### Windows
 
             1. `SituationReport-Windows.zip` herunterladen und entpacken
-            2. `SituationReport.bat` doppelklicken → Build Reports GUI
+            2. `BuildReports.bat` doppelklicken → Build Reports GUI
                `TransformData.bat` doppelklicken → Transform Data GUI
             3. Beim ersten Start: Windows SmartScreen → **Weitere Informationen** → **Trotzdem ausführen**
 
@@ -273,7 +273,7 @@ jobs:
             ### macOS (Apple Silicon)
 
             1. `SituationReport-macOS-ARM.zip` herunterladen und entpacken
-            2. Rechtsklick auf `SituationReport.command` → *Öffnen* → *Öffnen* bestätigen (Gatekeeper, einmalig)
+            2. Rechtsklick auf `BuildReports.command` → *Öffnen* → *Öffnen* bestätigen (Gatekeeper, einmalig)
             3. Beim **ersten Start**: einmalige Einrichtung (~1 Min, Internet erforderlich)
 
             ### Linux (x64)
@@ -281,7 +281,7 @@ jobs:
             1. `SituationReport-Linux.zip` herunterladen und entpacken
             2. Voraussetzung: `python3` und `python3-tk` installiert
                (`sudo apt install python3-tk` auf Ubuntu/Debian)
-            3. Im entpackten Ordner: `./SituationReport.sh`
+            3. Im entpackten Ordner: `./BuildReports.sh`
                Beim **ersten Start**: einmalige Einrichtung (~1 Min, Internet erforderlich)
 
             ---

--- a/docs/generate_manual.py
+++ b/docs/generate_manual.py
@@ -446,14 +446,14 @@ def content_de(st, images: dict[str, Path] | None = None):
     story.append(P(
         "Die passende Startdatei im entpackten Ordner doppelklicken:", st))
     story.append(BL(
-        "<b>Windows:</b> <b>SituationReport.bat</b> doppelklicken -- startet die GUI "
+        "<b>Windows:</b> <b>BuildReports.bat</b> doppelklicken -- startet die GUI "
         "ohne Konsolenfenster.", st))
     story.append(BL(
-        "<b>macOS:</b> Rechtsklick auf <b>SituationReport.command</b> → <i>Oeffnen</i> "
+        "<b>macOS:</b> Rechtsklick auf <b>BuildReports.command</b> → <i>Oeffnen</i> "
         "(einmalig wegen Gatekeeper).", st))
     story.append(BL(
         "<b>Linux:</b> Im Terminal: "
-        "<font name='Courier'>./SituationReport.sh</font>", st))
+        "<font name='Courier'>./BuildReports.sh</font>", st))
     story.append(SP(4))
     story.append(box(
         "<b>Tipp (Windows):</b> Beim ersten Start erscheint moeglicherweise ein "
@@ -1216,14 +1216,14 @@ def content_en(st, images: dict[str, Path] | None = None):
     story.append(P(
         "Double-click the appropriate launcher in the extracted folder:", st))
     story.append(BL(
-        "<b>Windows:</b> Double-click <b>SituationReport.bat</b> — starts the GUI "
+        "<b>Windows:</b> Double-click <b>BuildReports.bat</b> — starts the GUI "
         "without a console window.", st))
     story.append(BL(
-        "<b>macOS:</b> Right-click <b>SituationReport.command</b> → <i>Open</i> "
+        "<b>macOS:</b> Right-click <b>BuildReports.command</b> → <i>Open</i> "
         "(once, to bypass Gatekeeper).", st))
     story.append(BL(
         "<b>Linux:</b> In a terminal: "
-        "<font name='Courier'>./SituationReport.sh</font>", st))
+        "<font name='Courier'>./BuildReports.sh</font>", st))
     story.append(SP(4))
     story.append(box(
         "<b>Tip (Windows):</b> On the first launch, SmartScreen may show a warning. "

--- a/docs/releases.en.md
+++ b/docs/releases.en.md
@@ -27,7 +27,7 @@ All available releases are on the [GitHub Releases page](https://github.com/Jaeg
 1. Download `SituationReport-Windows.zip`
 2. Extract the zip (right-click → *Extract All*)
 3. In the extracted folder:
-   - Double-click `SituationReport.bat` → Build Reports GUI
+   - Double-click `BuildReports.bat` → Build Reports GUI
    - Double-click `TransformData.bat` → Transform Data GUI
 
 !!! note "Windows SmartScreen"
@@ -43,7 +43,7 @@ All available releases are on the [GitHub Releases page](https://github.com/Jaeg
 
 1. Download `SituationReport-macOS-ARM.zip`
 2. Extract the zip
-3. Right-click `SituationReport.command` → *Open* → confirm *Open* in the dialog
+3. Right-click `BuildReports.command` → *Open* → confirm *Open* in the dialog
 
 !!! note "macOS Gatekeeper"
     Because the scripts are not notarized, macOS blocks a direct double-click on the first launch.
@@ -67,7 +67,7 @@ All available releases are on the [GitHub Releases page](https://github.com/Jaeg
    If tkinter is missing: `sudo apt install python3-tk` (Ubuntu/Debian) or `sudo dnf install python3-tkinter` (Fedora)
 4. Run from the extracted folder:
    ```bash
-   ./SituationReport.sh    # Build Reports GUI
+   ./BuildReports.sh    # Build Reports GUI
    ./TransformData.sh      # Transform Data GUI
    ```
 
@@ -89,7 +89,7 @@ The package contains the full repository – source files, configurations, and e
 | `simulate/` | Simulation and test-data generation |
 | `testdata_generator/` | Example workflows and test data |
 | `build_reports/pi_config_example.json` | Template for PI configuration |
-| `SituationReport.bat/.command/.sh` | Launcher for Build Reports |
+| `BuildReports.bat/.command/.sh` | Launcher for Build Reports |
 | `TransformData.bat/.command/.sh` | Launcher for Transform Data |
 
 ---

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -27,7 +27,7 @@ Alle verfügbaren Releases sind auf der [GitHub-Releases-Seite](https://github.c
 1. `SituationReport-Windows.zip` herunterladen
 2. Zip-Datei entpacken (Rechtsklick → *Alle extrahieren*)
 3. Im entpackten Ordner:
-   - `SituationReport.bat` doppelklicken → Build Reports GUI
+   - `BuildReports.bat` doppelklicken → Build Reports GUI
    - `TransformData.bat` doppelklicken → Transform Data GUI
 
 !!! note "Windows SmartScreen"
@@ -43,7 +43,7 @@ Alle verfügbaren Releases sind auf der [GitHub-Releases-Seite](https://github.c
 
 1. `SituationReport-macOS-ARM.zip` herunterladen
 2. Zip-Datei entpacken
-3. Rechtsklick auf `SituationReport.command` → *Öffnen* → im Dialog erneut *Öffnen* bestätigen
+3. Rechtsklick auf `BuildReports.command` → *Öffnen* → im Dialog erneut *Öffnen* bestätigen
 
 !!! note "macOS Gatekeeper"
     Da die Skripte nicht notarisiert sind, blockiert macOS den ersten Start per Doppelklick.
@@ -67,7 +67,7 @@ Alle verfügbaren Releases sind auf der [GitHub-Releases-Seite](https://github.c
    Falls tkinter fehlt: `sudo apt install python3-tk` (Ubuntu/Debian) oder `sudo dnf install python3-tkinter` (Fedora)
 4. Im entpackten Ordner starten:
    ```bash
-   ./SituationReport.sh    # Build Reports GUI
+   ./BuildReports.sh    # Build Reports GUI
    ./TransformData.sh      # Transform Data GUI
    ```
 
@@ -89,7 +89,7 @@ Das Paket enthält das gesamte Repository – Quelldateien, Konfigurationen und 
 | `simulate/` | Simulation und Testdaten-Generierung |
 | `testdata_generator/` | Beispiel-Workflows und Testdaten |
 | `build_reports/pi_config_example.json` | Vorlage für PI-Konfiguration |
-| `SituationReport.bat/.command/.sh` | Starter für Build Reports |
+| `BuildReports.bat/.command/.sh` | Starter für Build Reports |
 | `TransformData.bat/.command/.sh` | Starter für Transform Data |
 
 ---


### PR DESCRIPTION
## Summary

- Renames all three launcher scripts from `SituationReport.*` to `BuildReports.*` across CI workflows, release notes, and docs
- `SituationReport` is reserved as the umbrella package name for a later combined package
- Affected files: `dev-build.yml`, `release.yml`, `releases.md`, `releases.en.md`, `generate_manual.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)