### PR TITLE
fix(testdata_generator): prevent right-censoring diagonal in scatter plot

### DIFF
--- a/testdata_generator/generator.py
+++ b/testdata_generator/generator.py
@@ -3,7 +3,7 @@
 # Repository:     https://github.com/Jaegerfeld/situation-report
 # KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
 # Erstellt:       02.05.2026
-# Geändert:       02.05.2026
+# Geändert:       07.05.2026
 # Lizenz:         BSD-3-Clause (siehe LICENSE)
 #
 # Fachliche Funktion:
@@ -17,6 +17,7 @@ from __future__ import annotations
 import random
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
+from math import ceil
 
 from .workflow_parser import WorkflowSpec
 
@@ -132,13 +133,21 @@ def _simulate_issue(
         workflow.closed_stage and workflow.closed_stage in stages
     ) else len(stages) - 1
 
-    created_ts = _random_datetime(rng, config.from_date, config.to_date)
     issue_type = rng.choices(list(config.issue_types.keys()), weights=list(config.issue_types.values()), k=1)[0]
-
     is_complete = rng.random() < config.completion_rate
 
     if is_complete:
         target_idx = closed_idx
+        # Sample created_ts early enough that the issue can close before to_date.
+        # Without this constraint, late-created completed issues would close after
+        # to_date and be filtered out by build_reports, creating a right-censoring
+        # artifact (downward diagonal in the scatter plot).
+        expected_steps = ceil(closed_idx / max(0.01, 1.0 - config.backflow_prob))
+        buffer_days = ceil((expected_steps + first_idx) * config.max_dwell_hours / 24) + 1
+        latest_start = config.to_date - timedelta(days=buffer_days)
+        if latest_start < config.from_date:
+            latest_start = config.from_date
+        created_ts = _random_datetime(rng, config.from_date, latest_start)
     else:
         # Decide if this is a To Do issue (before first_stage) or In Progress
         if first_idx > 0 and rng.random() < config.todo_rate:
@@ -147,6 +156,7 @@ def _simulate_issue(
             target_idx = rng.randint(first_idx, closed_idx - 1)
         else:
             target_idx = first_idx
+        created_ts = _random_datetime(rng, config.from_date, config.to_date)
 
     histories: list[dict] = []
     current_idx = 0  # issues implicitly start in stages[0]

--- a/tests/testdata_generator/unit/test_generator.py
+++ b/tests/testdata_generator/unit/test_generator.py
@@ -3,7 +3,7 @@
 # Repository:     https://github.com/Jaegerfeld/situation-report
 # KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
 # Erstellt:       02.05.2026
-# Geändert:       02.05.2026
+# Geändert:       07.05.2026
 # Lizenz:         BSD-3-Clause (siehe LICENSE)
 #
 # Fachliche Funktion:
@@ -287,3 +287,69 @@ class TestJSONSerializable:
         data = generate(_simple_workflow(), _config(issue_count=10))
         serialised = json.dumps(data)
         assert serialised
+
+
+class TestCycleTimeDistribution:
+    """Verify that right-censoring does not create a scatter plot diagonal."""
+
+    @pytest.fixture(scope="class")
+    def completed_issues(self) -> list[dict]:
+        wf = _simple_workflow()
+        data = generate(wf, _config(issue_count=200, completion_rate=0.8, seed=42))
+        closed_stage = wf.closed_stage
+        return [i for i in data["issues"] if i["fields"]["status"]["name"] == closed_stage]
+
+    def _get_closed_date(self, issue: dict) -> datetime:
+        """Return the timestamp of the last transition into closed_stage."""
+        histories = issue["changelog"]["histories"]
+        for h in reversed(histories):
+            if h["items"][0]["toString"] == _simple_workflow().closed_stage:
+                ts_str = h["created"]
+                # Parse Jira format: 2025-11-30T16:49:19.000+0100
+                return datetime.strptime(ts_str[:19], "%Y-%m-%dT%H:%M:%S")
+        raise AssertionError(f"No closed transition found in {issue['key']}")
+
+    def test_completed_issues_close_within_to_date(self, completed_issues: list[dict]) -> None:
+        """All completed issues must close on or before to_date."""
+        to_date = date(2025, 12, 31)
+        for issue in completed_issues:
+            closed_dt = self._get_closed_date(issue)
+            assert closed_dt.date() <= to_date, (
+                f"{issue['key']} closed on {closed_dt.date()} which is after to_date {to_date}"
+            )
+
+    def test_cycle_time_not_correlated_with_closed_date(self, completed_issues: list[dict]) -> None:
+        """Pearson correlation between closed_date and cycle_time must be > -0.5.
+
+        A strong negative correlation (< -0.5) indicates right-censoring:
+        late close dates only allow short cycle times.
+        """
+        if len(completed_issues) < 10:
+            pytest.skip("Too few completed issues for correlation check")
+
+        xs: list[float] = []
+        ys: list[float] = []
+
+        for issue in completed_issues:
+            created_str = issue["fields"]["created"]
+            created_dt = datetime.strptime(created_str[:19], "%Y-%m-%dT%H:%M:%S")
+            closed_dt = self._get_closed_date(issue)
+            cycle_days = (closed_dt - created_dt).total_seconds() / 86400
+            closed_ordinal = closed_dt.toordinal()
+            xs.append(float(closed_ordinal))
+            ys.append(cycle_days)
+
+        n = len(xs)
+        mean_x = sum(xs) / n
+        mean_y = sum(ys) / n
+        cov = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys)) / n
+        std_x = (sum((x - mean_x) ** 2 for x in xs) / n) ** 0.5
+        std_y = (sum((y - mean_y) ** 2 for y in ys) / n) ** 0.5
+
+        if std_x == 0 or std_y == 0:
+            pytest.skip("Zero variance — cannot compute correlation")
+
+        pearson_r = cov / (std_x * std_y)
+        assert pearson_r > -0.5, (
+            f"Pearson r={pearson_r:.3f} indicates right-censoring (scatter plot diagonal)"
+        )


### PR DESCRIPTION
## Summary
- Completed issues were sampled with `created_ts` from the full `[from_date, to_date]` range. Dwell times could push the close date past `to_date`, which build_reports filtered out — only short cycle times survived for late close dates, creating a downward diagonal in the scatter plot (right-censoring artifact).
- Fix: determine `is_complete` before sampling `created_ts`. For completed issues, restrict the creation window to `[from_date, latest_start]` where `latest_start = to_date - buffer_days` guarantees enough time to close within the configured period.
- Note: RNG order changes — existing seeds produce different (but correct and unbiased) results.

## Test plan
- [x] New `TestCycleTimeDistribution.test_completed_issues_close_within_to_date`: all completed issues have `closed_date ≤ to_date`
- [x] New `TestCycleTimeDistribution.test_cycle_time_not_correlated_with_closed_date`: Pearson r > -0.5 (no right-censoring diagonal)
- [x] All 630 existing tests pass (`python -m pytest -q`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)