### PR TITLE
chore(release): v0.9.7 – GUI-Standard Handbuch + Sprachauswahl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Das Format orientiert sich an [Keep a Changelog](https://keepachangelog.com/de/1
 
 ---
 
+## [0.9.7] – 2026-05-09
+
+### Changed
+- `testdata_generator`, `helper`: GUI-Sprachauswahl und Handbuch-Aufruf vereinheitlicht.
+  Beide Module folgen jetzt dem `build_reports`/`transform_data`-Standard:
+  5 Sprachen (DE/EN/RO/PT/FR), persistierte Sprachauswahl (`prefs.json`),
+  `Hilfe → Manual`-Menüeintrag, Flaggen-Kaskade als Sprachumschalter.
+  `helper` hat erstmals einen Manual-Menüeintrag (URL folgt mit PDF-Erstellung).
+
+---
+
 ## [0.9.6] – 2026-05-08
 
 ### Changed

--- a/docs/testdata_generator_Benutzerhandbuch.pdf
+++ b/docs/testdata_generator_Benutzerhandbuch.pdf
@@ -145,7 +145,7 @@ endobj
 endobj
 19 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260508220714+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260508220714+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260509000054+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260509000054+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -156,10 +156,10 @@ endobj
 endobj
 21 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 599
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 600
 >>
 stream
-Garo>>Ak00&;B$9=3Mmgb/E?5ooT;EX[%JM`=il)'5+X"fmq[)7"7A+Qh6Gm/D63Jq<"4-+V;;"gt)d]b6jP:"=0\p!\%)FI>%>pnZ+p\;C`8+<Cs"j*-S;)eO;QcCTgT=D87SekIcE]@=,hE7TcPg[30AnE8o)adOR//e76$G*gKQF/nZoOq"6%0JolXPZ:$KAj*R5#OI'WQlTe*0Dok=gJ6/cupE;K9p,;n4VYh@4+&H7eV'AkH8?#nsV6FWhJ]`:\f#eSlA!]+tL[TA%@g`%!?8BW]$$qj9TLt2#"Jj\)[cKojN,>3UA(lW[F4[U>k=i<S,I;c*U7]0<.jAb`;i;gnqH54MU)H?I3FUt'e8=lVc+B@4DS:sIe"j4Xm^bS7hLuqRfR>?Q8oU(9`,m)J2Z6%tIjEfu-r@g"raOjqK[p:&'s*$E*&pZF;@<AI[tiMUV&rD=F=38q7U)Xh(euGN0@*obK02J\.g^ndDKOR&$nTif@'P6nah.N^f>kf"-H%sBD;9&qk:`I*s)c&$]H(+6ed=-S\a![V2g)HfnFd\Ycjonq".udU;eQ8W(tsFuWFJ$rjRI[cs&),P(OtN%8,~>endstream
+Garo>>Ak00&;B$9=3Mmgb/E>J4n^*(MHYQ6c&*koj<i/a;6g5+=,?j%]U/8RJh5T<jn\&/iuntZdC?@j!1+EOY6[Zc[09I,T_\r_X5[33`)8)j-rihb!tMrm&F6&2bI,eI=W=T&crt'*#2!8C66k,45V:%p!h;5kSTG3u+n\qiNC,!+cfJ;'?MX7B9nKa)['E(U9?[&d]-&KKP\`WY6H@#@*T5JJ8\IpEZ+UT2O"n>&l3C9)F6SJp"&c.c5UdNZAY<LfQ<B6`'Y:[Aaa^K])kp-Kpl\3\9[KL2#?>N7+X!%eBJ([tASCs_+6(STS%F-_4(i/P1c!5Z-G&G7S0DDuS6??3f?Ze2'%IOcR1hL0:>Js#g9_6el.3HH2biq&l`TQkigil=L$c@4<J7^>+N40(B@BYPrC=`lLB9@2c<j7*"/.S<aWg$n%>UIN5q.M:]\C?hjO0#7"ko/3T$_?gMrD%;FRn4`24-nTk"7r`N?);J-Nf8d3ERi*DUP]&_tEQ(]^_[*E?"V@jn[*_ks$2m4PgiU,I7q[Q`E;<GZ-Qu!,mo^#MMK$DW(+DI.FDc*JV"06gQQL"?PTkoIg@^IfY'6h+I~>endstream
 endobj
 22 0 obj
 <<
@@ -241,18 +241,18 @@ xref
 0000072112 00000 n 
 0000072393 00000 n 
 0000072508 00000 n 
-0000073198 00000 n 
-0000074750 00000 n 
-0000076516 00000 n 
-0000076977 00000 n 
-0000079003 00000 n 
-0000081052 00000 n 
-0000082876 00000 n 
-0000083872 00000 n 
+0000073199 00000 n 
+0000074751 00000 n 
+0000076517 00000 n 
+0000076978 00000 n 
+0000079004 00000 n 
+0000081053 00000 n 
+0000082877 00000 n 
+0000083873 00000 n 
 trailer
 <<
 /ID 
-[<f51ce68a165d6d0edd35cc3ca1642f70><f51ce68a165d6d0edd35cc3ca1642f70>]
+[<330da1c923f55a668adc209bf29775f2><330da1c923f55a668adc209bf29775f2>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 19 0 R
@@ -260,5 +260,5 @@ trailer
 /Size 30
 >>
 startxref
-85838
+85839
 %%EOF

--- a/docs/testdata_generator_UserManual.pdf
+++ b/docs/testdata_generator_UserManual.pdf
@@ -135,7 +135,7 @@ endobj
 endobj
 18 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260508220714+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260508220714+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260509000054+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260509000054+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -149,7 +149,7 @@ endobj
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 579
 >>
 stream
-Garo>>Ak00&;B$9=3MmglGV`;fT1Pr70O=2$a7Vsc=TqZ$bI?$r]RTS&=QL"Z6d]cbrNg3TOcHWY7CW:93C!]OG7c`AC3a>*o<4%cN8s2ZOp#<6\YW^>s%8MU7'/0FK!l<#aR/t(nf'V]ok^c3*8GD.!brb3D5p'(;2)B0%W:]<L/tl&L0qT:XV)`0M4,*r?=u(BlQF9UGj1.Bu7s0:`eQ66TlF<:q+\trm>o,9.7PBH*rl382VU!I1"J]d?=P^7h!Uf!Y2a_2JG]hX5)bg%;kj(8Ua8cUAb\R.9'UTZ=:_VRAlhUgqecq*7Om"-dHDBRD1_?o5@#i`-sh>)C)F,jl%(KGlpOQoc_P=DJ.K;qVTQ%b<rst]=LX3p\chaBFM=d#LCHa9^hl5!Zh3%D^FqUS0K_h:r^Jj5n`gg[;tHB4Zo8$`Q=[fE,ru,R_<8iSjAdC0C8q(1,_EJ$'k3mZIb^j?[%]Q\A!]t*d5SB\8DhX]9KAOD=`4_\pX<5p@D)u<7(hVLWiB8?#Cp]=&lr[n>8qG?1&jn)u02Gr4sWfqQ]E(3<]p#AYf@"Ik%,d").>ZOT~>endstream
+Garo>>Ak00&;B$9=3MmglGV`;fT1Pr70O=2$a7Vsc=TqZ$bI?$r]RTS&=QL"Z6d]cbrKE1TOcHWY7CW:93C!]OG7c`AC3a>*o<4%cN8s2ZOp#<6\YW^>s%8MU7'/0FK!l<#aR/t(nf'V]ok^c3*8GD.!brb3D5p'(;2)B0%W:]<L/tl&L0qT:XV)`0M4,*r?=u(BlQF9UGj1.Bu7s0:`eQ66TlF<:q+\trm>o,9.7PBH*rl382VU!I1"J]d?=P^7h!Uf!Y2a_2JG]hX5)bg%;kj(8Ua8cUAb\R.9'UTZ=:_VRAlhUgqecq*7Om"-dHDBRD1_?o/*0f@R$GZNKI;'o'hU6]E'89q@MdY\$P?.rU4@Nje6"u?/6g*qu2sk1^;^CKBH`kVYC%+JI[.N=@mljk6MJHPjdVi+:3AD>.O7\*Ze)MioEjC34\&Qc/,`Ec_*t]QhH#$q)1Mg$'k3mZIb^j?[%]Q\A!]t*d5SB\8DhX]9KAOD=`4_\pX<5p@G1;W1jU6%[iTN]A,qDYGuo@iD#fm]A,bg2Xp7m35HjLqQ]E(3<]p#,P"(k:B_G^!,3_2PQ~>endstream
 endobj
 21 0 obj
 <<
@@ -233,7 +233,7 @@ xref
 trailer
 <<
 /ID 
-[<3a052d397371e0690fb4a7f1dfec41d0><3a052d397371e0690fb4a7f1dfec41d0>]
+[<d6d45e15fabd3a1cc97b5b2bbfdd3d86><d6d45e15fabd3a1cc97b5b2bbfdd3d86>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 18 0 R

--- a/helper/gui.py
+++ b/helper/gui.py
@@ -3,7 +3,7 @@
 # Repository:     https://github.com/Jaegerfeld/situation-report
 # KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
 # Erstellt:       03.05.2026
-# Geändert:       03.05.2026
+# Geändert:       08.05.2026
 # Lizenz:         BSD-3-Clause (siehe LICENSE)
 #
 # Fachliche Funktion:
@@ -17,8 +17,10 @@
 
 from __future__ import annotations
 
+import json
 import threading
 import tkinter as tk
+import webbrowser
 from pathlib import Path
 from tkinter import filedialog, scrolledtext, ttk
 
@@ -29,14 +31,59 @@ except ImportError:
 
 from .cli import run_merge
 
-_LANG_DE = "de"
-_LANG_EN = "en"
+LANG_DE = "de"
+LANG_EN = "en"
+LANG_RO = "ro"
+LANG_PT = "pt"
+LANG_FR = "fr"
+
+_LANG_ORDER = [LANG_DE, LANG_EN, LANG_RO, LANG_PT, LANG_FR]
+
+_LANG_FLAGS: dict[str, str] = {
+    LANG_DE: "🇩🇪", LANG_EN: "🇬🇧", LANG_RO: "🇷🇴", LANG_PT: "🇵🇹", LANG_FR: "🇫🇷",
+}
+
+_MANUAL_URLS: dict[str, str] = {
+    LANG_DE: "https://jaegerfeld.github.io/situation-report/helper_Benutzerhandbuch.pdf",
+    LANG_EN: "https://jaegerfeld.github.io/situation-report/helper_UserManual.pdf",
+    LANG_RO: "https://jaegerfeld.github.io/situation-report/helper_UserManual.pdf",
+    LANG_PT: "https://jaegerfeld.github.io/situation-report/helper_UserManual.pdf",
+    LANG_FR: "https://jaegerfeld.github.io/situation-report/helper_UserManual.pdf",
+}
+
+_PREFS_PATH = Path.home() / ".situation_report" / "prefs.json"
+
+
+def _load_lang_pref() -> str:
+    """Load the last-used language preference from disk, defaulting to English."""
+    try:
+        with open(_PREFS_PATH) as f:
+            val = json.load(f).get("lang", LANG_EN)
+            return val if val in _T else LANG_EN
+    except Exception:
+        return LANG_EN
+
+
+def _save_lang_pref(lang: str) -> None:
+    """Persist the language preference to disk."""
+    _PREFS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    prefs: dict = {}
+    try:
+        with open(_PREFS_PATH) as f:
+            prefs = json.load(f)
+    except Exception:
+        pass
+    prefs["lang"] = lang
+    with open(_PREFS_PATH, "w") as f:
+        json.dump(prefs, f, indent=2)
+
 
 _T: dict[str, dict[str, str]] = {
-    _LANG_DE: {
+    LANG_DE: {
         "title":           f"helper – JSON Merger  {_VERSION}",
-        "menu_options":    "Optionen",
-        "menu_language":   "Sprache",
+        "menu_help":       "Hilfe",
+        "menu_manual":     "Manual",
+        "tip_language":    "Sprache wechseln",
         "lbl_inputs":      "Eingabedateien",
         "btn_add":         "Hinzufügen…",
         "btn_remove":      "Entfernen",
@@ -53,10 +100,11 @@ _T: dict[str, dict[str, str]] = {
         "dlg_add":         "JSON-Dateien hinzufügen",
         "dlg_output":      "Ausgabedatei wählen",
     },
-    _LANG_EN: {
+    LANG_EN: {
         "title":           f"helper – JSON Merger  {_VERSION}",
-        "menu_options":    "Options",
-        "menu_language":   "Language",
+        "menu_help":       "Help",
+        "menu_manual":     "Manual",
+        "tip_language":    "Change language",
         "lbl_inputs":      "Input files",
         "btn_add":         "Add…",
         "btn_remove":      "Remove",
@@ -81,30 +129,38 @@ class _App:
 
     def __init__(self, root: tk.Tk) -> None:
         self._root = root
-        self._lang = _LANG_DE
         self._running = False
         self._var_output = tk.StringVar()
         self._var_dedup = tk.BooleanVar(value=True)
         self._labels: dict[str, tk.Widget] = {}
+        self._lang_var = tk.StringVar(value=_load_lang_pref())
 
         self._build_menu()
         self._build_form()
         self._build_log()
-        self._apply_lang()
+        self._lang_var.trace_add("write", lambda *_: self._apply_language())
+        self._apply_language()
 
     def _t(self, key: str) -> str:
         """Look up a translation key for the current language."""
-        return _T[self._lang].get(key, key)
+        return _T.get(self._lang_var.get(), _T[LANG_EN]).get(key, key)
 
     def _build_menu(self) -> None:
-        """Build the Options → Language menu."""
+        """Build (or rebuild) the top menu bar with Help → Manual and a language flag."""
         menubar = tk.Menu(self._root)
-        self._menu_options = tk.Menu(menubar, tearoff=False)
-        lang_menu = tk.Menu(self._menu_options, tearoff=False)
-        lang_menu.add_command(label="Deutsch", command=lambda: self._set_lang(_LANG_DE))
-        lang_menu.add_command(label="English", command=lambda: self._set_lang(_LANG_EN))
-        self._menu_options.add_cascade(label="Language / Sprache", menu=lang_menu)
-        menubar.add_cascade(label="Optionen / Options", menu=self._menu_options)
+
+        help_menu = tk.Menu(menubar, tearoff=False)
+        menubar.add_cascade(label=self._t("menu_help"), menu=help_menu)
+        help_menu.add_command(label=self._t("menu_manual"), command=self._open_manual)
+
+        lang_menu = tk.Menu(menubar, tearoff=False)
+        lang_menu.add_radiobutton(label="🇩🇪  Deutsch",   variable=self._lang_var, value=LANG_DE)
+        lang_menu.add_radiobutton(label="🇬🇧  English",   variable=self._lang_var, value=LANG_EN)
+        lang_menu.add_radiobutton(label="🇷🇴  Română",    variable=self._lang_var, value=LANG_RO)
+        lang_menu.add_radiobutton(label="🇵🇹  Português", variable=self._lang_var, value=LANG_PT)
+        lang_menu.add_radiobutton(label="🇫🇷  Français",  variable=self._lang_var, value=LANG_FR)
+        menubar.add_cascade(label=_LANG_FLAGS.get(self._lang_var.get(), "🌐"), menu=lang_menu)
+
         self._root.config(menu=menubar)
 
     def _build_form(self) -> None:
@@ -182,18 +238,20 @@ class _App:
         )
         self._log.grid(row=0, column=0, sticky="nsew")
 
-    def _apply_lang(self) -> None:
+    def _apply_language(self) -> None:
         """Update all translatable widgets for the current language."""
+        _save_lang_pref(self._lang_var.get())
         self._root.title(self._t("title"))
         self._log_frame.configure(text=self._t("lbl_log"))
         for key, widget in self._labels.items():
             text = self._t(key)
             if hasattr(widget, "configure"):
                 widget.configure(text=text)
+        self._build_menu()
 
-    def _set_lang(self, lang: str) -> None:
-        self._lang = lang
-        self._apply_lang()
+    def _open_manual(self) -> None:
+        """Open the language-appropriate user manual PDF on GitHub Pages."""
+        webbrowser.open(_MANUAL_URLS.get(self._lang_var.get(), _MANUAL_URLS[LANG_EN]))
 
     def _add_files(self) -> None:
         """Open a multi-file dialog and add selected JSON files to the list."""

--- a/testdata_generator/gui.py
+++ b/testdata_generator/gui.py
@@ -3,7 +3,7 @@
 # Repository:     https://github.com/Jaegerfeld/situation-report
 # KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
 # Erstellt:       02.05.2026
-# Geändert:       03.05.2026
+# Geändert:       08.05.2026
 # Lizenz:         BSD-3-Clause (siehe LICENSE)
 #
 # Fachliche Funktion:
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import json
 import threading
 import tkinter as tk
 import webbrowser
@@ -30,21 +31,59 @@ except ImportError:
 
 from .cli import run_generate
 
-_LANG_DE = "de"
-_LANG_EN = "en"
+LANG_DE = "de"
+LANG_EN = "en"
+LANG_RO = "ro"
+LANG_PT = "pt"
+LANG_FR = "fr"
 
-_MANUAL_URLS = {
-    _LANG_DE: "https://jaegerfeld.github.io/situation-report/testdata_generator_Benutzerhandbuch.pdf",
-    _LANG_EN: "https://jaegerfeld.github.io/situation-report/testdata_generator_UserManual.pdf",
+_LANG_ORDER = [LANG_DE, LANG_EN, LANG_RO, LANG_PT, LANG_FR]
+
+_LANG_FLAGS: dict[str, str] = {
+    LANG_DE: "🇩🇪", LANG_EN: "🇬🇧", LANG_RO: "🇷🇴", LANG_PT: "🇵🇹", LANG_FR: "🇫🇷",
 }
 
+_MANUAL_URLS: dict[str, str] = {
+    LANG_DE: "https://jaegerfeld.github.io/situation-report/testdata_generator_Benutzerhandbuch.pdf",
+    LANG_EN: "https://jaegerfeld.github.io/situation-report/testdata_generator_UserManual.pdf",
+    LANG_RO: "https://jaegerfeld.github.io/situation-report/testdata_generator_UserManual.pdf",
+    LANG_PT: "https://jaegerfeld.github.io/situation-report/testdata_generator_UserManual.pdf",
+    LANG_FR: "https://jaegerfeld.github.io/situation-report/testdata_generator_UserManual.pdf",
+}
+
+_PREFS_PATH = Path.home() / ".situation_report" / "prefs.json"
+
+
+def _load_lang_pref() -> str:
+    """Load the last-used language preference from disk, defaulting to English."""
+    try:
+        with open(_PREFS_PATH) as f:
+            val = json.load(f).get("lang", LANG_EN)
+            return val if val in _T else LANG_EN
+    except Exception:
+        return LANG_EN
+
+
+def _save_lang_pref(lang: str) -> None:
+    """Persist the language preference to disk."""
+    _PREFS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    prefs: dict = {}
+    try:
+        with open(_PREFS_PATH) as f:
+            prefs = json.load(f)
+    except Exception:
+        pass
+    prefs["lang"] = lang
+    with open(_PREFS_PATH, "w") as f:
+        json.dump(prefs, f, indent=2)
+
+
 _T: dict[str, dict[str, str]] = {
-    _LANG_DE: {
+    LANG_DE: {
         "title":            f"testdata_generator {_VERSION}",
-        "menu_options":     "Optionen",
-        "menu_language":    "Sprache",
-        "menu_lang_de":     "Deutsch",
-        "menu_lang_en":     "English",
+        "menu_help":        "Hilfe",
+        "menu_manual":      "Manual",
+        "tip_language":     "Sprache wechseln",
         "lbl_workflow":     "Workflow-Datei",
         "lbl_output":       "Ausgabedatei (JSON)",
         "lbl_project":      "Projekt-Key",
@@ -60,7 +99,6 @@ _T: dict[str, dict[str, str]] = {
         "btn_browse_wf":    "Durchsuchen…",
         "btn_browse_out":   "Durchsuchen…",
         "btn_run":          "Generieren",
-        "menu_manual":      "Benutzerhandbuch öffnen",
         "err_no_workflow":  "FEHLER: Keine Workflow-Datei ausgewählt.",
         "err_no_output":    "FEHLER: Keine Ausgabedatei angegeben.",
         "err_issues":       "FEHLER: Anzahl Issues muss eine positive Ganzzahl sein.",
@@ -77,12 +115,11 @@ _T: dict[str, dict[str, str]] = {
         "tip_issue_types":  "Leer = Feature:0.6 Bug:0.3 Enabler:0.1 (Standard)",
         "tip_seed":         "Gleicher Seed → identische Ausgabe (reproduzierbar)",
     },
-    _LANG_EN: {
+    LANG_EN: {
         "title":            f"testdata_generator {_VERSION}",
-        "menu_options":     "Options",
-        "menu_language":    "Language",
-        "menu_lang_de":     "Deutsch",
-        "menu_lang_en":     "English",
+        "menu_help":        "Help",
+        "menu_manual":      "Manual",
+        "tip_language":     "Change language",
         "lbl_workflow":     "Workflow File",
         "lbl_output":       "Output File (JSON)",
         "lbl_project":      "Project Key",
@@ -98,7 +135,6 @@ _T: dict[str, dict[str, str]] = {
         "btn_browse_wf":    "Browse…",
         "btn_browse_out":   "Browse…",
         "btn_run":          "Generate",
-        "menu_manual":      "Open User Manual",
         "err_no_workflow":  "ERROR: No workflow file selected.",
         "err_no_output":    "ERROR: No output file specified.",
         "err_issues":       "ERROR: Issue count must be a positive integer.",
@@ -123,7 +159,6 @@ class _App:
 
     def __init__(self, root: tk.Tk) -> None:
         self._root = root
-        self._lang = _LANG_DE
         self._running = False
 
         self._var_workflow = tk.StringVar()
@@ -137,32 +172,32 @@ class _App:
         self._var_todo = tk.StringVar(value="0.15")
         self._var_backflow = tk.StringVar(value="0.1")
         self._var_seed = tk.StringVar()
+        self._lang_var = tk.StringVar(value=_load_lang_pref())
 
         self._build_menu()
         self._build_form()
         self._build_log()
-        self._apply_lang()
+        self._lang_var.trace_add("write", lambda *_: self._apply_language())
+        self._apply_language()
 
     def _t(self, key: str) -> str:
-        return _T[self._lang].get(key, key)
+        return _T.get(self._lang_var.get(), _T[LANG_EN]).get(key, key)
 
     def _build_menu(self) -> None:
         menubar = tk.Menu(self._root)
-        self._menu_options = tk.Menu(menubar, tearoff=False)
-        self._menu_language = tk.Menu(self._menu_options, tearoff=False)
-        self._menu_language.add_command(
-            label="Deutsch", command=lambda: self._set_lang(_LANG_DE)
-        )
-        self._menu_language.add_command(
-            label="English", command=lambda: self._set_lang(_LANG_EN)
-        )
-        self._menu_options.add_cascade(label="Language / Sprache", menu=self._menu_language)
-        self._menu_options.add_separator()
-        self._menu_options.add_command(
-            label="Benutzerhandbuch öffnen", command=self._open_manual
-        )
-        self._menu_manual_item_idx = self._menu_options.index("end")
-        menubar.add_cascade(label="Optionen / Options", menu=self._menu_options)
+
+        help_menu = tk.Menu(menubar, tearoff=False)
+        menubar.add_cascade(label=self._t("menu_help"), menu=help_menu)
+        help_menu.add_command(label=self._t("menu_manual"), command=self._open_manual)
+
+        lang_menu = tk.Menu(menubar, tearoff=False)
+        lang_menu.add_radiobutton(label="🇩🇪  Deutsch",   variable=self._lang_var, value=LANG_DE)
+        lang_menu.add_radiobutton(label="🇬🇧  English",   variable=self._lang_var, value=LANG_EN)
+        lang_menu.add_radiobutton(label="🇷🇴  Română",    variable=self._lang_var, value=LANG_RO)
+        lang_menu.add_radiobutton(label="🇵🇹  Português", variable=self._lang_var, value=LANG_PT)
+        lang_menu.add_radiobutton(label="🇫🇷  Français",  variable=self._lang_var, value=LANG_FR)
+        menubar.add_cascade(label=_LANG_FLAGS.get(self._lang_var.get(), "🌐"), menu=lang_menu)
+
         self._root.config(menu=menubar)
 
     def _build_form(self) -> None:
@@ -212,23 +247,18 @@ class _App:
         self._log = scrolledtext.ScrolledText(log_frame, height=12, state="disabled", wrap="word")
         self._log.grid(row=0, column=0, sticky="nsew")
 
-    def _apply_lang(self) -> None:
+    def _apply_language(self) -> None:
+        _save_lang_pref(self._lang_var.get())
         self._root.title(self._t("title"))
         for key, lbl in self._labels.items():
             lbl.configure(text=self._t(key))
         self._btn_run.configure(text=self._t("btn_run"))
         self._log_frame.configure(text=self._t("lbl_log"))
-        self._menu_options.entryconfigure(
-            self._menu_manual_item_idx, label=self._t("menu_manual")
-        )
-
-    def _set_lang(self, lang: str) -> None:
-        self._lang = lang
-        self._apply_lang()
+        self._build_menu()
 
     def _open_manual(self) -> None:
         """Open the language-appropriate user manual PDF on GitHub Pages."""
-        webbrowser.open(_MANUAL_URLS.get(self._lang, _MANUAL_URLS[_LANG_EN]))
+        webbrowser.open(_MANUAL_URLS.get(self._lang_var.get(), _MANUAL_URLS[LANG_EN]))
 
     def _browse_workflow(self) -> None:
         path = filedialog.askopenfilename(

--- a/version.py
+++ b/version.py
@@ -3,7 +3,7 @@
 # Repository:     https://github.com/Jaegerfeld/situation-report
 # KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
 # Erstellt:       25.04.2026
-# Geändert:       08.05.2026
+# Geändert:       09.05.2026
 # Lizenz:         BSD-3-Clause (siehe LICENSE)
 #
 # Fachliche Funktion:
@@ -15,4 +15,4 @@
 #     PATCH: Bugfixes
 # =============================================================================
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"


### PR DESCRIPTION
## Summary
- testdata_generator + helper GUI auf einheitlichen Standard gebracht (build_reports/transform_data-Muster)
- 5 Sprachen (DE/EN/RO/PT/FR) statt bisher nur DE/EN
- Persistierte Sprachauswahl via prefs.json
- Help-Menue mit Manual-Eintrag + Flaggen-Kaskade als Sprachumschalter
- testdata_generator Manual auf v0.9.7 neu generiert

## Test plan
- [ ] testdata_generator starten: Help-Menue sichtbar, Manual-Link oeffnet PDF
- [ ] Sprache wechseln, neu starten: Sprache bleibt erhalten
- [ ] helper starten: Help-Menue sichtbar, 5 Sprachen verfuegbar
- [ ] Keine Regression: build_reports + transform_data weiterhin funktional
- [ ] Unit-Tests: py -m pytest tests/testdata_generator/unit/ tests/helper/unit/ -q

Generated with Claude Code