### PR TITLE
fix(ci): Coverage-Workflow – workflow_ART_A.txt + xvfb

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,11 +21,14 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install system dependencies
+        run: sudo apt-get install -y xvfb
+
       - name: Install dependencies
         run: pip install -e ".[dev]" --quiet
 
       - name: Run tests with coverage
-        run: python -m pytest --cov --cov-report=xml -q --tb=short
+        run: xvfb-run python -m pytest --cov --cov-report=xml -q --tb=short
 
       - name: Generate coverage badge
         run: genbadge coverage -i coverage.xml -o docs/coverage.svg

--- a/testdata_generator/workflow_ART_A.txt
+++ b/testdata_generator/workflow_ART_A.txt
@@ -1,0 +1,11 @@
+Funnel:New:Open:To Do
+Analysis:In Analysis:Estimated
+Program Backlog:Ready for Dev:Backlog
+Implementation:In Implementation:In Review:In Progress
+Blocker
+Validating on Staging:QA
+Deploying to Production:Ready for Development
+Releasing:Completed
+Done:Canceled
+<First>Analysis
+<Closed>Releasing


### PR DESCRIPTION
## Summary

- `testdata_generator/workflow_ART_A.txt` war nicht in git — Akzeptanztests für `testdata_generator` und `helper` schlugen in CI mit FileNotFoundError fehl
- `coverage.yml`: `xvfb` installieren und `xvfb-run` verwenden, damit tkinter-GUI-Tests keinen physischen Display brauchen

## Test plan

- [ ] Coverage-Workflow läuft in CI durch (alle 628 Tests grün)
- [ ] Badge wird korrekt generiert und auf main committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)