### PR TITLE
ci: workflow_dispatch für Coverage-Workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "**.py"
       - "tests/**"
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Ermöglicht manuelles Triggern via gh workflow run / GitHub UI.