### PR TITLE
docs(testdata_generator): Kap. 4b Flow-Antipattern-Muster im Handbuch

### DIFF
--- a/docs/generate_testdata_generator_manual.py
+++ b/docs/generate_testdata_generator_manual.py
@@ -3,7 +3,7 @@
 # Repository:     https://github.com/Jaegerfeld/situation-report
 # KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
 # Erstellt:       03.05.2026
-# Geändert:       13.05.2026
+# Geändert:       08.05.2026
 # Lizenz:         BSD-3-Clause (siehe LICENSE)
 #
 # Fachliche Funktion:
@@ -436,47 +436,78 @@ def content_de(st: dict) -> list:
     # ---- 4b. Flow-Antipattern-Muster ----
     story += [PageBreak(),
               H1("4b  Flow-Antipattern-Muster", st), HR(),
-              P("Ab Version 0.99 kann der Testdata Generator typische Flow-Antipatterns "
-                "aus Vacanti/Singh simulieren. Dazu wird <b>--mean-cycle-days</b> kombiniert "
-                "mit <b>--pattern</b>.", st),
-              tbl(["Muster", "Scatterplot-Erscheinung", "Erklärung"],
+              P("Ab Version 0.9.9 kann der Testdata Generator typische Flow-Antipatterns "
+                "aus der Literatur von Vacanti und Singh simulieren. Dazu wird "
+                "<b>--mean-cycle-days</b> mit <b>--pattern</b> kombiniert. In der GUI "
+                "stehen Radiobuttons und Schieberegler zur Verfügung.", st),
+              SP(4),
+              tbl(["Muster", "Scatterplot-Erscheinung", "Beschreibung"],
                   [["none",
                     "Gleichmäßige Punktwolke",
-                    "Zufällige Cycle-Time ohne Trend (Standard)"],
+                    "Zufällige Cycle-Time ohne Trend — Standard-Verhalten"],
                    ["triangle",
-                    "Dreieck mit rechtem Winkel unten rechts",
-                    "CT steigt linear über die Zeit: mult = 1 + 3×t"],
+                    "Dreieck: rechter Winkel unten rechts",
+                    "Cycle-Time steigt linear über die Zeit (Multiplikator 1–4×). "
+                    "Zeigt einen Prozess, der zunehmend langsamer wird."],
                    ["flat_triangle",
-                    "Dreieck, aber Anstieg flacht am Ende ab",
-                    "CT-Anstieg wird durch tanh(2.5×t) gedämpft"],
+                    "Dreieck, Anstieg flacht am Ende ab",
+                    "Wie triangle, aber der Anstieg verflacht durch tanh(2.5×t). "
+                    "Zeigt eine Prozessverschlechterung, die sich stabilisiert."],
                    ["cluster",
-                    "Häufungen senkrechter Punkte am PI-Ende",
-                    "CT lognormal (stabil), aber Abschlüsse in letzten 2 Wochen eines PI"],
+                    "Senkrechte Punkthäufungen am PI-Ende",
+                    "Cycle-Time bleibt stabil (lognormal), aber die meisten Issues "
+                    "werden in den letzten 2 Wochen vor PI-Ende abgeschlossen. "
+                    "Deadline-getriebenes Verhalten."],
                    ["batch",
-                    "Senkrechte Säulen mit variabler CT am PI-Ende",
-                    "CT uniform 0.1× bis 3× Mittelwert + PI-Clustering"]],
-                  col_widths=[3.5 * cm, 4.5 * cm, 7.5 * cm]),
+                    "Säulen variabler Höhe am PI-Ende",
+                    "Wie cluster, aber mit stark unterschiedlicher Cycle-Time "
+                    "(0.1× bis 3× Mittelwert). Zeigt, dass kurze und sehr lange "
+                    "Aufgaben gemeinsam ans PI-Ende geschoben werden."]],
+                  col_widths=[3.0 * cm, 4.0 * cm, 8.5 * cm]),
+              SP(8),
+              H2("Cycle-Time-Steuerung", st),
+              P("Wenn <b>--mean-cycle-days</b> angegeben ist, wird die Cycle-Time "
+                "lognormalverteilt mit dem angegebenen Mittelwert erzeugt. Die "
+                "Lognormalverteilung erzeugt die in der Praxis typische Rechtsschiefe — "
+                "die meisten Issues sind schnell, wenige dauern sehr lang.", st),
+              tbl(["Parameter", "Bedeutung"],
+                  [["--mean-cycle-days",
+                    "Mittelwert der Cycle-Time in Tagen (z. B. 20). "
+                    "Pflicht für alle Muster außer none."],
+                   ["--std-cycle-days",
+                    "Standardabweichung in Tagen (Standard: 30 % des Mittelwerts). "
+                    "Höhere Werte erzeugen breitere Streuung im Scatterplot."],
+                   ["--pi-duration-weeks",
+                    "Länge eines PI-Zyklus in Wochen (Standard 12). "
+                    "Nur relevant für cluster und batch."]],
+                  col_widths=[4.5 * cm, 11.0 * cm]),
               SP(8),
               H2("Beispiele", st),
-              PRE("# Triangle-Muster\n"
+              PRE("# Triangle-Muster: CT steigt von 20d auf 80d\n"
                   "python -m testdata_generator \\\n"
                   "    --workflow workflow.txt --issues 300 \\\n"
-                  "    --pattern triangle --mean-cycle-days 20 --std-cycle-days 6 \\\n"
+                  "    --pattern triangle \\\n"
+                  "    --mean-cycle-days 20 --std-cycle-days 6 \\\n"
+                  "    --completion-rate 0.8 --seed 1 \\\n"
                   "    --output triangle.json\n\n"
-                  "# Cluster of Dots (12-Wochen-PI)\n"
+                  "# Cluster of Dots: Lieferungen am PI-Ende (12 Wochen)\n"
                   "python -m testdata_generator \\\n"
                   "    --workflow workflow.txt --issues 300 \\\n"
-                  "    --pattern cluster --mean-cycle-days 30 \\\n"
-                  "    --pi-duration-weeks 12 --output cluster.json\n\n"
-                  "# Batch Transfers\n"
+                  "    --pattern cluster \\\n"
+                  "    --mean-cycle-days 30 --pi-duration-weeks 12 \\\n"
+                  "    --completion-rate 0.8 --seed 2 \\\n"
+                  "    --output cluster.json\n\n"
+                  "# Batch Transfers: PI-Ende + hohe CT-Varianz\n"
                   "python -m testdata_generator \\\n"
                   "    --workflow workflow.txt --issues 300 \\\n"
-                  "    --pattern batch --mean-cycle-days 30 \\\n"
-                  "    --pi-duration-weeks 12 --output batch.json", st),
+                  "    --pattern batch \\\n"
+                  "    --mean-cycle-days 30 --pi-duration-weeks 12 \\\n"
+                  "    --completion-rate 0.8 --seed 3 \\\n"
+                  "    --output batch.json", st),
               SP(6),
               box("<b>Hinweis:</b> --pattern erfordert --mean-cycle-days. "
-                  "Ohne --mean-cycle-days wird pattern ignoriert und das "
-                  "bisherige min/max-Dwell-Verhalten verwendet.", st)]
+                  "Ohne --mean-cycle-days wird das Muster ignoriert und das "
+                  "ursprüngliche min/max-Dwell-Verhalten verwendet.", st)]
 
     # ---- 5. ART_A – Vollständiges Beispiel ----
     story += [PageBreak(),
@@ -719,43 +750,74 @@ def content_en(st: dict) -> list:
     # ---- 4b. Flow Anti-Pattern Modes ----
     story += [PageBreak(),
               H1("4b  Flow Anti-Pattern Modes", st), HR(),
-              P("Since version 0.99, the Testdata Generator can simulate typical flow "
-                "anti-patterns from Vacanti/Singh. Combine <b>--mean-cycle-days</b> "
-                "with <b>--pattern</b>.", st),
-              tbl(["Pattern", "Scatter plot appearance", "Explanation"],
+              P("Since version 0.9.9 the Testdata Generator can simulate typical flow "
+                "anti-patterns from Vacanti and Singh. Combine <b>--mean-cycle-days</b> "
+                "with <b>--pattern</b>. The GUI provides radio buttons and sliders for "
+                "all pattern settings.", st),
+              SP(4),
+              tbl(["Pattern", "Scatter plot appearance", "Description"],
                   [["none",
                     "Even point cloud",
-                    "Random cycle time without trend (default)"],
+                    "Random cycle time without trend — default behaviour"],
                    ["triangle",
-                    "Triangle with right angle at bottom right",
-                    "CT rises linearly over time: mult = 1 + 3×t"],
+                    "Triangle: right angle bottom right",
+                    "Cycle time rises linearly over time (multiplier 1–4×). "
+                    "Indicates a process that is becoming progressively slower."],
                    ["flat_triangle",
-                    "Triangle, but the rise flattens at the end",
-                    "CT increase is damped by tanh(2.5×t)"],
+                    "Triangle, rise flattens at the end",
+                    "Like triangle but the increase is damped by tanh(2.5×t). "
+                    "Shows a process deterioration that is levelling off."],
                    ["cluster",
                     "Vertical clusters of points at PI end",
-                    "CT lognormal (stable), but deliveries in last 2 weeks of each PI"],
+                    "Cycle time stays stable (lognormal), but most issues are "
+                    "delivered in the last 2 weeks before the PI end. "
+                    "Deadline-driven behaviour."],
                    ["batch",
-                    "Vertical columns with variable CT at PI end",
-                    "CT uniform 0.1× to 3× mean + PI clustering"]],
-                  col_widths=[3.5 * cm, 4.5 * cm, 7.5 * cm]),
+                    "Columns of variable height at PI end",
+                    "Like cluster but with highly variable cycle time "
+                    "(0.1× to 3× mean). Shows that both short and very long "
+                    "issues are pushed to the PI end together."]],
+                  col_widths=[3.0 * cm, 4.0 * cm, 8.5 * cm]),
+              SP(8),
+              H2("Cycle time control", st),
+              P("When <b>--mean-cycle-days</b> is provided, cycle times are sampled "
+                "from a lognormal distribution with the given mean. The lognormal "
+                "distribution produces the right-skewed shape typical in practice — "
+                "most issues are fast, a few take much longer.", st),
+              tbl(["Parameter", "Meaning"],
+                  [["--mean-cycle-days",
+                    "Mean cycle time in days (e.g. 20). "
+                    "Required for all patterns except none."],
+                   ["--std-cycle-days",
+                    "Standard deviation in days (default: 30 % of mean). "
+                    "Higher values produce a wider spread in the scatter plot."],
+                   ["--pi-duration-weeks",
+                    "Length of one PI cycle in weeks (default 12). "
+                    "Only relevant for cluster and batch."]],
+                  col_widths=[4.5 * cm, 11.0 * cm]),
               SP(8),
               H2("Examples", st),
-              PRE("# Triangle pattern\n"
+              PRE("# Triangle pattern: CT rises from 20d to 80d\n"
                   "python -m testdata_generator \\\n"
                   "    --workflow workflow.txt --issues 300 \\\n"
-                  "    --pattern triangle --mean-cycle-days 20 --std-cycle-days 6 \\\n"
+                  "    --pattern triangle \\\n"
+                  "    --mean-cycle-days 20 --std-cycle-days 6 \\\n"
+                  "    --completion-rate 0.8 --seed 1 \\\n"
                   "    --output triangle.json\n\n"
-                  "# Cluster of Dots (12-week PI)\n"
+                  "# Cluster of Dots: deliveries at PI end (12-week PI)\n"
                   "python -m testdata_generator \\\n"
                   "    --workflow workflow.txt --issues 300 \\\n"
-                  "    --pattern cluster --mean-cycle-days 30 \\\n"
-                  "    --pi-duration-weeks 12 --output cluster.json\n\n"
-                  "# Batch Transfers\n"
+                  "    --pattern cluster \\\n"
+                  "    --mean-cycle-days 30 --pi-duration-weeks 12 \\\n"
+                  "    --completion-rate 0.8 --seed 2 \\\n"
+                  "    --output cluster.json\n\n"
+                  "# Batch Transfers: PI end + high CT variance\n"
                   "python -m testdata_generator \\\n"
                   "    --workflow workflow.txt --issues 300 \\\n"
-                  "    --pattern batch --mean-cycle-days 30 \\\n"
-                  "    --pi-duration-weeks 12 --output batch.json", st),
+                  "    --pattern batch \\\n"
+                  "    --mean-cycle-days 30 --pi-duration-weeks 12 \\\n"
+                  "    --completion-rate 0.8 --seed 3 \\\n"
+                  "    --output batch.json", st),
               SP(6),
               box("<b>Note:</b> --pattern requires --mean-cycle-days. "
                   "Without --mean-cycle-days the pattern is ignored and "

--- a/docs/generate_transform_data_manual.py
+++ b/docs/generate_transform_data_manual.py
@@ -3,13 +3,12 @@
 # Repository:     https://github.com/Jaegerfeld/situation-report
 # KI-Unterstuetzung: Erstellt mit Unterstuetzung von Claude (Anthropic)
 # Erstellt:       21.04.2026
-# Geaendert:      28.04.2026
+# Geaendert:      13.05.2026
 # Lizenz:         BSD-3-Clause (siehe LICENSE)
 #
 # Fachliche Funktion:
-#   Erzeugt das Benutzerhandbuch fuer transform_data als PDF-Datei.
-#   Produziert beide Sprachversionen: Deutsch (transform_data_Benutzerhandbuch.pdf)
-#   und Englisch (transform_data_UserManual.pdf).
+#   Erzeugt das Benutzerhandbuch fuer transform_data als PDF in allen 5 Sprachen:
+#   Deutsch, Englisch, Rumaenisch, Portugiesisch, Franzoesisch.
 #   Kapitel: Einleitung, Eingabedateien, Workflow-Definition, GUI-Bedienung,
 #   Ausgabedateien, Datumsberechnung, FAQ und Glossar.
 # =============================================================================
@@ -43,6 +42,45 @@ C_HINT   = colors.HexColor("#7f8c8d")
 
 OUTPUT_DE = Path(__file__).parent / "transform_data_Benutzerhandbuch.pdf"
 OUTPUT_EN = Path(__file__).parent / "transform_data_UserManual.pdf"
+OUTPUT_RO = Path(__file__).parent / "transform_data_ManualUtilizator.pdf"
+OUTPUT_PT = Path(__file__).parent / "transform_data_ManualUtilizador.pdf"
+OUTPUT_FR = Path(__file__).parent / "transform_data_ManuelUtilisateur.pdf"
+
+_HEADER = {
+    "de": "transform_data -- Benutzerhandbuch",
+    "en": "transform_data -- User Manual",
+    "ro": "transform_data -- Manual de Utilizator",
+    "pt": "transform_data -- Manual do Utilizador",
+    "fr": "transform_data -- Manuel d'utilisation",
+}
+_PAGE_LABEL = {
+    "de": "Seite %d",
+    "en": "Page %d",
+    "ro": "Pagina %d",
+    "pt": "Pagina %d",
+    "fr": "Page %d",
+}
+_COVER_TITLE2 = {
+    "de": "Benutzerhandbuch",
+    "en": "User Manual",
+    "ro": "Manual de Utilizator",
+    "pt": "Manual do Utilizador",
+    "fr": "Manuel d'utilisation",
+}
+_COVER_SUBTITLE = {
+    "de": "Jira-Daten aufbereiten fuer Metriken und Berichte",
+    "en": "Prepare Jira data for metrics and reports",
+    "ro": "Pregatiti datele Jira pentru metrici si rapoarte",
+    "pt": "Preparar dados Jira para metricas e relatorios",
+    "fr": "Preparer les donnees Jira pour les metriques et rapports",
+}
+_COVER_AUDIENCE = {
+    "de": "Fuer nicht-technische Anwender",
+    "en": "For non-technical users",
+    "ro": "Pentru utilizatori non-tehnici",
+    "pt": "Para utilizadores nao tecnicos",
+    "fr": "Pour les utilisateurs non techniques",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -78,10 +116,6 @@ def make_styles():
 # Page template
 # ---------------------------------------------------------------------------
 
-def _make_header_text(lang: str) -> str:
-    return "transform_data -- Benutzerhandbuch" if lang == "de" else "transform_data -- User Manual"
-
-
 class ManualDoc(BaseDocTemplate):
     def __init__(self, filename, lang="de", **kw):
         super().__init__(filename, pagesize=A4, **kw)
@@ -106,12 +140,11 @@ class ManualDoc(BaseDocTemplate):
         canvas.rect(0, h - 1.1*cm, w, 1.1*cm, fill=1, stroke=0)
         canvas.setFont("Helvetica-Bold", 9)
         canvas.setFillColor(C_WHITE)
-        canvas.drawString(2.2*cm, h - 0.7*cm, _make_header_text(self._lang))
+        canvas.drawString(2.2*cm, h - 0.7*cm, _HEADER[self._lang])
         canvas.drawRightString(w - 2.2*cm, h - 0.7*cm, "situation-report")
         canvas.setFillColor(C_HINT)
         canvas.setFont("Helvetica", 8)
-        page_label = "Seite %d" if self._lang == "de" else "Page %d"
-        canvas.drawCentredString(w/2, 1.0*cm, page_label % doc.page)
+        canvas.drawCentredString(w/2, 1.0*cm, _PAGE_LABEL[self._lang] % doc.page)
         canvas.setStrokeColor(C_MID)
         canvas.line(2.2*cm, 1.4*cm, w - 2.2*cm, 1.4*cm)
         canvas.restoreState()
@@ -137,14 +170,10 @@ def build_cover(canvas, doc, lang="de"):
     canvas.setFont("Helvetica-Bold", 32)
     canvas.drawCentredString(w/2, h*0.60, "transform_data")
     canvas.setFont("Helvetica-Bold", 18)
-    title2 = "Benutzerhandbuch" if lang == "de" else "User Manual"
-    canvas.drawCentredString(w/2, h*0.545, title2)
+    canvas.drawCentredString(w/2, h*0.545, _COVER_TITLE2[lang])
     canvas.setFont("Helvetica", 12)
     canvas.setFillColor(C_LIGHT)
-    subtitle = ("Jira-Daten aufbereiten fuer Metriken und Berichte"
-                if lang == "de"
-                else "Prepare Jira data for metrics and reports")
-    canvas.drawCentredString(w/2, h*0.49, subtitle)
+    canvas.drawCentredString(w/2, h*0.49, _COVER_SUBTITLE[lang])
     canvas.setStrokeColor(C_LIGHT)
     canvas.setLineWidth(0.5)
     canvas.line(w*0.2, h*0.455, w*0.8, h*0.455)
@@ -152,9 +181,8 @@ def build_cover(canvas, doc, lang="de"):
     canvas.setFillColor(C_MID)
     canvas.drawCentredString(w/2, h*0.12,
                              "situation-report - github.com/Jaegerfeld/situation-report")
-    audience = ("Fuer nicht-technische Anwender" if lang == "de"
-                else "For non-technical users")
-    canvas.drawCentredString(w/2, h*0.09, f"{audience} — Version {_VERSION}")
+    canvas.drawCentredString(w/2, h*0.09,
+                             f"{_COVER_AUDIENCE[lang]} -- Version {_VERSION}")
     canvas.restoreState()
 
 
@@ -211,28 +239,31 @@ def tbl(headers, rows, col_widths=None):
     return t
 
 
+def _make_toc(lang):
+    toc = TableOfContents()
+    sfx = lang
+    toc.levelStyles = [
+        ParagraphStyle(f"TOCH1_{sfx}", fontName="Helvetica-Bold", fontSize=11,
+                       leading=18, leftIndent=0, spaceAfter=2),
+        ParagraphStyle(f"TOCH2_{sfx}", fontName="Helvetica", fontSize=9,
+                       leading=15, leftIndent=16, spaceAfter=1),
+        ParagraphStyle(f"TOCH3_{sfx}", fontName="Helvetica-Oblique", fontSize=8,
+                       leading=13, leftIndent=28, spaceAfter=1),
+    ]
+    return toc
+
+
 # ---------------------------------------------------------------------------
 # Content — German
 # ---------------------------------------------------------------------------
 
 def content_de(st):
-    """Build German document story."""
     story = []
-
     story.append(PageBreak())
     story.append(H1("Inhalt", st))
-    toc = TableOfContents()
-    toc.levelStyles = [
-        ParagraphStyle("TOCH1", fontName="Helvetica-Bold", fontSize=11,
-                       leading=18, leftIndent=0, spaceAfter=2),
-        ParagraphStyle("TOCH2", fontName="Helvetica", fontSize=9,
-                       leading=15, leftIndent=16, spaceAfter=1),
-        ParagraphStyle("TOCH3", fontName="Helvetica-Oblique", fontSize=8,
-                       leading=13, leftIndent=28, spaceAfter=1),
-    ]
+    toc = _make_toc("de")
     story.append(toc)
 
-    # 1
     story.append(PageBreak())
     story.append(H1("1  Was ist transform_data?", st))
     story.append(P(
@@ -257,38 +288,26 @@ def content_de(st):
         "Die erzeugten Excel-Dateien werden anschliessend vom Modul <b>build_reports</b> "
         "verwendet, um Diagramme und Berichte zu erstellen.", st))
 
-    # 2
     story.append(PageBreak())
     story.append(H1("2  Voraussetzungen und Installation", st))
     story.append(H2("2.1  Was muss installiert sein?", st))
     story.append(P(
         "transform_data wird als <b>portables Paket</b> geliefert. Eine separate "
         "Python-Installation ist nicht notwendig.", st))
-    story.append(BL(
-        "<b>Windows:</b> Python 3.11 ist bereits im Paket enthalten -- einfach "
-        "entpacken und starten.", st))
+    story.append(BL("<b>Windows:</b> Python ist bereits im Paket enthalten -- einfach entpacken und starten.", st))
     story.append(BL(
         "<b>macOS / Linux:</b> Beim ersten Start wird einmalig eine Python-Umgebung "
         "eingerichtet (ca. 1 Minute, Internet erforderlich). Danach laeuft die App offline.", st))
     story.append(H2("2.2  Programm starten", st))
-    story.append(P(
-        "Die passende Startdatei im entpackten Ordner doppelklicken:", st))
-    story.append(BL(
-        "<b>Windows:</b> <b>TransformData.bat</b> doppelklicken -- startet die GUI "
-        "ohne Konsolenfenster.", st))
-    story.append(BL(
-        "<b>macOS:</b> Rechtsklick auf <b>TransformData.command</b> → <i>Oeffnen</i> "
-        "(einmalig wegen Gatekeeper).", st))
-    story.append(BL(
-        "<b>Linux:</b> Im Terminal: "
-        "<font name='Courier'>./TransformData.sh</font>", st))
+    story.append(BL("<b>Windows:</b> <b>TransformData.bat</b> doppelklicken.", st))
+    story.append(BL("<b>macOS:</b> Rechtsklick auf <b>TransformData.command</b> → <i>Oeffnen</i>.", st))
+    story.append(BL("<b>Linux:</b> Im Terminal: <font name='Courier'>./TransformData.sh</font>", st))
     story.append(SP(4))
     story.append(box(
         "<b>Tipp (Windows):</b> Beim ersten Start erscheint moeglicherweise ein "
         "SmartScreen-Hinweis. Auf <b>Weitere Informationen</b> → "
         "<b>Trotzdem ausfuehren</b> klicken.", st, "#e8f8f0"))
 
-    # 3
     story.append(PageBreak())
     story.append(H1("3  Eingabedateien", st))
     story.append(P(
@@ -298,16 +317,14 @@ def content_de(st):
     story.append(P(
         "Dies ist ein Export aller Issues eines Jira-Projekts im JSON-Format. "
         "Er enthaelt fuer jedes Ticket die komplette Statushistorie (Changelog), "
-        "Metadaten wie Issuetyp, Komponenten und Erstellungsdatum sowie den aktuellen "
-        "Status.", st))
+        "Metadaten wie Issuetyp, Komponenten und Erstellungsdatum sowie den aktuellen Status.", st))
     story.append(P(
         "Wie der Export aus Jira erzeugt wird, beschreibt das Modul <b>get_data</b>. "
         "Die JSON-Datei sollte nicht manuell bearbeitet werden.", st))
     story.append(SP(4))
     story.append(box(
         "<b>Typischer Dateiname:</b> ART_A.json, MYPROJECT.json o.ae.<br/>"
-        "<b>Groesse:</b> Abhaengig von der Anzahl der Issues; haeufig einige MB.", st,
-        "#fff8e1"))
+        "<b>Groesse:</b> Abhaengig von der Anzahl der Issues; haeufig einige MB.", st, "#fff8e1"))
     story.append(H2("3.2  Workflow-Definitionsdatei", st))
     story.append(P(
         "Die Workflow-Datei ist eine einfache Textdatei (.txt), die beschreibt, "
@@ -320,19 +337,13 @@ def content_de(st):
         "<b>Erstellt von:</b> Ihrem technischen Ansprechpartner oder Scrum Master -- "
         "einmalig pro Projekt, selten geaendert.", st, "#e8f8f0"))
 
-    # 4
     story.append(PageBreak())
     story.append(H1("4  Die Workflow-Definitionsdatei", st))
     story.append(P(
         "Die Workflow-Datei steuert, wie transform_data die Jira-Status Ihres Projekts "
         "interpretiert. Sie muessen diese Datei in der Regel nicht selbst erstellen -- "
-        "dieses Kapitel erklaert jedoch ihren Aufbau, damit Sie sie lesen und bei Bedarf "
-        "anpassen koennen.", st))
+        "dieses Kapitel erklaert jedoch ihren Aufbau.", st))
     story.append(H2("4.1  Aufbau", st))
-    story.append(P(
-        "Jede Zeile der Datei beschreibt entweder eine <b>Stage</b> (einen Prozessschritt) "
-        "oder einen <b>Marker</b> (einen Meilenstein). Leerzeilen werden ignoriert.", st))
-    story.append(SP(4))
     story.append(P("<b>Beispiel:</b>", st))
     story.append(CD(
         "Funnel:New:Open:To Do<br/>"
@@ -346,57 +357,44 @@ def content_de(st):
     story.append(tbl(
         ["Format", "Bedeutung"],
         [
-            ["Stage:Alias1:Alias2",
-             "Stage mit Jira-Statusnamen, die darauf gemappt werden. Der erste Name ist der "
-             "kanonische Stage-Name."],
-            ["<First>Stage",
-             "Diese Stage markiert den Beginn der aktiven Bearbeitung (First Date)."],
-            ["<InProgress>Stage",
-             "Diese Stage setzt das Implementation Date."],
-            ["<Closed>Stage",
-             "Diese Stage markiert den Abschluss (Closed Date)."],
+            ["Stage:Alias1:Alias2", "Stage mit Jira-Statusnamen. Der erste Name ist der kanonische Stage-Name."],
+            ["<First>Stage", "Diese Stage markiert den Beginn der aktiven Bearbeitung (First Date)."],
+            ["<InProgress>Stage", "Diese Stage setzt das Implementation Date."],
+            ["<Closed>Stage", "Diese Stage markiert den Abschluss (Closed Date)."],
         ],
         col_widths=[4*cm, 12*cm]))
     story.append(H2("4.2  Reihenfolge der Stages", st))
     story.append(P(
         "Die Stages werden in der Reihenfolge aufgefuehrt, in der sie im Prozess "
-        "durchlaufen werden. Diese Reihenfolge wird fuer das Cumulative Flow Diagram "
-        "und fuer die Berechnung des Closed Date bei uebersprungenen Stages verwendet.", st))
+        "durchlaufen werden. Diese Reihenfolge wird fuer das CFD und fuer die "
+        "Berechnung des Closed Date bei uebersprungenen Stages verwendet.", st))
     story.append(H2("4.3  Nicht gemappte Jira-Status", st))
     story.append(P(
         "Enthaelt der Jira-Export Status, die in der Workflow-Datei nicht definiert sind, "
         "gibt transform_data eine Warnung aus. Die Zeit wird der letzten bekannten Stage "
         "zugerechnet (Carry-forward).", st))
 
-    # 5
     story.append(PageBreak())
     story.append(H1("5  Die grafische Oberflaeche (GUI)", st))
     story.append(P(
         "Nach dem Start oeffnet sich ein Fenster mit Datei-Auswahl-Feldern, "
         "Optionen und einem Log-Bereich fuer Statusmeldungen.", st))
     story.append(H2("5.1  Dateien auswaehlen", st))
-    story.append(P("Laden Sie die beiden Eingabedateien:", st))
     story.append(BL(
         "<b>JSON-Datei</b> - Klicken Sie auf 'Durchsuchen' und waehlen Sie Ihren "
         "Jira-Export aus. Ausgabeordner und Praefix werden automatisch vorbelegt.", st))
     story.append(BL(
-        "<b>Workflow-Datei</b> - Waehlen Sie die passende .txt-Workflow-Datei "
-        "fuer Ihr Projekt aus.", st))
+        "<b>Workflow-Datei</b> - Waehlen Sie die passende .txt-Workflow-Datei fuer Ihr Projekt aus.", st))
     story.append(SP(4))
     story.append(box(
         "<b>Tipp:</b> Wenn Sie die JSON-Datei zuerst auswaehlen, werden Ausgabeordner "
         "und Praefix automatisch vorausgefuellt.", st, "#e8f8f0"))
     story.append(H2("5.2  Ausgabe konfigurieren", st))
-    story.append(SP(4))
     story.append(tbl(
         ["Feld", "Bedeutung"],
         [
-            ["Ausgabeordner",
-             "Verzeichnis, in das die drei Excel-Dateien gespeichert werden. "
-             "Standard: Verzeichnis der JSON-Datei."],
-            ["Praefix",
-             "Namens-Praefix fuer die Ausgabedateien. Aus 'ART_A' werden z.B. "
-             "ART_A_IssueTimes.xlsx, ART_A_Transitions.xlsx und ART_A_CFD.xlsx."],
+            ["Ausgabeordner", "Verzeichnis fuer die drei Excel-Dateien. Standard: Verzeichnis der JSON-Datei."],
+            ["Praefix", "Namens-Praefix. Aus 'ART_A' werden ART_A_IssueTimes.xlsx, ART_A_Transitions.xlsx und ART_A_CFD.xlsx."],
         ],
         col_widths=[4*cm, 12*cm]))
     story.append(H2("5.3  Verarbeitung starten", st))
@@ -412,21 +410,14 @@ def content_de(st):
     story.append(H2("5.4  Sprache und Hilfe", st))
     story.append(P(
         "Im Menue <b>Optionen</b> koennen Sie zwischen Deutsch und Englisch wechseln. "
-        "Alle Beschriftungen werden sofort aktualisiert. "
-        "Unter <b>Hilfe &rarr; Manual</b> oeffnet sich dieses Handbuch "
-        "in der jeweils aktiven Sprache im Browser.", st))
+        "Unter <b>Hilfe &rarr; Manual</b> oeffnet sich dieses Handbuch im Browser.", st))
 
-    # 6
     story.append(PageBreak())
     story.append(H1("6  Die Ausgabedateien", st))
     story.append(P(
         "transform_data erzeugt drei Excel-Dateien. Diese Dateien dienen als "
         "Eingabe fuer build_reports und sollten nicht manuell bearbeitet werden.", st))
     story.append(H2("6.1  IssueTimes.xlsx", st))
-    story.append(P(
-        "Die wichtigste Ausgabedatei. Sie enthaelt eine Zeile pro Issue mit allen "
-        "Zeitangaben.", st))
-    story.append(SP(4))
     story.append(tbl(
         ["Spalte", "Inhalt"],
         [
@@ -446,7 +437,6 @@ def content_de(st):
     story.append(P(
         "Enthaelt die vollstaendige Statushistorie aller Issues -- einen Eintrag pro "
         "Statuswechsel. Nuetzlich fuer detaillierte Analysen einzelner Issues.", st))
-    story.append(SP(4))
     story.append(tbl(
         ["Spalte", "Inhalt"],
         [
@@ -458,22 +448,17 @@ def content_de(st):
     story.append(H2("6.3  CFD.xlsx", st))
     story.append(P(
         "Enthaelt fuer jeden Kalendertag die Anzahl der Issues, die an diesem Tag in "
-        "die jeweilige Stage eingetreten sind. build_reports akkumuliert diese Werte "
-        "kumulativ und erzeugt daraus das Cumulative Flow Diagram.", st))
+        "die jeweilige Stage eingetreten sind. build_reports erzeugt daraus das "
+        "Cumulative Flow Diagram.", st))
 
-    # 7
     story.append(PageBreak())
     story.append(H1("7  Wie werden Datum und Zeiten berechnet?", st))
-    story.append(P(
-        "Dieses Kapitel erklaert, nach welchen Regeln transform_data die Meilenstein-"
-        "Daten (First Date, Closed Date) und die Stage-Zeiten ermittelt.", st))
     story.append(H2("7.1  Stage-Zeiten", st))
     story.append(tbl(
         ["Situation", "Regel"],
         [
             ["Issue erstellt, aber noch kein Statuswechsel",
-             "Die Zeit von der Erstellung bis zum ersten Statuswechsel wird der "
-             "initialen Stage zugerechnet."],
+             "Die Zeit von der Erstellung bis zum ersten Statuswechsel wird der initialen Stage zugerechnet."],
             ["Statuswechsel zu einer nicht gemappten Stage",
              "Die Zeit laeuft in der letzten bekannten Stage weiter (Carry-forward)."],
             ["Aktueller Status",
@@ -483,91 +468,68 @@ def content_de(st):
     story.append(H2("7.2  First Date", st))
     story.append(P(
         "Das First Date wird gesetzt, sobald ein Issue zum ersten Mal in die mit "
-        "<b>&lt;First&gt;</b> markierte Stage wechselt. "
-        "Es repraesentiert den Beginn der aktiven Bearbeitung.", st))
+        "<b>&lt;First&gt;</b> markierte Stage wechselt.", st))
     story.append(SP(4))
     story.append(box(
         "<b>Uebersprungene First-Stage:</b> Betritt ein Issue eine Stage nach der "
-        "&lt;First&gt;-Stage, ohne diese selbst zu betreten, wird der Eintrittszeitpunkt "
-        "als First Date verwendet.", st, "#e8f5e9"))
+        "&lt;First&gt;-Stage direkt, wird der Eintrittszeitpunkt als First Date verwendet.", st, "#e8f5e9"))
     story.append(H2("7.3  Closed Date", st))
     story.append(P(
         "Das Closed Date wird beim Eintritt in die mit <b>&lt;Closed&gt;</b> markierte "
-        "Stage gesetzt. Bei Issues, die mehrfach geoeffnet und geschlossen wurden, "
-        "zaehlt der <b>letzte</b> Schliessungszeitpunkt.", st))
+        "Stage gesetzt. Bei mehrfach geoeffneten Issues zaehlt der <b>letzte</b> Schliessungszeitpunkt.", st))
     story.append(SP(4))
     story.append(box(
-        "<b>Wiedergeoeffnete Issues:</b> Befindet sich ein Issue aktuell in einer Stage "
-        "vor der &lt;Closed&gt;-Stage, wird kein Closed Date gesetzt -- auch wenn die "
-        "Stage zuvor schon einmal erreicht wurde.", st, "#fce4ec"))
+        "<b>Wiedergeoeffnete Issues:</b> Befindet sich ein Issue in einer Stage vor "
+        "&lt;Closed&gt;, wird kein Closed Date gesetzt.", st, "#fce4ec"))
     story.append(SP(4))
     story.append(box(
-        "<b>Nie bearbeitete Issues:</b> Issues ohne First Date (direkt von To Do nach "
-        "Closed gesprungen) erhalten kein Closed Date und zaehlen nicht in der "
-        "Flow Velocity.", st, "#e8eaf6"))
+        "<b>Nie bearbeitete Issues:</b> Issues ohne First Date erhalten kein Closed Date "
+        "und zaehlen nicht in der Flow Velocity.", st, "#e8eaf6"))
 
-    # 8
     story.append(PageBreak())
     story.append(H1("8  Haeufige Fragen und Tipps", st))
     faqs = [
         ("Ein Issue hat kein First Date -- warum?",
-         "Das Issue hat weder die <First>-Stage noch eine Stage danach (vor Closed) "
-         "erreicht. In build_reports wird es als 'To Do' gezaehlt."),
+         "Das Issue hat weder die <First>-Stage noch eine Stage danach erreicht. "
+         "In build_reports wird es als 'To Do' gezaehlt."),
         ("Ein Issue hat kein Closed Date -- warum?",
-         "Moegliche Gruende: (1) Das Issue ist noch offen. "
-         "(2) Es hat kein First Date. "
-         "(3) Es wurde nach dem Abschluss wieder geoeffnet. "
-         "(4) Die <Closed>-Stage wurde uebersprungen und es gibt keine spaetere Stage."),
+         "Moegliche Gruende: (1) Das Issue ist noch offen. (2) Es hat kein First Date. "
+         "(3) Es wurde nach dem Abschluss wieder geoeffnet."),
         ("Im Log erscheint eine Warnung ueber nicht gemappte Status.",
          "Einige Jira-Status sind nicht in der Workflow-Datei definiert. "
-         "Die Verarbeitung wird trotzdem abgeschlossen. Wenden Sie sich an Ihren "
-         "technischen Ansprechpartner, um die Workflow-Datei zu ergaenzen."),
+         "Die Verarbeitung wird trotzdem abgeschlossen."),
         ("Die Ausgabedateien werden nicht erstellt.",
          "Pruefen Sie, ob der Ausgabeordner existiert und ob Sie Schreibrechte haben. "
          "Stellen Sie sicher, dass die Dateien nicht in Excel geoeffnet sind."),
         ("Welche Datei verwende ich fuer build_reports?",
-         "IssueTimes.xlsx ist die Pflichtdatei fuer alle Metriken ausser CFD. "
+         "IssueTimes.xlsx ist die Pflichtdatei fuer alle Metriken. "
          "CFD.xlsx benoetigen Sie zusaetzlich fuer das Cumulative Flow Diagram."),
         ("Wie oft muss ich transform_data ausfuehren?",
          "Immer dann, wenn Sie aktualisierte Daten aus Jira benoetigen."),
         ("Was bedeutet 'Carry-forward'?",
-         "Zeit in einem nicht gemappten Status wird der letzten bekannten Stage "
-         "zugerechnet -- es gibt keinen Zeitverlust."),
+         "Zeit in einem nicht gemappten Status wird der letzten bekannten Stage zugerechnet."),
     ]
     for q, a in faqs:
         story.append(H3("F: " + q, st))
         story.append(P("A: " + a, st))
         story.append(SP(4))
 
-    # 9
     story.append(PageBreak())
     story.append(H1("9  Glossar", st))
     story.append(tbl(
         ["Begriff", "Erklaerung"],
         [
-            ["Carry-forward",
-             "Zeit in einem nicht gemappten Status wird der letzten bekannten Stage zugerechnet."],
-            ["CFD",
-             "Cumulative Flow Diagram -- zeigt die Entwicklung des Bestands nach Stages."],
-            ["Closed Date",
-             "Datum des Abschlusses eines Issues."],
-            ["First Date",
-             "Datum der ersten aktiven Bearbeitung."],
-            ["Implementation Date",
-             "Datum des Entwicklungsbeginns."],
-            ["Issue",
-             "Ein Ticket im Ticketsystem (z.B. eine Jira-Karte)."],
-            ["JSON",
-             "Einfaches Textformat fuer strukturierte Daten."],
-            ["Marker",
-             "Zeilen in der Workflow-Datei, die eine Stage als Meilenstein auszeichnen: "
-             "<First>, <InProgress>, <Closed>."],
-            ["Praefix",
-             "Namens-Vorsatz fuer die Ausgabedateien (z.B. 'ART_A')."],
-            ["Stage",
-             "Ein logischer Prozessschritt, dem ein oder mehrere Jira-Status zugeordnet sind."],
-            ["Workflow-Datei",
-             "Textdatei, die die Stages und Marker eines Projekts beschreibt."],
+            ["Carry-forward", "Zeit in einem nicht gemappten Status wird der letzten bekannten Stage zugerechnet."],
+            ["CFD", "Cumulative Flow Diagram -- zeigt die Entwicklung des Bestands nach Stages."],
+            ["Closed Date", "Datum des Abschlusses eines Issues."],
+            ["First Date", "Datum der ersten aktiven Bearbeitung."],
+            ["Implementation Date", "Datum des Entwicklungsbeginns."],
+            ["Issue", "Ein Ticket im Ticketsystem (z.B. eine Jira-Karte)."],
+            ["JSON", "Einfaches Textformat fuer strukturierte Daten."],
+            ["Marker", "Zeilen in der Workflow-Datei, die eine Stage als Meilenstein auszeichnen: <First>, <InProgress>, <Closed>."],
+            ["Praefix", "Namens-Vorsatz fuer die Ausgabedateien (z.B. 'ART_A')."],
+            ["Stage", "Ein logischer Prozessschritt, dem ein oder mehrere Jira-Status zugeordnet sind."],
+            ["Workflow-Datei", "Textdatei, die die Stages und Marker eines Projekts beschreibt."],
         ],
         col_widths=[4.5*cm, 11.5*cm]))
 
@@ -579,23 +541,12 @@ def content_de(st):
 # ---------------------------------------------------------------------------
 
 def content_en(st):
-    """Build English document story."""
     story = []
-
     story.append(PageBreak())
     story.append(H1("Contents", st))
-    toc = TableOfContents()
-    toc.levelStyles = [
-        ParagraphStyle("TOCH1en", fontName="Helvetica-Bold", fontSize=11,
-                       leading=18, leftIndent=0, spaceAfter=2),
-        ParagraphStyle("TOCH2en", fontName="Helvetica", fontSize=9,
-                       leading=15, leftIndent=16, spaceAfter=1),
-        ParagraphStyle("TOCH3en", fontName="Helvetica-Oblique", fontSize=8,
-                       leading=13, leftIndent=28, spaceAfter=1),
-    ]
+    toc = _make_toc("en")
     story.append(toc)
 
-    # 1
     story.append(PageBreak())
     story.append(H1("1  What is transform_data?", st))
     story.append(P(
@@ -611,8 +562,7 @@ def content_en(st):
     story.append(SP(8))
     story.append(box(
         "<b>What transform_data produces:</b><br/>"
-        "- <b>IssueTimes.xlsx</b>: All issues with milestone timestamps and minutes "
-        "per workflow stage.<br/>"
+        "- <b>IssueTimes.xlsx</b>: All issues with milestone timestamps and minutes per workflow stage.<br/>"
         "- <b>Transitions.xlsx</b>: Complete status history of all issues.<br/>"
         "- <b>CFD.xlsx</b>: Daily entry counts per stage for the Cumulative Flow Diagram.", st))
     story.append(SP(8))
@@ -620,38 +570,21 @@ def content_en(st):
         "The generated Excel files are then used by the <b>build_reports</b> module "
         "to create charts and reports.", st))
 
-    # 2
     story.append(PageBreak())
     story.append(H1("2  Prerequisites and Installation", st))
     story.append(H2("2.1  What needs to be installed?", st))
-    story.append(P(
-        "transform_data is delivered as a <b>portable package</b>. No separate Python "
-        "installation is required.", st))
-    story.append(BL(
-        "<b>Windows:</b> Python 3.11 is already included in the package — just unzip "
-        "and run.", st))
-    story.append(BL(
-        "<b>macOS / Linux:</b> On the first launch, a Python environment is set up "
-        "automatically (approx. 1 minute, internet required). After that the app runs "
-        "offline.", st))
+    story.append(P("transform_data is delivered as a <b>portable package</b>. No separate Python installation is required.", st))
+    story.append(BL("<b>Windows:</b> Python is already included in the package — just unzip and run.", st))
+    story.append(BL("<b>macOS / Linux:</b> On the first launch, a Python environment is set up automatically (approx. 1 minute, internet required).", st))
     story.append(H2("2.2  Starting the program", st))
-    story.append(P(
-        "Double-click the appropriate launcher in the extracted folder:", st))
-    story.append(BL(
-        "<b>Windows:</b> Double-click <b>TransformData.bat</b> — starts the GUI "
-        "without a console window.", st))
-    story.append(BL(
-        "<b>macOS:</b> Right-click <b>TransformData.command</b> → <i>Open</i> "
-        "(once, to bypass Gatekeeper).", st))
-    story.append(BL(
-        "<b>Linux:</b> In a terminal: "
-        "<font name='Courier'>./TransformData.sh</font>", st))
+    story.append(BL("<b>Windows:</b> Double-click <b>TransformData.bat</b>.", st))
+    story.append(BL("<b>macOS:</b> Right-click <b>TransformData.command</b> → <i>Open</i> (once, to bypass Gatekeeper).", st))
+    story.append(BL("<b>Linux:</b> In a terminal: <font name='Courier'>./TransformData.sh</font>", st))
     story.append(SP(4))
     story.append(box(
         "<b>Tip (Windows):</b> On the first launch, SmartScreen may show a warning. "
         "Click <b>More info</b> → <b>Run anyway</b>.", st, "#e8f8f0"))
 
-    # 3
     story.append(PageBreak())
     story.append(H1("3  Input Files", st))
     story.append(P(
@@ -662,9 +595,8 @@ def content_en(st):
         "This is an export of all issues in a Jira project in JSON format. "
         "It contains the complete status history (changelog), metadata such as issue "
         "type and creation date, and the current status for each ticket.", st))
-    story.append(P(
-        "How to generate the export from Jira is described in the <b>get_data</b> module. "
-        "The JSON file should not be edited manually.", st))
+    story.append(P("How to generate the export from Jira is described in the <b>get_data</b> module. "
+                   "The JSON file should not be edited manually.", st))
     story.append(SP(4))
     story.append(box(
         "<b>Typical filename:</b> ART_A.json, MYPROJECT.json, etc.<br/>"
@@ -673,15 +605,12 @@ def content_en(st):
     story.append(P(
         "The workflow file is a plain text file (.txt) that describes how the Jira "
         "statuses in your project map to logical process steps (stages). It also "
-        "defines which stage marks the start of active work (First Date) and "
-        "completion (Closed Date).", st))
+        "defines which stage marks the start of active work (First Date) and completion (Closed Date).", st))
     story.append(SP(4))
     story.append(box(
         "<b>Typical filename:</b> workflow_ART_A.txt, etc.<br/>"
-        "<b>Created by:</b> Your technical contact or Scrum Master -- "
-        "once per project, rarely changed.", st, "#e8f8f0"))
+        "<b>Created by:</b> Your technical contact or Scrum Master -- once per project, rarely changed.", st, "#e8f8f0"))
 
-    # 4
     story.append(PageBreak())
     story.append(H1("4  The Workflow Definition File", st))
     story.append(P(
@@ -689,10 +618,6 @@ def content_en(st):
         "in your project. You usually do not need to create this file yourself -- "
         "this chapter explains its structure so you can read and adjust it if needed.", st))
     story.append(H2("4.1  Structure", st))
-    story.append(P(
-        "Each line describes either a <b>stage</b> (a process step) or a <b>marker</b> "
-        "(a milestone). Blank lines are ignored.", st))
-    story.append(SP(4))
     story.append(P("<b>Example:</b>", st))
     story.append(CD(
         "Funnel:New:Open:To Do<br/>"
@@ -706,64 +631,42 @@ def content_en(st):
     story.append(tbl(
         ["Format", "Meaning"],
         [
-            ["Stage:Alias1:Alias2",
-             "Stage with Jira status names mapped to it. The first name is the "
-             "canonical stage name."],
-            ["<First>Stage",
-             "This stage marks the start of active work (First Date)."],
-            ["<InProgress>Stage",
-             "This stage sets the Implementation Date."],
-            ["<Closed>Stage",
-             "This stage marks completion (Closed Date)."],
+            ["Stage:Alias1:Alias2", "Stage with Jira status names mapped to it. The first name is the canonical stage name."],
+            ["<First>Stage", "This stage marks the start of active work (First Date)."],
+            ["<InProgress>Stage", "This stage sets the Implementation Date."],
+            ["<Closed>Stage", "This stage marks completion (Closed Date)."],
         ],
         col_widths=[4*cm, 12*cm]))
     story.append(H2("4.2  Stage order", st))
     story.append(P(
         "Stages are listed in the order they are traversed in the process. "
-        "This order is used for the Cumulative Flow Diagram and for computing "
-        "the Closed Date when stages are skipped.", st))
+        "This order is used for the CFD and for computing the Closed Date when stages are skipped.", st))
     story.append(H2("4.3  Unmapped Jira statuses", st))
     story.append(P(
         "If the Jira export contains statuses not defined in the workflow file, "
         "transform_data issues a warning. Time in unmapped statuses is attributed "
         "to the last known stage (carry-forward).", st))
 
-    # 5
     story.append(PageBreak())
     story.append(H1("5  The Graphical User Interface (GUI)", st))
-    story.append(P(
-        "After starting, a window opens with file selection fields, options, "
-        "and a log area for status messages.", st))
+    story.append(P("After starting, a window opens with file selection fields, options, and a log area.", st))
     story.append(H2("5.1  Selecting files", st))
-    story.append(P("Load the two input files:", st))
-    story.append(BL(
-        "<b>JSON File</b> - Click 'Browse' and select your Jira export. "
-        "The output folder and prefix are filled in automatically.", st))
-    story.append(BL(
-        "<b>Workflow File</b> - Select the appropriate .txt workflow file "
-        "for your project.", st))
+    story.append(BL("<b>JSON File</b> - Click 'Browse' and select your Jira export. Output folder and prefix are filled in automatically.", st))
+    story.append(BL("<b>Workflow File</b> - Select the appropriate .txt workflow file for your project.", st))
     story.append(SP(4))
-    story.append(box(
-        "<b>Tip:</b> If you select the JSON file first, the output folder "
-        "and prefix are pre-filled automatically.", st, "#e8f8f0"))
+    story.append(box("<b>Tip:</b> If you select the JSON file first, the output folder and prefix are pre-filled automatically.", st, "#e8f8f0"))
     story.append(H2("5.2  Configuring output", st))
-    story.append(SP(4))
     story.append(tbl(
         ["Field", "Meaning"],
         [
-            ["Output Folder",
-             "Directory where the three Excel files are saved. "
-             "Default: directory of the JSON file."],
-            ["Prefix",
-             "Name prefix for output files. 'ART_A' produces "
-             "ART_A_IssueTimes.xlsx, ART_A_Transitions.xlsx, and ART_A_CFD.xlsx."],
+            ["Output Folder", "Directory where the three Excel files are saved. Default: directory of the JSON file."],
+            ["Prefix", "Name prefix for output files. 'ART_A' produces ART_A_IssueTimes.xlsx, ART_A_Transitions.xlsx, and ART_A_CFD.xlsx."],
         ],
         col_widths=[4*cm, 12*cm]))
     story.append(H2("5.3  Starting the transformation", st))
     story.append(P(
         "Click <b>'Run'</b>. The program reads the data, computes all values, "
-        "and saves the three Excel files. Progress and any warnings appear in the "
-        "log area.", st))
+        "and saves the three Excel files. Progress and any warnings appear in the log area.", st))
     story.append(SP(4))
     story.append(box(
         "<b>Warnings in the log:</b> A warning about unmapped statuses does not mean "
@@ -771,20 +674,12 @@ def content_en(st):
     story.append(H2("5.4  Language and Help", st))
     story.append(P(
         "Use the <b>Options</b> menu to switch between German and English. "
-        "All labels update immediately. "
-        "Under <b>Help &rarr; Manual</b>, this manual opens in the active language "
-        "in your browser.", st))
+        "Under <b>Help &rarr; Manual</b>, this manual opens in your browser.", st))
 
-    # 6
     story.append(PageBreak())
     story.append(H1("6  Output Files", st))
-    story.append(P(
-        "transform_data produces three Excel files. These files serve as input for "
-        "build_reports and should not be edited manually.", st))
+    story.append(P("transform_data produces three Excel files used as input for build_reports.", st))
     story.append(H2("6.1  IssueTimes.xlsx", st))
-    story.append(P(
-        "The main output file. Contains one row per issue with all time data.", st))
-    story.append(SP(4))
     story.append(tbl(
         ["Column", "Content"],
         [
@@ -801,10 +696,7 @@ def content_en(st):
         ],
         col_widths=[4.5*cm, 11.5*cm]))
     story.append(H2("6.2  Transitions.xlsx", st))
-    story.append(P(
-        "Contains the complete status history of all issues -- one entry per status "
-        "change. Useful for detailed analysis of individual issues.", st))
-    story.append(SP(4))
+    story.append(P("Contains the complete status history of all issues -- one entry per status change.", st))
     story.append(tbl(
         ["Column", "Content"],
         [
@@ -815,23 +707,17 @@ def content_en(st):
         col_widths=[4*cm, 12*cm]))
     story.append(H2("6.3  CFD.xlsx", st))
     story.append(P(
-        "Contains, for each calendar day, the number of issues that entered each "
-        "stage on that day. build_reports accumulates these values cumulatively "
-        "to produce the Cumulative Flow Diagram.", st))
+        "Contains, for each calendar day, the number of issues that entered each stage on that day. "
+        "build_reports accumulates these values to produce the Cumulative Flow Diagram.", st))
 
-    # 7
     story.append(PageBreak())
     story.append(H1("7  How are Dates and Times Calculated?", st))
-    story.append(P(
-        "This chapter explains the rules transform_data uses to determine milestone "
-        "dates (First Date, Closed Date) and stage times.", st))
     story.append(H2("7.1  Stage times", st))
     story.append(tbl(
         ["Situation", "Rule"],
         [
             ["Issue created but no status change yet",
-             "Time from creation to the first status change is attributed to the "
-             "initial stage."],
+             "Time from creation to the first status change is attributed to the initial stage."],
             ["Status change to an unmapped stage",
              "Time continues in the last known stage (carry-forward). No time is lost."],
             ["Current status",
@@ -841,91 +727,814 @@ def content_en(st):
     story.append(H2("7.2  First Date", st))
     story.append(P(
         "The First Date is set when an issue first enters the stage marked "
-        "<b>&lt;First&gt;</b> in the workflow file. It represents the start of "
-        "active work.", st))
+        "<b>&lt;First&gt;</b>. It represents the start of active work.", st))
     story.append(SP(4))
     story.append(box(
-        "<b>Skipped First stage:</b> If an issue enters a stage after the "
-        "&lt;First&gt; stage without entering it directly, the entry timestamp "
-        "of that later stage is used as the First Date.", st, "#e8f5e9"))
+        "<b>Skipped First stage:</b> If an issue enters a stage after &lt;First&gt; "
+        "without entering it directly, that entry timestamp is used as the First Date.", st, "#e8f5e9"))
     story.append(H2("7.3  Closed Date", st))
     story.append(P(
-        "The Closed Date is set when an issue enters the stage marked "
-        "<b>&lt;Closed&gt;</b>. If an issue was closed and re-opened multiple times, "
-        "the <b>last</b> closing timestamp is used.", st))
+        "The Closed Date is set when an issue enters the stage marked <b>&lt;Closed&gt;</b>. "
+        "If closed and re-opened multiple times, the <b>last</b> closing timestamp is used.", st))
     story.append(SP(4))
     story.append(box(
-        "<b>Re-opened issues:</b> If an issue is currently in a stage before "
-        "&lt;Closed&gt;, no Closed Date is set -- even if the stage was reached "
-        "previously.", st, "#fce4ec"))
+        "<b>Re-opened issues:</b> If an issue is currently before &lt;Closed&gt;, "
+        "no Closed Date is set.", st, "#fce4ec"))
     story.append(SP(4))
     story.append(box(
-        "<b>Never-worked issues:</b> Issues without a First Date (jumped directly "
-        "from To Do to Closed) receive no Closed Date and are not counted in "
-        "Flow Velocity.", st, "#e8eaf6"))
+        "<b>Never-worked issues:</b> Issues without a First Date receive no Closed Date "
+        "and are not counted in Flow Velocity.", st, "#e8eaf6"))
 
-    # 8
     story.append(PageBreak())
     story.append(H1("8  Frequently Asked Questions", st))
     faqs = [
         ("An issue has no First Date -- why?",
-         "The issue never reached the <First> stage or any stage after it. "
-         "In build_reports it is counted as 'To Do'."),
+         "The issue never reached the <First> stage or any stage after it. In build_reports it is counted as 'To Do'."),
         ("An issue has no Closed Date -- why?",
-         "Possible reasons: (1) The issue is still open. "
-         "(2) It has no First Date. "
-         "(3) It was re-opened after closing. "
-         "(4) The <Closed> stage was skipped with no later stage in the workflow."),
+         "Possible reasons: (1) The issue is still open. (2) It has no First Date. (3) It was re-opened after closing."),
         ("The log shows a warning about unmapped statuses.",
-         "Some Jira statuses in the export are not defined in the workflow file. "
-         "Processing still completes. Contact your technical contact to update "
-         "the workflow file."),
+         "Some Jira statuses are not defined in the workflow file. Processing still completes."),
         ("The output files are not created.",
-         "Check that the output folder exists and you have write permissions. "
-         "Make sure the files are not open in Excel."),
+         "Check that the output folder exists and you have write permissions. Make sure the files are not open in Excel."),
         ("Which file do I use for build_reports?",
-         "IssueTimes.xlsx is required for all metrics except CFD. "
-         "CFD.xlsx is additionally needed for the Cumulative Flow Diagram."),
+         "IssueTimes.xlsx is required for all metrics. CFD.xlsx is additionally needed for the Cumulative Flow Diagram."),
         ("How often do I need to run transform_data?",
          "Whenever you need updated data from Jira."),
         ("What does 'carry-forward' mean?",
-         "Time spent in an unmapped status is attributed to the last known stage "
-         "-- no time is lost."),
+         "Time in an unmapped status is attributed to the last known stage -- no time is lost."),
     ]
     for q, a in faqs:
         story.append(H3("Q: " + q, st))
         story.append(P("A: " + a, st))
         story.append(SP(4))
 
-    # 9
     story.append(PageBreak())
     story.append(H1("9  Glossary", st))
     story.append(tbl(
         ["Term", "Explanation"],
         [
-            ["Carry-forward",
-             "Time in an unmapped status is attributed to the last known stage."],
-            ["CFD",
-             "Cumulative Flow Diagram -- shows backlog evolution over time by stage."],
-            ["Closed Date",
-             "The date an issue was completed."],
-            ["First Date",
-             "The date active work began on an issue."],
-            ["Implementation Date",
-             "The date development work started."],
-            ["Issue",
-             "A ticket in the issue tracker (e.g. a Jira card)."],
-            ["JSON",
-             "A simple text format for structured data."],
-            ["Marker",
-             "Lines in the workflow file that designate a stage as a milestone: "
-             "<First>, <InProgress>, <Closed>."],
-            ["Prefix",
-             "Name prefix for output files (e.g. 'ART_A')."],
-            ["Stage",
-             "A logical process step mapped to one or more Jira statuses."],
-            ["Workflow file",
-             "Text file describing the stages and markers of a project."],
+            ["Carry-forward", "Time in an unmapped status is attributed to the last known stage."],
+            ["CFD", "Cumulative Flow Diagram -- shows backlog evolution over time by stage."],
+            ["Closed Date", "The date an issue was completed."],
+            ["First Date", "The date active work began on an issue."],
+            ["Implementation Date", "The date development work started."],
+            ["Issue", "A ticket in the issue tracker (e.g. a Jira card)."],
+            ["JSON", "A simple text format for structured data."],
+            ["Marker", "Lines in the workflow file that designate a stage as a milestone: <First>, <InProgress>, <Closed>."],
+            ["Prefix", "Name prefix for output files (e.g. 'ART_A')."],
+            ["Stage", "A logical process step mapped to one or more Jira statuses."],
+            ["Workflow file", "Text file describing the stages and markers of a project."],
+        ],
+        col_widths=[4.5*cm, 11.5*cm]))
+
+    return story, toc
+
+
+# ---------------------------------------------------------------------------
+# Content — Romanian
+# ---------------------------------------------------------------------------
+
+def content_ro(st):
+    story = []
+    story.append(PageBreak())
+    story.append(H1("Cuprins", st))
+    toc = _make_toc("ro")
+    story.append(toc)
+
+    story.append(PageBreak())
+    story.append(H1("1  Ce este transform_data?", st))
+    story.append(P(
+        "transform_data este primul modul din lantul de instrumente situation-report. "
+        "Citeste un export de date brute din sistemul dvs. de tickete (Jira) si "
+        "pregateste datele pentru analiza ulterioara. Rezultatul sunt trei "
+        "<b>fisiere Excel</b> care arata cat timp au petrecut issue-urile in "
+        "fiecare etapa a fluxului de lucru.", st))
+    story.append(P(
+        "Programul are o interfata grafica simpla (GUI): nu sunt necesare cunostinte "
+        "de programare. Selectati doua fisiere, faceti clic pe 'Executare' si "
+        "fisierele Excel sunt generate automat.", st))
+    story.append(SP(8))
+    story.append(box(
+        "<b>Ce produce transform_data:</b><br/>"
+        "- <b>IssueTimes.xlsx</b>: Toate issue-urile cu marcajele de timp si minutele per etapa.<br/>"
+        "- <b>Transitions.xlsx</b>: Istoricul complet al statusurilor pentru toate issue-urile.<br/>"
+        "- <b>CFD.xlsx</b>: Numarul zilnic de intrari pe etapa pentru Diagrama de Flux Cumulativ.", st))
+    story.append(SP(8))
+    story.append(P(
+        "Fisierele Excel generate sunt utilizate de modulul <b>build_reports</b> "
+        "pentru a crea diagrame si rapoarte.", st))
+
+    story.append(PageBreak())
+    story.append(H1("2  Cerinte si instalare", st))
+    story.append(H2("2.1  Ce trebuie instalat?", st))
+    story.append(P("transform_data este livrat ca <b>pachet portabil</b>. Nu este necesara o instalare separata Python.", st))
+    story.append(BL("<b>Windows:</b> Python este deja inclus in pachet -- dezarhivati si porniti.", st))
+    story.append(BL("<b>macOS / Linux:</b> La prima pornire, un mediu Python este configurat automat (aprox. 1 minut, internet necesar).", st))
+    story.append(H2("2.2  Pornirea programului", st))
+    story.append(BL("<b>Windows:</b> Dublu-clic pe <b>TransformData.bat</b>.", st))
+    story.append(BL("<b>macOS:</b> Clic dreapta pe <b>TransformData.command</b> → <i>Deschidere</i>.", st))
+    story.append(BL("<b>Linux:</b> In terminal: <font name='Courier'>./TransformData.sh</font>", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Sfat (Windows):</b> La prima pornire, SmartScreen poate afisa un avertisment. "
+        "Faceti clic pe <b>Mai multe informatii</b> → <b>Rulare oricum</b>.", st, "#e8f8f0"))
+
+    story.append(PageBreak())
+    story.append(H1("3  Fisiere de intrare", st))
+    story.append(P(
+        "transform_data necesita exact doua fisiere: exportul JSON din Jira si "
+        "fisierul de definitie a fluxului de lucru. Ambele se selecteaza in GUI.", st))
+    story.append(H2("3.1  Exportul JSON din Jira", st))
+    story.append(P(
+        "Acesta este un export al tuturor issue-urilor dintr-un proiect Jira in format JSON. "
+        "Contine istoricul complet al statusurilor (changelog), metadate si statusul curent.", st))
+    story.append(P("Cum se genereaza exportul din Jira este descris in modulul <b>get_data</b>.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Nume tipic:</b> ART_A.json, MYPROJECT.json etc.<br/>"
+        "<b>Dimensiune:</b> Depinde de numarul de issue-uri; adesea cativa MB.", st, "#fff8e1"))
+    story.append(H2("3.2  Fisierul de definitie a fluxului", st))
+    story.append(P(
+        "Fisierul de flux este un fisier text simplu (.txt) care descrie cum statusurile "
+        "Jira din proiectul dvs. sunt mapate la etape logice ale procesului. "
+        "Defineste si care etapa marcheaza inceputul lucrului activ si inchiderea.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Nume tipic:</b> workflow_ART_A.txt etc.<br/>"
+        "<b>Creat de:</b> Contactul tehnic sau Scrum Master -- o data per proiect, rar modificat.", st, "#e8f8f0"))
+
+    story.append(PageBreak())
+    story.append(H1("4  Fisierul de definitie a fluxului", st))
+    story.append(P(
+        "Fisierul de flux controleaza modul in care transform_data interpreteaza "
+        "statusurile Jira. De obicei nu trebuie sa il creati dvs.", st))
+    story.append(H2("4.1  Structura", st))
+    story.append(P("<b>Exemplu:</b>", st))
+    story.append(CD(
+        "Funnel:New:Open:To Do<br/>"
+        "Analysis:In Analysis:Estimated<br/>"
+        "Implementation:In Implementation:In Progress<br/>"
+        "Done:Canceled<br/>"
+        "&lt;First&gt;Analysis<br/>"
+        "&lt;InProgress&gt;Implementation<br/>"
+        "&lt;Closed&gt;Done", st))
+    story.append(SP(6))
+    story.append(tbl(
+        ["Format", "Semnificatie"],
+        [
+            ["Etapa:Alias1:Alias2", "Etapa cu statusurile Jira mapate. Primul nume este numele canonic al etapei."],
+            ["<First>Etapa", "Aceasta etapa marcheaza inceputul lucrului activ (First Date)."],
+            ["<InProgress>Etapa", "Aceasta etapa seteaza Implementation Date."],
+            ["<Closed>Etapa", "Aceasta etapa marcheaza finalizarea (Closed Date)."],
+        ],
+        col_widths=[4*cm, 12*cm]))
+    story.append(H2("4.2  Ordinea etapelor", st))
+    story.append(P(
+        "Etapele sunt listate in ordinea in care sunt parcurse in proces. "
+        "Aceasta ordine este utilizata pentru CFD si pentru calculul Closed Date.", st))
+    story.append(H2("4.3  Statusuri nemapate", st))
+    story.append(P(
+        "Daca exportul Jira contine statusuri nedefinite in fisierul de flux, "
+        "transform_data afiseaza un avertisment. Timpul este atribuit ultimei etape cunoscute.", st))
+
+    story.append(PageBreak())
+    story.append(H1("5  Interfata grafica (GUI)", st))
+    story.append(P("Dupa pornire, se deschide o fereastra cu campuri de selectie fisiere si un jurnal de stare.", st))
+    story.append(H2("5.1  Selectarea fisierelor", st))
+    story.append(BL("<b>Fisier JSON</b> - Faceti clic pe 'Navigare' si selectati exportul Jira. Dosarul de iesire si prefixul sunt completate automat.", st))
+    story.append(BL("<b>Fisier de flux</b> - Selectati fisierul .txt corespunzator proiectului dvs.", st))
+    story.append(SP(4))
+    story.append(box("<b>Sfat:</b> Daca selectati mai intai fisierul JSON, dosarul de iesire si prefixul sunt precompletate automat.", st, "#e8f8f0"))
+    story.append(H2("5.2  Configurarea iesirii", st))
+    story.append(tbl(
+        ["Camp", "Semnificatie"],
+        [
+            ["Dosar de iesire", "Directorul in care sunt salvate cele trei fisiere Excel. Implicit: directorul fisierului JSON."],
+            ["Prefix", "Prefixul numelui fisierelor. Din 'ART_A' rezulta ART_A_IssueTimes.xlsx, ART_A_Transitions.xlsx si ART_A_CFD.xlsx."],
+        ],
+        col_widths=[4*cm, 12*cm]))
+    story.append(H2("5.3  Pornirea procesarii", st))
+    story.append(P(
+        "Faceti clic pe <b>'Executare'</b>. Programul citeste datele, calculeaza toate "
+        "valorile si salveaza cele trei fisiere Excel. Progresul apare in jurnal.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Atentie la avertismente:</b> Un avertisment despre statusuri nemapate nu "
+        "inseamna ca procesarea a esuat -- fisierele de iesire sunt totusi create.", st, "#fff8e1"))
+    story.append(H2("5.4  Limba si ajutor", st))
+    story.append(P(
+        "Utilizati meniul <b>Optiuni</b> pentru a schimba limba. "
+        "Sub <b>Ajutor &rarr; Manual</b>, acest manual se deschide in browser.", st))
+
+    story.append(PageBreak())
+    story.append(H1("6  Fisierele de iesire", st))
+    story.append(P("transform_data produce trei fisiere Excel utilizate ca intrare pentru build_reports.", st))
+    story.append(H2("6.1  IssueTimes.xlsx", st))
+    story.append(tbl(
+        ["Coloana", "Continut"],
+        [
+            ["Project",            "Cheia proiectului (ex. ART_A)"],
+            ["Key",                "Cheia issue-ului (ex. ART_A-123)"],
+            ["Issuetype",          "Tipul issue-ului (ex. Feature, Bug, Story)"],
+            ["Status",             "Statusul curent Jira"],
+            ["Created Date",       "Data crearii issue-ului in Jira"],
+            ["First Date",         "Prima intrare in etapa <First>"],
+            ["Implementation Date","Prima intrare in etapa <InProgress>"],
+            ["Closed Date",        "Marca de timp a finalizarii (gol = inca deschis)"],
+            ["Coloane etape",      "Cate o coloana per etapa: minute petrecute in acea etapa"],
+            ["Resolution",         "Tipul inchiderii din Jira"],
+        ],
+        col_widths=[4.5*cm, 11.5*cm]))
+    story.append(H2("6.2  Transitions.xlsx", st))
+    story.append(P("Contine istoricul complet al statusurilor -- o inregistrare per modificare de status.", st))
+    story.append(tbl(
+        ["Coloana", "Continut"],
+        [
+            ["Key",        "Cheia issue-ului"],
+            ["Transition", "Numele etapei (sau 'Created' pentru marca de timp a crearii)"],
+            ["Timestamp",  "Data si ora modificarii de status"],
+        ],
+        col_widths=[4*cm, 12*cm]))
+    story.append(H2("6.3  CFD.xlsx", st))
+    story.append(P(
+        "Contine, pentru fiecare zi calendaristica, numarul de issue-uri care au "
+        "intrat in fiecare etapa in acea zi. build_reports acumuleaza aceste valori "
+        "pentru Diagrama de Flux Cumulativ.", st))
+
+    story.append(PageBreak())
+    story.append(H1("7  Cum se calculeaza datele si timpii?", st))
+    story.append(H2("7.1  Timpii pe etape", st))
+    story.append(tbl(
+        ["Situatie", "Regula"],
+        [
+            ["Issue creat, dar fara modificare de status",
+             "Timpul de la creare pana la prima modificare este atribuit etapei initiale."],
+            ["Modificare de status catre o etapa nemapata",
+             "Timpul continua in ultima etapa cunoscuta (carry-forward)."],
+            ["Status curent",
+             "Ultima etapa cunoscuta acumuleaza timp pana la momentul procesarii."],
+        ],
+        col_widths=[5*cm, 11*cm]))
+    story.append(H2("7.2  First Date", st))
+    story.append(P(
+        "First Date este setat cand un issue intra pentru prima data in etapa "
+        "marcata cu <b>&lt;First&gt;</b>. Reprezinta inceputul lucrului activ.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Etapa First sarita:</b> Daca un issue intra intr-o etapa dupa &lt;First&gt; "
+        "fara a o atinge direct, marca de timp a acelei etape este utilizata ca First Date.", st, "#e8f5e9"))
+    story.append(H2("7.3  Closed Date", st))
+    story.append(P(
+        "Closed Date este setat la intrarea in etapa marcata cu <b>&lt;Closed&gt;</b>. "
+        "Daca un issue a fost inchis si redeschis de mai multe ori, se utilizeaza "
+        "<b>ultima</b> marca de timp de inchidere.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Issue-uri redeschise:</b> Daca un issue se afla intr-o etapa inaintea "
+        "&lt;Closed&gt;, nu se seteaza Closed Date.", st, "#fce4ec"))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Issue-uri niciodata lucrate:</b> Issue-urile fara First Date nu primesc "
+        "Closed Date si nu sunt numarate in Flow Velocity.", st, "#e8eaf6"))
+
+    story.append(PageBreak())
+    story.append(H1("8  Intrebari frecvente si sfaturi", st))
+    faqs = [
+        ("Un issue nu are First Date -- de ce?",
+         "Issue-ul nu a atins niciodata etapa <First> sau vreo etapa ulterioara. In build_reports este numarat ca 'To Do'."),
+        ("Un issue nu are Closed Date -- de ce?",
+         "Motive posibile: (1) Issue-ul este inca deschis. (2) Nu are First Date. (3) A fost redeschis dupa inchidere."),
+        ("Jurnalul afiseaza un avertisment despre statusuri nemapate.",
+         "Unele statusuri Jira nu sunt definite in fisierul de flux. Procesarea se finalizeaza totusi."),
+        ("Fisierele de iesire nu sunt create.",
+         "Verificati daca dosarul de iesire exista si aveti permisiuni de scriere. Asigurati-va ca fisierele nu sunt deschise in Excel."),
+        ("Ce fisier folosesc pentru build_reports?",
+         "IssueTimes.xlsx este obligatoriu pentru toate metricile. CFD.xlsx este necesar suplimentar pentru Diagrama de Flux Cumulativ."),
+        ("Cat de des trebuie sa rulez transform_data?",
+         "Ori de cate ori aveti nevoie de date actualizate din Jira."),
+        ("Ce inseamna 'carry-forward'?",
+         "Timpul petrecut intr-un status nemadat este atribuit ultimei etape cunoscute -- nu se pierde timp."),
+    ]
+    for q, a in faqs:
+        story.append(H3("I: " + q, st))
+        story.append(P("R: " + a, st))
+        story.append(SP(4))
+
+    story.append(PageBreak())
+    story.append(H1("9  Glosar", st))
+    story.append(tbl(
+        ["Termen", "Explicatie"],
+        [
+            ["Carry-forward", "Timpul intr-un status nemadat este atribuit ultimei etape cunoscute."],
+            ["CFD", "Cumulative Flow Diagram -- arata evolutia stocului pe etape in timp."],
+            ["Closed Date", "Data finalizarii unui issue."],
+            ["First Date", "Data inceperii lucrului activ la un issue."],
+            ["Implementation Date", "Data inceperii lucrului de dezvoltare."],
+            ["Issue", "Un tichet in sistemul de tickete (ex. un card Jira)."],
+            ["JSON", "Format text simplu pentru date structurate."],
+            ["Marker", "Linii in fisierul de flux care desemneaza o etapa ca jalon: <First>, <InProgress>, <Closed>."],
+            ["Prefix", "Prefixul numelui fisierelor de iesire (ex. 'ART_A')."],
+            ["Etapa (Stage)", "Un pas logic al procesului mapat la unul sau mai multe statusuri Jira."],
+            ["Fisier de flux", "Fisier text care descrie etapele si jalonii unui proiect."],
+        ],
+        col_widths=[4.5*cm, 11.5*cm]))
+
+    return story, toc
+
+
+# ---------------------------------------------------------------------------
+# Content — Portuguese
+# ---------------------------------------------------------------------------
+
+def content_pt(st):
+    story = []
+    story.append(PageBreak())
+    story.append(H1("Indice", st))
+    toc = _make_toc("pt")
+    story.append(toc)
+
+    story.append(PageBreak())
+    story.append(H1("1  O que e o transform_data?", st))
+    story.append(P(
+        "transform_data e o primeiro modulo da cadeia de ferramentas situation-report. "
+        "Le um exporto de dados brutos do seu sistema de tickets (Jira) e prepara "
+        "os dados para analise posterior. O resultado sao tres <b>ficheiros Excel</b> "
+        "que mostram quanto tempo os issues passaram em cada etapa do fluxo de trabalho.", st))
+    story.append(P(
+        "O programa tem uma interface grafica simples (GUI): nao sao necessarios "
+        "conhecimentos de programacao. Selecione dois ficheiros, clique em 'Executar' "
+        "e os ficheiros Excel sao produzidos automaticamente.", st))
+    story.append(SP(8))
+    story.append(box(
+        "<b>O que o transform_data produz:</b><br/>"
+        "- <b>IssueTimes.xlsx</b>: Todos os issues com marcas de tempo e minutos por etapa.<br/>"
+        "- <b>Transitions.xlsx</b>: Historico completo de statusos de todos os issues.<br/>"
+        "- <b>CFD.xlsx</b>: Contagens diarias de entradas por etapa para o Diagrama de Fluxo Cumulativo.", st))
+    story.append(SP(8))
+    story.append(P(
+        "Os ficheiros Excel gerados sao utilizados pelo modulo <b>build_reports</b> "
+        "para criar graficos e relatorios.", st))
+
+    story.append(PageBreak())
+    story.append(H1("2  Requisitos e instalacao", st))
+    story.append(H2("2.1  O que precisa de ser instalado?", st))
+    story.append(P("transform_data e fornecido como um <b>pacote portatil</b>. Nao e necessaria uma instalacao Python separada.", st))
+    story.append(BL("<b>Windows:</b> O Python ja esta incluido no pacote -- basta descompactar e iniciar.", st))
+    story.append(BL("<b>macOS / Linux:</b> No primeiro arranque, um ambiente Python e configurado automaticamente (aprox. 1 minuto, internet necessaria).", st))
+    story.append(H2("2.2  Iniciar o programa", st))
+    story.append(BL("<b>Windows:</b> Duplo clique em <b>TransformData.bat</b>.", st))
+    story.append(BL("<b>macOS:</b> Clique com o botao direito em <b>TransformData.command</b> → <i>Abrir</i>.", st))
+    story.append(BL("<b>Linux:</b> No terminal: <font name='Courier'>./TransformData.sh</font>", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Dica (Windows):</b> No primeiro arranque, o SmartScreen pode mostrar um aviso. "
+        "Clique em <b>Mais informacoes</b> → <b>Executar mesmo assim</b>.", st, "#e8f8f0"))
+
+    story.append(PageBreak())
+    story.append(H1("3  Ficheiros de entrada", st))
+    story.append(P(
+        "transform_data requer exatamente dois ficheiros: o exporto JSON do Jira e o "
+        "ficheiro de definicao do fluxo de trabalho. Ambos sao selecionados na GUI.", st))
+    story.append(H2("3.1  Exporto JSON do Jira", st))
+    story.append(P(
+        "Este e um exporto de todos os issues de um projeto Jira em formato JSON. "
+        "Contem o historico completo de statusos (changelog), metadados e o status atual.", st))
+    story.append(P("Como gerar o exporto do Jira e descrito no modulo <b>get_data</b>.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Nome tipico:</b> ART_A.json, MYPROJECT.json, etc.<br/>"
+        "<b>Tamanho:</b> Depende do numero de issues; frequentemente varios MB.", st, "#fff8e1"))
+    story.append(H2("3.2  Ficheiro de definicao do fluxo", st))
+    story.append(P(
+        "O ficheiro de fluxo e um ficheiro de texto simples (.txt) que descreve como os "
+        "statusos Jira do seu projeto sao mapeados para etapas logicas do processo. "
+        "Tambem define qual etapa marca o inicio do trabalho ativo e o fecho.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Nome tipico:</b> workflow_ART_A.txt, etc.<br/>"
+        "<b>Criado por:</b> O seu contacto tecnico ou Scrum Master -- uma vez por projeto, raramente alterado.", st, "#e8f8f0"))
+
+    story.append(PageBreak())
+    story.append(H1("4  O ficheiro de definicao do fluxo", st))
+    story.append(P(
+        "O ficheiro de fluxo controla como o transform_data interpreta os statusos Jira. "
+        "Normalmente nao precisa de criar este ficheiro.", st))
+    story.append(H2("4.1  Estrutura", st))
+    story.append(P("<b>Exemplo:</b>", st))
+    story.append(CD(
+        "Funnel:New:Open:To Do<br/>"
+        "Analysis:In Analysis:Estimated<br/>"
+        "Implementation:In Implementation:In Progress<br/>"
+        "Done:Canceled<br/>"
+        "&lt;First&gt;Analysis<br/>"
+        "&lt;InProgress&gt;Implementation<br/>"
+        "&lt;Closed&gt;Done", st))
+    story.append(SP(6))
+    story.append(tbl(
+        ["Formato", "Significado"],
+        [
+            ["Etapa:Alias1:Alias2", "Etapa com statusos Jira mapeados. O primeiro nome e o nome canonico da etapa."],
+            ["<First>Etapa", "Esta etapa marca o inicio do trabalho ativo (First Date)."],
+            ["<InProgress>Etapa", "Esta etapa define o Implementation Date."],
+            ["<Closed>Etapa", "Esta etapa marca a conclusao (Closed Date)."],
+        ],
+        col_widths=[4*cm, 12*cm]))
+    story.append(H2("4.2  Ordem das etapas", st))
+    story.append(P(
+        "As etapas sao listadas na ordem em que sao percorridas no processo. "
+        "Esta ordem e usada para o CFD e para calcular o Closed Date quando etapas sao ignoradas.", st))
+    story.append(H2("4.3  Statusos nao mapeados", st))
+    story.append(P(
+        "Se o exporto Jira contiver statusos nao definidos no ficheiro de fluxo, "
+        "o transform_data emite um aviso. O tempo e atribuido a ultima etapa conhecida.", st))
+
+    story.append(PageBreak())
+    story.append(H1("5  A interface grafica (GUI)", st))
+    story.append(P("Apos o inicio, abre-se uma janela com campos de selecao de ficheiros e um registo de estado.", st))
+    story.append(H2("5.1  Selecionar ficheiros", st))
+    story.append(BL("<b>Ficheiro JSON</b> - Clique em 'Procurar' e selecione o exporto Jira. A pasta de saida e o prefixo sao preenchidos automaticamente.", st))
+    story.append(BL("<b>Ficheiro de fluxo</b> - Selecione o ficheiro .txt adequado para o seu projeto.", st))
+    story.append(SP(4))
+    story.append(box("<b>Dica:</b> Se selecionar primeiro o ficheiro JSON, a pasta de saida e o prefixo sao preenchidos automaticamente.", st, "#e8f8f0"))
+    story.append(H2("5.2  Configurar a saida", st))
+    story.append(tbl(
+        ["Campo", "Significado"],
+        [
+            ["Pasta de saida", "Diretorio onde os tres ficheiros Excel sao guardados. Predefinicao: diretorio do ficheiro JSON."],
+            ["Prefixo", "Prefixo do nome dos ficheiros. 'ART_A' produz ART_A_IssueTimes.xlsx, ART_A_Transitions.xlsx e ART_A_CFD.xlsx."],
+        ],
+        col_widths=[4*cm, 12*cm]))
+    story.append(H2("5.3  Iniciar a transformacao", st))
+    story.append(P(
+        "Clique em <b>'Executar'</b>. O programa le os dados, calcula todos os valores "
+        "e guarda os tres ficheiros Excel. O progresso e quaisquer avisos aparecem no registo.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Avisos no registo:</b> Um aviso sobre statusos nao mapeados nao significa "
+        "que a transformacao falhou -- os ficheiros de saida sao criados na mesma.", st, "#fff8e1"))
+    story.append(H2("5.4  Idioma e ajuda", st))
+    story.append(P(
+        "Use o menu <b>Opcoes</b> para mudar o idioma. "
+        "Em <b>Ajuda &rarr; Manual</b>, este manual abre no browser.", st))
+
+    story.append(PageBreak())
+    story.append(H1("6  Ficheiros de saida", st))
+    story.append(P("transform_data produz tres ficheiros Excel utilizados como entrada para build_reports.", st))
+    story.append(H2("6.1  IssueTimes.xlsx", st))
+    story.append(tbl(
+        ["Coluna", "Conteudo"],
+        [
+            ["Project",            "Chave do projeto (ex. ART_A)"],
+            ["Key",                "Chave do issue (ex. ART_A-123)"],
+            ["Issuetype",          "Tipo do issue (ex. Feature, Bug, Story)"],
+            ["Status",             "Status atual do Jira"],
+            ["Created Date",       "Data de criacao do issue no Jira"],
+            ["First Date",         "Primeira entrada na etapa <First>"],
+            ["Implementation Date","Primeira entrada na etapa <InProgress>"],
+            ["Closed Date",        "Marca de tempo da conclusao (vazio = ainda aberto)"],
+            ["Colunas de etapas",  "Uma coluna por etapa: minutos passados nessa etapa"],
+            ["Resolution",         "Tipo de fecho do Jira"],
+        ],
+        col_widths=[4.5*cm, 11.5*cm]))
+    story.append(H2("6.2  Transitions.xlsx", st))
+    story.append(P("Contem o historico completo de statusos de todos os issues -- uma entrada por alteracao de status.", st))
+    story.append(tbl(
+        ["Coluna", "Conteudo"],
+        [
+            ["Key",        "Chave do issue"],
+            ["Transition", "Nome da etapa (ou 'Created' para a marca de tempo de criacao)"],
+            ["Timestamp",  "Data e hora da alteracao de status"],
+        ],
+        col_widths=[4*cm, 12*cm]))
+    story.append(H2("6.3  CFD.xlsx", st))
+    story.append(P(
+        "Contem, para cada dia do calendario, o numero de issues que entraram em cada etapa "
+        "nesse dia. build_reports acumula estes valores para o Diagrama de Fluxo Cumulativo.", st))
+
+    story.append(PageBreak())
+    story.append(H1("7  Como sao calculadas as datas e durações?", st))
+    story.append(H2("7.1  Tempos por etapa", st))
+    story.append(tbl(
+        ["Situacao", "Regra"],
+        [
+            ["Issue criado mas sem alteracao de status",
+             "O tempo desde a criacao ate a primeira alteracao e atribuido a etapa inicial."],
+            ["Alteracao de status para uma etapa nao mapeada",
+             "O tempo continua na ultima etapa conhecida (carry-forward)."],
+            ["Status atual",
+             "A ultima etapa conhecida acumula tempo ate ao momento do processamento."],
+        ],
+        col_widths=[5*cm, 11*cm]))
+    story.append(H2("7.2  First Date", st))
+    story.append(P(
+        "O First Date e definido quando um issue entra pela primeira vez na etapa "
+        "marcada com <b>&lt;First&gt;</b>. Representa o inicio do trabalho ativo.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Etapa First ignorada:</b> Se um issue entrar numa etapa apos &lt;First&gt; "
+        "sem a atingir diretamente, a marca de tempo dessa etapa e usada como First Date.", st, "#e8f5e9"))
+    story.append(H2("7.3  Closed Date", st))
+    story.append(P(
+        "O Closed Date e definido ao entrar na etapa marcada com <b>&lt;Closed&gt;</b>. "
+        "Se fechado e reaberto varias vezes, usa-se a <b>ultima</b> marca de tempo de fecho.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Issues reabertos:</b> Se um issue estiver antes de &lt;Closed&gt;, "
+        "nao e definido Closed Date.", st, "#fce4ec"))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Issues nunca trabalhados:</b> Issues sem First Date nao recebem Closed Date "
+        "e nao sao contados no Flow Velocity.", st, "#e8eaf6"))
+
+    story.append(PageBreak())
+    story.append(H1("8  Perguntas frequentes e dicas", st))
+    faqs = [
+        ("Um issue nao tem First Date -- porque?",
+         "O issue nunca atingiu a etapa <First> nem qualquer etapa posterior. No build_reports e contado como 'To Do'."),
+        ("Um issue nao tem Closed Date -- porque?",
+         "Razoes possiveis: (1) O issue ainda esta aberto. (2) Nao tem First Date. (3) Foi reaberto apos o fecho."),
+        ("O registo mostra um aviso sobre statusos nao mapeados.",
+         "Alguns statusos Jira nao estao definidos no ficheiro de fluxo. O processamento conclui na mesma."),
+        ("Os ficheiros de saida nao sao criados.",
+         "Verifique se a pasta de saida existe e se tem permissoes de escrita. Certifique-se de que os ficheiros nao estao abertos no Excel."),
+        ("Que ficheiro uso para o build_reports?",
+         "IssueTimes.xlsx e obrigatorio para todas as metricas. CFD.xlsx e adicionalmente necessario para o Diagrama de Fluxo Cumulativo."),
+        ("Com que frequencia devo executar o transform_data?",
+         "Sempre que precisar de dados atualizados do Jira."),
+        ("O que significa 'carry-forward'?",
+         "O tempo num status nao mapeado e atribuido a ultima etapa conhecida -- nenhum tempo e perdido."),
+    ]
+    for q, a in faqs:
+        story.append(H3("P: " + q, st))
+        story.append(P("R: " + a, st))
+        story.append(SP(4))
+
+    story.append(PageBreak())
+    story.append(H1("9  Glossario", st))
+    story.append(tbl(
+        ["Termo", "Explicacao"],
+        [
+            ["Carry-forward", "Tempo num status nao mapeado e atribuido a ultima etapa conhecida."],
+            ["CFD", "Cumulative Flow Diagram -- mostra a evolucao do stock por etapas ao longo do tempo."],
+            ["Closed Date", "A data de conclusao de um issue."],
+            ["First Date", "A data em que o trabalho ativo num issue comecou."],
+            ["Implementation Date", "A data em que o trabalho de desenvolvimento comecou."],
+            ["Issue", "Um ticket no sistema de tickets (ex. um cartao Jira)."],
+            ["JSON", "Formato de texto simples para dados estruturados."],
+            ["Marcador (Marker)", "Linhas no ficheiro de fluxo que designam uma etapa como marco: <First>, <InProgress>, <Closed>."],
+            ["Prefixo", "Prefixo do nome dos ficheiros de saida (ex. 'ART_A')."],
+            ["Etapa (Stage)", "Um passo logico do processo mapeado para um ou mais statusos Jira."],
+            ["Ficheiro de fluxo", "Ficheiro de texto que descreve as etapas e marcos de um projeto."],
+        ],
+        col_widths=[4.5*cm, 11.5*cm]))
+
+    return story, toc
+
+
+# ---------------------------------------------------------------------------
+# Content — French
+# ---------------------------------------------------------------------------
+
+def content_fr(st):
+    story = []
+    story.append(PageBreak())
+    story.append(H1("Table des matieres", st))
+    toc = _make_toc("fr")
+    story.append(toc)
+
+    story.append(PageBreak())
+    story.append(H1("1  Qu'est-ce que transform_data ?", st))
+    story.append(P(
+        "transform_data est le premier module de la chaine d'outils situation-report. "
+        "Il lit un export de donnees brutes de votre systeme de tickets (Jira) et "
+        "prepare les donnees pour une analyse ulterieure. Le resultat sont trois "
+        "<b>fichiers Excel</b> qui montrent combien de temps les issues ont passe "
+        "dans chaque etape du flux de travail.", st))
+    story.append(P(
+        "Le programme dispose d'une interface graphique simple (GUI) : aucune "
+        "connaissance en programmation n'est requise. Selectionnez deux fichiers, "
+        "cliquez sur 'Executer' et les fichiers Excel sont produits automatiquement.", st))
+    story.append(SP(8))
+    story.append(box(
+        "<b>Ce que produit transform_data :</b><br/>"
+        "- <b>IssueTimes.xlsx</b> : Tous les issues avec horodatages et minutes par etape.<br/>"
+        "- <b>Transitions.xlsx</b> : Historique complet des statuts de tous les issues.<br/>"
+        "- <b>CFD.xlsx</b> : Comptages d'entrees quotidiens par etape pour le Diagramme de Flux Cumulatif.", st))
+    story.append(SP(8))
+    story.append(P(
+        "Les fichiers Excel generes sont ensuite utilises par le module <b>build_reports</b> "
+        "pour creer des graphiques et des rapports.", st))
+
+    story.append(PageBreak())
+    story.append(H1("2  Prerequis et installation", st))
+    story.append(H2("2.1  Que faut-il installer ?", st))
+    story.append(P("transform_data est fourni sous forme de <b>paquet portable</b>. Aucune installation Python separee n'est necessaire.", st))
+    story.append(BL("<b>Windows :</b> Python est deja inclus dans le paquet -- decompressez et demarrez.", st))
+    story.append(BL("<b>macOS / Linux :</b> Au premier lancement, un environnement Python est configure automatiquement (environ 1 minute, internet requis).", st))
+    story.append(H2("2.2  Demarrer le programme", st))
+    story.append(BL("<b>Windows :</b> Double-cliquez sur <b>TransformData.bat</b>.", st))
+    story.append(BL("<b>macOS :</b> Clic droit sur <b>TransformData.command</b> → <i>Ouvrir</i>.", st))
+    story.append(BL("<b>Linux :</b> Dans un terminal : <font name='Courier'>./TransformData.sh</font>", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Conseil (Windows) :</b> Au premier lancement, SmartScreen peut afficher un avertissement. "
+        "Cliquez sur <b>Plus d'informations</b> → <b>Executer quand meme</b>.", st, "#e8f8f0"))
+
+    story.append(PageBreak())
+    story.append(H1("3  Fichiers d'entree", st))
+    story.append(P(
+        "transform_data necessite exactement deux fichiers : l'export JSON de Jira et le "
+        "fichier de definition du flux de travail. Les deux sont selectionnes dans la GUI.", st))
+    story.append(H2("3.1  Export JSON de Jira", st))
+    story.append(P(
+        "Il s'agit d'un export de tous les issues d'un projet Jira au format JSON. "
+        "Il contient l'historique complet des statuts (changelog), les metadonnees et le statut actuel.", st))
+    story.append(P("La procedure d'export depuis Jira est decrite dans le module <b>get_data</b>.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Nom typique :</b> ART_A.json, MYPROJECT.json, etc.<br/>"
+        "<b>Taille :</b> Depend du nombre d'issues ; souvent plusieurs Mo.", st, "#fff8e1"))
+    story.append(H2("3.2  Fichier de definition du flux", st))
+    story.append(P(
+        "Le fichier de flux est un fichier texte simple (.txt) qui decrit comment les "
+        "statuts Jira de votre projet sont mappes aux etapes logiques du processus. "
+        "Il definit egalement quelle etape marque le debut du travail actif et la cloture.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Nom typique :</b> workflow_ART_A.txt, etc.<br/>"
+        "<b>Cree par :</b> Votre contact technique ou Scrum Master -- une fois par projet, rarement modifie.", st, "#e8f8f0"))
+
+    story.append(PageBreak())
+    story.append(H1("4  Le fichier de definition du flux", st))
+    story.append(P(
+        "Le fichier de flux controle la facon dont transform_data interprete les statuts Jira. "
+        "Vous n'avez generalement pas besoin de creer ce fichier vous-meme.", st))
+    story.append(H2("4.1  Structure", st))
+    story.append(P("<b>Exemple :</b>", st))
+    story.append(CD(
+        "Funnel:New:Open:To Do<br/>"
+        "Analysis:In Analysis:Estimated<br/>"
+        "Implementation:In Implementation:In Progress<br/>"
+        "Done:Canceled<br/>"
+        "&lt;First&gt;Analysis<br/>"
+        "&lt;InProgress&gt;Implementation<br/>"
+        "&lt;Closed&gt;Done", st))
+    story.append(SP(6))
+    story.append(tbl(
+        ["Format", "Signification"],
+        [
+            ["Etape:Alias1:Alias2", "Etape avec les statuts Jira mappes. Le premier nom est le nom canonique de l'etape."],
+            ["<First>Etape", "Cette etape marque le debut du travail actif (First Date)."],
+            ["<InProgress>Etape", "Cette etape definit l'Implementation Date."],
+            ["<Closed>Etape", "Cette etape marque la cloture (Closed Date)."],
+        ],
+        col_widths=[4*cm, 12*cm]))
+    story.append(H2("4.2  Ordre des etapes", st))
+    story.append(P(
+        "Les etapes sont listees dans l'ordre dans lequel elles sont parcourues dans le processus. "
+        "Cet ordre est utilise pour le CFD et pour calculer le Closed Date.", st))
+    story.append(H2("4.3  Statuts non mappes", st))
+    story.append(P(
+        "Si l'export Jira contient des statuts non definis dans le fichier de flux, "
+        "transform_data emet un avertissement. Le temps est attribue a la derniere etape connue.", st))
+
+    story.append(PageBreak())
+    story.append(H1("5  L'interface graphique (GUI)", st))
+    story.append(P("Apres le demarrage, une fenetre s'ouvre avec des champs de selection de fichiers et un journal.", st))
+    story.append(H2("5.1  Selection des fichiers", st))
+    story.append(BL("<b>Fichier JSON</b> - Cliquez sur 'Parcourir' et selectionnez votre export Jira. Le dossier de sortie et le prefixe sont remplis automatiquement.", st))
+    story.append(BL("<b>Fichier de flux</b> - Selectionnez le fichier .txt approprie pour votre projet.", st))
+    story.append(SP(4))
+    story.append(box("<b>Conseil :</b> Si vous selectionnez d'abord le fichier JSON, le dossier de sortie et le prefixe sont pre-remplis automatiquement.", st, "#e8f8f0"))
+    story.append(H2("5.2  Configuration de la sortie", st))
+    story.append(tbl(
+        ["Champ", "Signification"],
+        [
+            ["Dossier de sortie", "Repertoire ou les trois fichiers Excel sont enregistres. Par defaut : repertoire du fichier JSON."],
+            ["Prefixe", "Prefixe du nom des fichiers. 'ART_A' produit ART_A_IssueTimes.xlsx, ART_A_Transitions.xlsx et ART_A_CFD.xlsx."],
+        ],
+        col_widths=[4*cm, 12*cm]))
+    story.append(H2("5.3  Lancer la transformation", st))
+    story.append(P(
+        "Cliquez sur <b>'Executer'</b>. Le programme lit les donnees, calcule toutes les valeurs "
+        "et enregistre les trois fichiers Excel. La progression et les avertissements apparaissent dans le journal.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Avertissements dans le journal :</b> Un avertissement sur des statuts non mappes "
+        "ne signifie pas que la transformation a echoue -- les fichiers de sortie sont quand meme produits.", st, "#fff8e1"))
+    story.append(H2("5.4  Langue et aide", st))
+    story.append(P(
+        "Utilisez le menu <b>Options</b> pour changer la langue. "
+        "Sous <b>Aide &rarr; Manuel</b>, ce manuel s'ouvre dans votre navigateur.", st))
+
+    story.append(PageBreak())
+    story.append(H1("6  Fichiers de sortie", st))
+    story.append(P("transform_data produit trois fichiers Excel utilises comme entree pour build_reports.", st))
+    story.append(H2("6.1  IssueTimes.xlsx", st))
+    story.append(tbl(
+        ["Colonne", "Contenu"],
+        [
+            ["Project",            "Cle du projet (ex. ART_A)"],
+            ["Key",                "Cle de l'issue (ex. ART_A-123)"],
+            ["Issuetype",          "Type de l'issue (ex. Feature, Bug, Story)"],
+            ["Status",             "Statut actuel dans Jira"],
+            ["Created Date",       "Date de creation de l'issue dans Jira"],
+            ["First Date",         "Premiere entree dans l'etape <First>"],
+            ["Implementation Date","Premiere entree dans l'etape <InProgress>"],
+            ["Closed Date",        "Horodatage de cloture (vide = encore ouvert)"],
+            ["Colonnes d'etapes",  "Une colonne par etape : minutes passees dans cette etape"],
+            ["Resolution",         "Type de cloture depuis Jira"],
+        ],
+        col_widths=[4.5*cm, 11.5*cm]))
+    story.append(H2("6.2  Transitions.xlsx", st))
+    story.append(P("Contient l'historique complet des statuts de tous les issues -- une entree par changement de statut.", st))
+    story.append(tbl(
+        ["Colonne", "Contenu"],
+        [
+            ["Key",        "Cle de l'issue"],
+            ["Transition", "Nom de l'etape (ou 'Created' pour l'horodatage de creation)"],
+            ["Timestamp",  "Date et heure du changement de statut"],
+        ],
+        col_widths=[4*cm, 12*cm]))
+    story.append(H2("6.3  CFD.xlsx", st))
+    story.append(P(
+        "Contient, pour chaque jour calendaire, le nombre d'issues entres dans chaque etape ce jour-la. "
+        "build_reports accumule ces valeurs pour produire le Diagramme de Flux Cumulatif.", st))
+
+    story.append(PageBreak())
+    story.append(H1("7  Comment les dates et les durees sont-elles calculees ?", st))
+    story.append(H2("7.1  Temps par etape", st))
+    story.append(tbl(
+        ["Situation", "Regle"],
+        [
+            ["Issue cree mais sans changement de statut",
+             "Le temps depuis la creation jusqu'au premier changement est attribue a l'etape initiale."],
+            ["Changement de statut vers une etape non mappee",
+             "Le temps continue dans la derniere etape connue (carry-forward)."],
+            ["Statut actuel",
+             "La derniere etape connue accumule le temps jusqu'au moment du traitement."],
+        ],
+        col_widths=[5*cm, 11*cm]))
+    story.append(H2("7.2  First Date", st))
+    story.append(P(
+        "Le First Date est defini lorsqu'un issue entre pour la premiere fois dans l'etape "
+        "marquee <b>&lt;First&gt;</b>. Il represente le debut du travail actif.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Etape First ignoree :</b> Si un issue entre dans une etape apres &lt;First&gt; "
+        "sans y entrer directement, l'horodatage de cette etape est utilise comme First Date.", st, "#e8f5e9"))
+    story.append(H2("7.3  Closed Date", st))
+    story.append(P(
+        "Le Closed Date est defini lors de l'entree dans l'etape marquee <b>&lt;Closed&gt;</b>. "
+        "Si ferme et rouvert plusieurs fois, le <b>dernier</b> horodatage de fermeture est utilise.", st))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Issues rouverts :</b> Si un issue se trouve avant &lt;Closed&gt;, "
+        "aucun Closed Date n'est defini.", st, "#fce4ec"))
+    story.append(SP(4))
+    story.append(box(
+        "<b>Issues jamais travailles :</b> Les issues sans First Date ne recoivent pas de Closed Date "
+        "et ne sont pas comptes dans le Flow Velocity.", st, "#e8eaf6"))
+
+    story.append(PageBreak())
+    story.append(H1("8  Questions frequentes et conseils", st))
+    faqs = [
+        ("Un issue n'a pas de First Date -- pourquoi ?",
+         "L'issue n'a jamais atteint l'etape <First> ni aucune etape ulterieure. Dans build_reports, il est compte comme 'To Do'."),
+        ("Un issue n'a pas de Closed Date -- pourquoi ?",
+         "Raisons possibles : (1) L'issue est encore ouvert. (2) Il n'a pas de First Date. (3) Il a ete rouvert apres fermeture."),
+        ("Le journal affiche un avertissement sur des statuts non mappes.",
+         "Certains statuts Jira ne sont pas definis dans le fichier de flux. Le traitement se termine quand meme."),
+        ("Les fichiers de sortie ne sont pas crees.",
+         "Verifiez que le dossier de sortie existe et que vous avez les droits d'ecriture. Assurez-vous que les fichiers ne sont pas ouverts dans Excel."),
+        ("Quel fichier utiliser pour build_reports ?",
+         "IssueTimes.xlsx est obligatoire pour toutes les metriques. CFD.xlsx est necessaire en plus pour le Diagramme de Flux Cumulatif."),
+        ("A quelle frequence dois-je executer transform_data ?",
+         "Chaque fois que vous avez besoin de donnees mises a jour depuis Jira."),
+        ("Que signifie 'carry-forward' ?",
+         "Le temps dans un statut non mappe est attribue a la derniere etape connue -- aucun temps n'est perdu."),
+    ]
+    for q, a in faqs:
+        story.append(H3("Q : " + q, st))
+        story.append(P("R : " + a, st))
+        story.append(SP(4))
+
+    story.append(PageBreak())
+    story.append(H1("9  Glossaire", st))
+    story.append(tbl(
+        ["Terme", "Explication"],
+        [
+            ["Carry-forward", "Le temps dans un statut non mappe est attribue a la derniere etape connue."],
+            ["CFD", "Cumulative Flow Diagram -- montre l'evolution du stock par etapes dans le temps."],
+            ["Closed Date", "La date de cloture d'un issue."],
+            ["First Date", "La date de debut du travail actif sur un issue."],
+            ["Implementation Date", "La date de debut du travail de developpement."],
+            ["Issue", "Un ticket dans le systeme de tickets (ex. une carte Jira)."],
+            ["JSON", "Format texte simple pour les donnees structurees."],
+            ["Marqueur (Marker)", "Lignes dans le fichier de flux qui designent une etape comme jalon : <First>, <InProgress>, <Closed>."],
+            ["Prefixe", "Prefixe du nom des fichiers de sortie (ex. 'ART_A')."],
+            ["Etape (Stage)", "Une etape logique du processus mappee a un ou plusieurs statuts Jira."],
+            ["Fichier de flux", "Fichier texte decrivant les etapes et jalons d'un projet."],
         ],
         col_widths=[4.5*cm, 11.5*cm]))
 
@@ -949,13 +1558,22 @@ def _build_doc(output: Path, lang: str, story_fn, title: str, subject: str):
 
 
 def main():
-    """Generate German and English transform_data user manuals."""
+    """Generate transform_data user manuals in all 5 languages."""
     _build_doc(OUTPUT_DE, "de", content_de,
                "transform_data Benutzerhandbuch",
                "Jira-Daten aufbereiten fuer Metriken und Berichte")
     _build_doc(OUTPUT_EN, "en", content_en,
                "transform_data User Manual",
                "Prepare Jira data for metrics and reports")
+    _build_doc(OUTPUT_RO, "ro", content_ro,
+               "transform_data Manual de Utilizator",
+               "Pregatiti datele Jira pentru metrici si rapoarte")
+    _build_doc(OUTPUT_PT, "pt", content_pt,
+               "transform_data Manual do Utilizador",
+               "Preparar dados Jira para metricas e relatorios")
+    _build_doc(OUTPUT_FR, "fr", content_fr,
+               "transform_data Manuel d'utilisation",
+               "Preparer les donnees Jira pour les metriques et rapports")
 
 
 if __name__ == "__main__":

--- a/docs/testdata_generator_Benutzerhandbuch.pdf
+++ b/docs/testdata_generator_Benutzerhandbuch.pdf
@@ -17,7 +17,7 @@ endobj
 endobj
 4 0 obj
 <<
-/Contents 21 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 20 0 R /Resources <<
+/Contents 23 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -27,7 +27,7 @@ endobj
 endobj
 5 0 obj
 <<
-/Contents 22 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 20 0 R /Resources <<
+/Contents 24 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -68,7 +68,7 @@ Gb"0;!=]#/!5bE.WG`8*TE"rlzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
 endobj
 11 0 obj
 <<
-/Contents 23 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 20 0 R /Resources <<
+/Contents 25 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.9680444cb5f21bac74f984ffaea1fb3f 9 0 R
 >>
@@ -80,7 +80,7 @@ endobj
 endobj
 12 0 obj
 <<
-/Contents 24 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 20 0 R /Resources <<
+/Contents 26 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -90,7 +90,7 @@ endobj
 endobj
 13 0 obj
 <<
-/Contents 25 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 20 0 R /Resources <<
+/Contents 27 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -100,7 +100,7 @@ endobj
 endobj
 14 0 obj
 <<
-/Contents 26 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 20 0 R /Resources <<
+/Contents 28 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -110,7 +110,7 @@ endobj
 endobj
 15 0 obj
 <<
-/Contents 27 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 20 0 R /Resources <<
+/Contents 29 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -120,7 +120,7 @@ endobj
 endobj
 16 0 obj
 <<
-/Contents 28 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 20 0 R /Resources <<
+/Contents 30 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -130,7 +130,7 @@ endobj
 endobj
 17 0 obj
 <<
-/Contents 29 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 20 0 R /Resources <<
+/Contents 31 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -140,85 +140,120 @@ endobj
 endobj
 18 0 obj
 <<
-/PageMode /UseNone /Pages 20 0 R /Type /Catalog
+/Contents 32 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 19 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260513135316+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260513135316+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
-  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+/Contents 33 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 20 0 obj
 <<
-/Count 9 /Kids [ 4 0 R 5 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R ] /Type /Pages
+/PageMode /UseNone /Pages 22 0 R /Type /Catalog
 >>
 endobj
 21 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260513165249+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260513165249+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+22 0 obj
+<<
+/Count 11 /Kids [ 4 0 R 5 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 18 0 R 
+  19 0 R ] /Type /Pages
+>>
+endobj
+23 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 595
 >>
 stream
 Garo>>AqtU'SPBB/*7Enj^c]opQ5GEX[%KXiX#q%ai652**Cr^o[b<pd\\J7d]Tt2q9I3c)$0k%Y+#Ntb-ATkYXH2-CXU9gidIEsb(uTF3e4#,X;knUV*QT;AsAcm8318>23[dN,=Ut%11Dc(f,u:t=9_Ki=XShKCKWmDV%'5SG-d\nI&Y=ZCD,&+es%@?>?g3qIg--L<]L[8R=\q(r.%l7]'G9W4uRWTk:q+_OoI[q2+pH8(m%Y1"A7XoZLcEqOEXH[^b3(O[ciV;ASbg*\mp'.A32[d8H+5k%Im8V<f2i7'6P%Z^3b[8.[oaQ^SriR%-E\O*gm_>-OH6pfjQgKke2@EMNO]i;H,>\]q;1(s"n!r]=Qft&[um4(,p*ba2PZbM[ajePg]pTbors>fU&j'Zh>IKG98Rqpmj9M%O@!A-mqP92E3r`92Z,gFLK6dPVS1@"o2(f2kuqo:(4`N.`fethNA2bK*@I#erM97;h.<*&hFeHl`TOABlcBfDi7`;[#=hKo((r7p<S4BYM$f2E__F)b&nd>hN[[sipF#'<3\mLD"7<*T8KKo@iE@9NN'%@%0QhABCmhpZG1oHh+[~>endstream
 endobj
-22 0 obj
+24 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 1464
 >>
 stream
 GasaogQ(#H'R]XVbbGiQ=coFrGpsZu->eh[afa%(/.h#c/2NTjKVGc3^V1h%3V(n9/I]^T,gMf<F"ZS\&:jXnf`JA/puMqi(KbUk-'MHGa3Ar#D8CH@,+3ug)=fH^F&rsie-h69.1]MnU^<bH@NpY<KUhRsEu;dVjh_*-A0*[;klI-gI8'%"O"<8"_89:[UdD:N-3EKK91ut#EgqQ]8X%85B7SM>GYNLgHSX>\=2e!R?XWg9l^&*."tAT"8M9'QB!:Q_>Lhu'Ts(#lZa3>;Bb4laOj!k-(.BF2'2b*ie-X6!I*aU+-.7V>1eJoh(<Tb!51U`'9+^\+M<$dU_3.nIJbsU&"`E3MoJ$SZ`o8f^,[*U0?l9L:c[-,h(*=@M(<=@ij.Sjd/E/c\ffj?0N-0Z9-gFCb?C\'IpK2H`b'U)DU*>6__$7QCD"r-"l/N)@,[jh$Or+L$B7)Z[(*)cYN5n5I9!B`%=j4]ORU3]1BHb9PKh:4l7]D`m`c3g;5>`+a:/Sq2*c[TWr;[m!9tnIHVpW0q^slImPCZfp'Asrbcc$s^R#WgcAktd2dJqR:931`IQLIY;I.^"e&%&pn/SV/,]Q\^D[pK%,iK)NYcEt,n\5kG_06$glbMjei4P-F5F@F1m3#k@*^![WFAS>`(.d'B]5J(ZDcH'4Rl[I<Np9Ts%7f5?9g_?Q#OW3'`OeCHD!\&=B\+Z'<Eg3AHS*N4adda([>g>I"P'kBAT9Mf\"H*@7V!p[@-ca`3=7+AEFML`0W;_nF:S$0URdOVW]BX6G'^8]g\aNB)VVF**YT\uu&LuK_I7WRmc"lUJ:/l6\GaM%dK7>7I1o(K,(pkU<QWlmYUWP0W>h9+TnV(4DGc3,TOJtdGVM8j6f"\a;b^Gl"E`Z1XLQ09G/+hr3;03n7$#+&3Br6*FhPba>`YZ0/KA5/oo&>.04V5Z8?gP[doD)Y4\=5Tg=VRcR#aV;BjDl1&)?8B>X)&^7F"_1_M;t%lK(8o.=u,fS:MhN*g2R#NlY,UDdX?$-2&2!"]m<Ym/e?.U=j?t8"2S&Qe+g`h[l-cA5/+r?n&pIX'tOIE^#Da9#1Z\Fa1]i0f,<IdA'9u-GYaF2VRGeRL'o2::YL+MQ[%<296hKm^(:1g^>'3A?Vj1;pO(2sE]Z+1XtPKR:IYk39uWc@5;NZ#j]YldIFi1K\u(liR:kR8B`"IFSI9R3b?*.m_u<KCe#jf&Qg953>^tN@<N?Y@a]l&]/emuj"ilsB[KDHW0NI=Q7qCC.M'mJeFPEE+Dp7&tL\^^5O$u?ZZ,`a)17GDX$NlH0/eT'#pG+d:4s3e9K$o"(.ds!sqesS;+3u>6rDIk$er?f"Mt\m-4I.)bLB9T>Q[J!=mA>F25:Y,G5i^KrQJmfZGdOs)ofu5=)E7]+hAMI#\Go%rhU6RHn<j+55BD'Ib^MO;c8[`^-F7\Cl9X$_7jSrN!c-KOo`~>endstream
 endobj
-23 0 obj
+25 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 1669
 >>
 stream
 Gatm;gMYb*&:O:SbbJCD)=\nCl<B0']kjoI)IpB-$nNf@A>t\>01E"PrV?[HfoZpqDLfTS$u:T=k'DcZ&3p6F5I1RPbnA;S-r:,k!iR4CQC%)a3W!GYBZ*6"!+CIX*W^7V(4o]81^"B=J4)[C6(!=Y7A0iZ$&pA;K2B4NH,C%'D`8g/BU=>JR'i+g?;Q`BE6/s8N0-@n%$h@H/Ts$R<rK^$NCMUP!%\lcDc$3%#F\QT4RKKG"Y@F)ntiZU0e&nDJhh=ZZ`@oGCt7g)_+e_3j=Cm7*:O)%.$B)]#t(#7SYIf)YmVg#Ef=L[`T!!+3/iF-KF96)a1B+0,4I$L,UeWtO@Y6WE8M.f_<6"u^!?^TLlB5:5Q`0B,b\Ju]rU+(G!5_8[SL-j*/[id6:tb/R\pNPnN)2SGLR@aqVYTh>f*#IT<1t=f:i/jlSWG@FUg?2*TZP_^l^#h8]W(^&WJ00:tX&AI%1cuK.%L#_LNtr!Z<!MJNErC#bDSK"jYs9jKUCM_@FFFC@jfVF<;g$7S,"5[Do5R`X]0$/Qu9$Z.Th.=ef<:GVn!b2pp+o-OUuGLBBF<)L1VqA"Te32C%o$NS9[K/jsR8lFSWP%4N3sC^4),25Y&hF-*X4DR%Uq*H%*=(?'o6XK$'nepsW29oc*RZBC`\<Z"Q3F_]jp].,BL)om=jcV?pO@k&`AbU-is-R&t^G]uW5P@b\Z;WWFCfYdNL&.(RaDpXp[e#rT)=_s*3#GhacDOAI#^@-,SZ'slPMs[PA"EZUWc^.8emC#*-3@Z[Pl?g!M5*@B'YaV2nRgmrXFd:c(2!=ra&%n#oAY3j8i/O`InZoT;Pg1<3B?X!&Gtd_ic7\lKi;&7aEYKL(@Lap6A5VQ;draMallEU;FT:5)?O';Gp<_K1\cZ3(J"0C2p(Z<q%bk8b:Uhd44o%4W8\<UReF6qAESQM;;h:0[JIkb2(oVlLone4(;*ZQPdbp5\5=VI77i3_G0[rr[kL8sNC'3nI_8`?4]+AJW\M*[R8oM!"TNL_T(`</K'jR]KmNBKK)-2RR1P?,eCGZLOH*>hMVTVT5[/CI)$?lWOX/r[)<'&nkT+c\PE4%ZtNoPMf$oBIejk?s\)Wq;khOCV%\H-F#B"&Kn9An6tG.h4sJn]#$^=_,RhraicRib*0DlYb\/h9q1;*XgENVC!%b!,9iMu7?tX0-e5k,7+/HNK2HhJ]BQb&1'@^0C<E`U8'<Qs:oa0APXt?M>K$fYDWjFe,p#_J27mdW?r;`*O6W1A*1)ALojss7WLM1-`pEKH^"P%@cVYV_;JCJR:3G(Z@Zs2hU:O"s.*':Br$2!]VYGr"l6%_g-t5>Bu^4.;F'ja\"\_Bb6oL6F#J$*GQ/t)C,WaYh[+n&!`Eoq?+^H$$Ua:6<?0ulJTA@2mu!-=Z"K)(>`)<X\p^ScI(hrD5l7HaGal\U*4JU\>HN+$`_L(mYt_5?!r4Rs3d@jU2IFB0+CnB%4RjC5n+VO"A4rRL9Au$hq!X&XO=X7q%et/a!^/4m5a-i7cBF\/n5MT^()7c:(tJG^PL\&]%Pb*CRW#lPU&!oKFh9)(6#+?MaW]GU*p^*>,8f]oCe=#6u7bS;p-<a^0;&a*t%:*7<qFWLnr3p%eJ:d8q=W:hD(+%#J1EUq\?l\2_>N!NOaYos)0cj9`~>endstream
 endobj
-24 0 obj
+26 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 369
 >>
 stream
 Gaqcq92@l?%#+HI/'_$aW7+N)[3\[/DNMIh<u;uJ/ohgfrd&Vd&_!OMg@RJo@9?Y$.F5K=Uqsq^K*BL4XJBN9nCX,A+cbP>K1$`l#TC!noIJD,,-dtX;hWJg,l.M]`/,@[_/a']?pQtr/YriA0grbpk3"636-'3A,S@=#"jIg,[2eJ+XmOlCFJWpAXp;sV?rFRGr@\&[m2#02q>)/W#Fa&U^-QK>Ub)A7H.^VV>;s03gm>3M?Z1*ZF0[EN]OiZ:mj7;gTn>^HGU-4tr,JJXaV-%o+GlTm%4A8\g!g):Q&*R&""4A5G,U%fi:YcF<tAQ5OM"S0iLNeWVglBUbfnT'c.0=G?Aacb1FLDUAnk_&!%HE7>6~>endstream
 endobj
-25 0 obj
+27 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 1924
 >>
 stream
 Gatm;D/\/e&H;*)EF4G]"jDf;ok"U9m(=%W\h5YU"r%7Cg,dDn,g)tI\EU1=8BJ0MfPrha!Ff8'hECW0S1&X?!HnG*"i,?a^Ksd1$ml@TS8ajCKZcsUCQHhu"Zuh&\53&/M#GX$crj.q#;PmBjM_]68O-AlK]#cq@nK$3/Dg)j@Kq\<l]J^)9>UVlbfX]8'LG:eO>2P/,9Dm_9FBu&X@t+&GfW^T(8fR]K)rb)e_5C@]bDreXlmk`R!aJ,>H>B2P(t4>Pjs0mPr*8bA>obO=/@gG]7_Q:k9iLrSp1Z7&?ph+J_CCKerbW=N?90F/.MrFK,@]aHlhk*ft'[f&;%'ALf54G5ba?1T)H#3);MpoWAXs06Gb_O3"ur!N$Qp9]4X.ZpMP=bHYq^#qGP6U&l9La]QcSZ*Rl,=*)N+MlC>1<n.GL\>Y'O_9DuBAbK\s3(mH$oDYF]1&P3$>Kb2YA"+e=d8)_$LB]ql>#828<#q:rSRIf&\."M1$nKZBFX1^UU?Pn,1j]:NWn:l4r2\`4R]EtYu"-7\U69.^td!t9rUpuLYU,J**KR4q!XPguo@g1I^Mnun;3iuel;NR/p<)eBGI?thgbp&MGV-.2t6AcMjhpuL1[c-eIfmAR['^g!qq$c5^e:fT\OU+j9d6^ik;ATkPggS?-A8NI=#W#FY5N8)^L&KLT6^].r;5WY!ajJ&6TaUX%BcP@;Moq]0Abb*(+LJt6g+5ttB>tcs;9\%<L$fjXK[2&fKGdh^V+*I$F`^lk#`NdQ.]d%3(V)i6KTT&*B\(_lP:07Y/F$JHI^;1%4bF4/'G[EZ]c/&9W\2HE$M2eO4W4GXbKsp%aq4?\5md:^8l:)IE"j!Q5>'G(@&+Q)AZeKT<Jlm4#4ZAH-lA`+1R)LRZJiou"jnr(^YEM073RW+oL<NaK5F=#pe>"GB))3TH+s_e.Tt#_W,5Xk/o\2s?s@=Chl`cXbe$MR)&tXY>b$$/o=V.YI5dU+2BR3I<N,W;3;3nV#Te/Yp]S3*lKq'YJ?ai.>4unD'H]A&P$2eP%,6F??4q2FK],M1SH!f@N4l67NsjW6"plHP8]-hi@7I"S,*C4LmEmYc\@-P13Ss-ZgK1QqN4@@-6WJ+/8>F$J*su0FAHAX0rrSP@2+OPp<S`DchE5TtKRiGhgOh3IQV3#dS=Z8Oe\):W:,=&RRB!l1>PP>>'5!\;Y"tKuY:!42^Gf`5o3mBA<6E"`J,VRVEA3LYg,R`!F:;5U_eT&87rd(gp:IX=XI36E=7Do`ed*J'@"I%QDC+!8^$\bmo%MY]I+Yg^g7`QadusM=No*%'n't2p7uf!Tj/sYf><s*L"_$$j3:@3!]fn=0g(?$i#UlTn&1rY1`tlS[OeL#%erI.jEYeXB!bO-tRllX;N3ZVYbQlmNjs7KVYDZo:>%!??m(6cfm4<hfKrAg7B:)?!Kn?FLE)nR>e9CbY#0hcf8^+Yi;qPgO_bB2Af!@\oH!\&?UYpTCKnIe/Uics]lni4X+Slt7Bp\/gP^0Z;$M34(g^O3fTc-Zu\0tQ2*%@"7=0``nYU`!1rN\2a&-gVWfSqL>/IE>Qq.!`C_`JRs1Fu--(\fh'T!kO]'WW2]<5uVK=Of'sgu4I8NW&!]A(Al5r\uRoO/UgjIu.F-_FTqXWSAJT.N@6)g&i/$b0+EJ2l0N@Y34*S*_OZ"Pss'V]#,LVAQ>:f(1,VMMc/O'>c9[FSYs_Wh8\]u51++-Z:2,,kI\FuTUbF%)6^a'*S?a(2uW0p+cLj32T(Y,:d;*_L2%!4lH4>RW6B;IF.O=qP,NTZ-t<jF4NI<g$f9X@TOPUe.9!&qlte"c3UJJtmKH!&huV9j&512)98Rt@7\G_mA26)]hV6Sh,mXQ1B/&^'0jj?Dn#34hA5O0TlhM1%R2n9XW2p7(IL1S^5E"5jh#~>endstream
 endobj
-26 0 obj
+28 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1950
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2312
 >>
 stream
-Gat=,;/b2K%"?O+i+"[h3_>WK]/UeW?JD/X[rkCT6\,4B-Y="#[[bJ5op/s7O=`Qff$s(18.(dEa,_uIO_$e/!ipfP)8OoFI_0.+36^!i";*?&L5Ylgqh-YqHQiU0L!*^CM#$-RkflKrKn*%[e%c2AoEb1S#qdGR?jnm/qX('_jq-+RPQVbgJbeMhOZ+g.85<F33<Yic.XV`t%&P<dAK6u_h]#OnUGCF$NWX6TW[dbA[ulQ7eS=sck4^QZCTr/I6:rF=(IQCj.BBC@EoguijgsgC&eP>t%=raJU`>3RnPHS\bm=QnOcW-"8'_q]4Mh.Q!$2\Q80MbQ1JCCDff.jt`dA*2QboZ_YHc1-pAIC%BAeM4"s+M@J`h%d105HeV(eBdSU@&O#8]3h550oS=9,Dgq%qXm9u3fcR[:s-k=c:h_c4EGUn\>keBTYK;5;k>]_FNqi;4el\1b[26&u)"`sIA/'>c$f!s-?8/<gQ6_lWRa!+[5-OLRJ3G`?oCq'SP5#B")E(N6t+)$Z&Nc?Q`QVeM"nJ"T>3$q:/_Dc91@`2MYn?WRf8"[pmU$W4=7++DG?/5gK%a!=+K#PEE%qI6di1`8Lb_>A%=dYLP93!4qWRlt&Ge9_=JC(CUii6[3Y-p/CPSJ%iq^aon#%r<;H!dipV!5!UuR*jLf#JhgkPcoiW06hQaHSh[`r7B(8JU=c,-=$mA?1+*G'$gqg[sqFJ.ZSWKoQDi4$&&Ysm:TP&[Mk?@V)CK%I\rO_HB'BaC*^iFbk8k7bobp8lM=tKY16]LDq8X.g6RXU@uRP02f$Ama*"*h;q-^b.PZLnPa)1h"d6Z8;kP-YYKC-Nei_'&OfL4B<q5pTcL5aQrm>%H(dFdE?uFM5ekoZgRFA1g6qaUa+!\r1@ED]JnF>LUKP.>A^R389342sT,W]s`N.m&8q1q7MI^OA+l4Oh:'h*hq;3nMu?QCMnpVH#IMH5:*3l]P74B;8lS&2o)BV@1,7u3!K^)^jgo?8pZ%<m#?GL!*^cM@8Q8ZU&apDh<qb/UqpKhH9#M_,\j(3#t*'%=3c)\\iDG*K#;KPRT!r`Z$s[3j&+j,Ob[$FAR*'uG&r=MVdr`=hhj)Ij].rl]K-+$2#]IWojQndPjJ,@mqM,t;IBnUqM]B@Z-t&f30"ZqO>h:bq0`"fYkC1]O^I"^+a?H[IY=Uf&.69P7@k+_4SMJ20oO!U:+H;&uhLI[b2T4PQ^b[#4!O>[Dn?SWA#-Ppu5nf\;C`Wl-0j&c<-u"RGNKBjP36bfXUOJ6HHgg7j2<PV+q^lo99o9u8ZHo9[q7C6UDjKX]cOH0=M$ai"5[7)@R]^Ok0l_K8Ss'U.X:HuRhf>t1ll^@-0XI$#LOFZap8`c'7*(TT,7b1o)iR$<,X_?+V7"02ZJ,:6u)^_.<j`u).3MS-`k2P1Aq(p6&`nS`?_IC1t9RAS)<oJX'jC^ef6WWnGES]B8E6+r46[[.CRVYSMjF-I/":&Fcq_VkF(l%HS9fJT_CQJF)ddse*ZD]^oac'."M,=&-Zm>D*3M"jf)+7,@i[O3iR:?9TLaHm-o2t4j=4-;Ut@@!I?%;;,?.gcJ3Jcc<>i#iOE`.3F&S\sq6>4]ssH6ul*LMh)k5V?^`)FiR8>5?bp".!>M!V4@#`YGR>dtGq5$'<MtJTQHrJT.#j]ACASi(MhtrnL3$3N_Zq%n7E?CM,WbeS3d^FnO*blaNfHSL;&*$/GLorthQnX/%/JNr"B:P5pP46%.XCq'/Qtf`I8Og0BF@lEj_gpB8bI=DcB![qRGh:U&<e)aM*WC/[%NAbY'i;ar[EXl`nRhfXq.ODmeTZ[aufOt8t;b%cLl'&gapb@g"NBlQ0-+c.pGgU'2c/2,l12I]Xa+>ST<*0X@\[LY1$2a&,k'PN:;H((IRC<Eqqioid+4Bj+dq:83JB59oEn*(Hn`D$?Mj?F"'JZo~>endstream
+Gat=,D/\/g')q<+0jbE0(FtfIW41R@J>>boZtVIY]dRnTY`PulX[Jnr'XcfYf,lD<ZIFl/U^3-LR^Zp#c4">&:nYVh^T/@4C_#ne)))Ql2)%<!bcfu755B7d=MR'3!TCn,D?.WQjW:AF6ir((;%h50!&*mK%m1q=7Td_K."q7HP?K\rW7FU5B_=,75AF]l%13;'-a(cUKU`]*!Y4fAVA`*u`&dm-K+_1c$O,HJ!,!]1rIeo)b@FbX[dRUQ&+a.em[d&0qa<+jL-!LW=0YL.kpY=%9(ukQLdLAr5WfWU%`Is`,[-jQLI1#l7"";jcP@$S_EomY*YMQL_QRh$0\$GXhaAS($[a(J0*5nf2&84-I[nJs&)<!9Tgo:Ii45@GbS>nO)9aGb-@\e%N=-]!J-X#&/;.%&o"juq;fHKEk)`^4S@JaR0GSO?X#NV/b.5JK.[3^l0>7l,"9F?A*r$;NYQo`qI_t$lKJ9#&T`F(L(ASA0K<4e!.*+]a&TInfoJPJgkFWiA4lqDfs5Ash35^9og)7);jtt9Ni")'O9V<s1`AW?J6@oP.rdG#j<^L&n[LcO+qW$`_cXW@W:RG`"J"^%!gd#\AYp/44iOZ3T%C6;B`t*OTE,MGK$^7%"V9e[nW)4PfCD@/:7U[Z4_bnB8o\Zg=qdNg8i'3p&do"(8$K&#=Hl?#OM4[W2NZT<P5B1r,pt>I-EHL1T-hjo:K<3AuR1%:,&*s/F"l8bVR^k'@]SL_.1EFXa<lst"guTde=O==F@Cb)A9UD%"oL/Pd_'FZ"J?gM!43kQ:&*p=L_r]GA`>Di1[@#gPZZNV*Mg&ZeXi,F!`Att].T99#as>Q*_I?.0ha\FW^a!9M(7!`V]#I>0b<h5>D$BsG;oLo&oRGV)MTH7c*V*8/AfW7A>!/q09t\C_ohhs%eiJgK$D0!>`c,+Lq8I/6L<6`M8lb65(^gl.q2C@l^=p15Psu']AQ`Ge'W";Ob-^;`Y@A-G!2FWEU#eD%:[p>qVlGB'dXW;<`gckm3,;OTNnJ0W]=Y[r^3jqGcc8:S@8=Ar;!(S4L=HW9.T>65=DBDG6BrIqXHFND5HF]1<8%P<0&?rbMUk$1GMH&g<a`@?\3cRl+dT?O?*Qf*M8t^`;"RQ<d>p@?@=EEAEUk+U+X:Z)nOng`V=9-N+3pn2#ph3/aEX,H3h^*.KiUiprm(F]LD'/W_aiLO4As91/>fa'cOo`J/4#`.^];mhQRIom#NiK-[jprSL<ThPSB'aaDl<1]kH$Kd_3b=jo2KHu1OG14Kd=Y6pHquGQoHlBD\,_o9NPG_YaEiBk<=4n^M%+S(J4-$jAq9Rk)D[9X;6,e?CR#r\<'<bgF/.[4&MH%h_N)kq)UIY/%Tn6)6]K&^Ji,BFfnj"=55"Cq*!T7Ej`kcRO[r[W<Q$BQ>gVe=?W&:QtfpD&lZ<\"S7)P]Y^5<%IOi`JZGta/m/+loVl#`(sT@.1Kka"d*.lUT@aJbmSo<J:FW;TXK\feYa?1fF0jon39HkCo,M9)X<(F\3_B6O^?Q-.n7)6%2H#ND\,9T2XYWo^+)5lg1p?Ar4PnSs-7_![:q8mjDhoKWqNn0Wn6tb/1fgQ0c^02A?5qIl:>Y8pQ!I'h$NG\\9/&=[.nAF$P3m<A?LCN1S*X[Cf/$/CKC?6G]o09f-/m&9Zh_T-f__\2P(giZG?)P+B`d[$lI;7_!@&!@6)ui.S':eSS]1GdhKkGeV.g1l__Tf`7L6_Bq&9Q:-`L'$37oH>Pck@J7[EQV-gY(5b5'rT6WTJt[0[kaWH\)`@2#T!%#at1NHoK'V@!2X@;u7pN.JLCmon"Cj)(*Zofgfd\"=VMk"CcsLa(<Rp.=[<R;#@l,T:hOduX2nB%`;o0d-;:1o+tHq]p03@9Uf;M'$,m:9mAFbDm8F@$kLqncgelZ6Qm^(hVH`fDpY/[\Rkm,!:DF#8m@@">N.aHM]DOL=SIC_]a(I%>Jb?3%WARjt7Qu[qP$`Nf7LR*d'i1B;Zm-F8JmtLm]1g,kCl[GC`/UE1(COc9[((ppTMdZ'hq^S[P"L(hFD_S`*,<c4J5GW#g$1nuYr[cI:V;"E&];3#C_j-.B/9'%"J!#rY8#6%ct*q7]W&Fj\HBD'#Jcl8lA@4qTb!@&6":h,[FiIo&44]E;,/=D`.9OQtu!VK?`3qi9t<kq:pm"2Z?]^d?lX9(O$fH-MS@/J11kIf&E#2_?B>!Mg%A=^,Ob0e^[VCE!RPPRs<]fc8I7ijQ%&BQ&4L*[oD9.uPrGq:o6!VPKtC5iUIU1lSnM\@n8j3kje+OX2q&(af7fBVCFg~>endstream
 endobj
-27 0 obj
+29 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2219
+>>
+stream
+Gb!;dhf%7/&q9R^0eWdAMhil]^\=kDG'dMjLU?S05[e%d>@WM*M9_8`]Zjf5(eU*Z-B<-Nmbn_mZ-;0?k2X[5T>Vn+&@haF[fC=^nFNh'\:DO&Gg'W!>f++lm&q;eR7Q<=R"ut.A\dM.,[dX?L(JAHZ7O3U8;`(W/4h#EN9?^`6.l)lo8WtghJ^L+_(Q&i1DR%d;/f&0Mc(]@(P7?\-=G6<gnAkeFRkJ"2&b_&"s=0OhOs;l4doR>En.;X=0VH5(-drMM9@kQ=j0>4d&0mHP>:Le@.8>Pggi'rM`cq*?qFUV!a(VA,!H-%#j%:A_9sKfah:*60V0XPLn$nR)Q3R@f;KZU2SDNpF.T5DZ8BinqG2;LnG3#VNu17g9CjEfTnOa)XPcs'r2kP9fr*M1ZOs^[hirtV-(O/&DP'/'8^nmd5#=9cmZXCa\:f.?JmY#'5'X3#\s:R7dD<lK3]*%*5!=]Hb?0m_/;9&GP<_+oB,lAi0qO,&*Wo&%?DJQC+.plK*4-8I"cK[Jr:N'6Q"?C2'B]m(M%WF7#p'gY#)bY6KQ?UJ*E$cc(kS_prd"`Tcrd^)&@-m&Ya&BZM$=__`PMGVinV"IA_/e'6H"KBXP\0"*#Wr)mWKM_aL0Mm*KUUW(;\Ec,XkJckFF6a>3W$kX4j^RBM^L0/+5RP.oV&Wl-I;g4V*,[V%2)6edVh[r+61d6Xk+MQ$Zul&Eb;(mB0_DXjB$3+8WY-s8E&#_]&3#YihWiWHP>f\Xg1ej'L=E=(ngQd(k'B#g(=Hb2TGM'g#P>irLLI"+7D%&eVgYNi?o@,`[!\#VjPoEPQf<*^4/QMV`>-1h71G@?HV7/O/P[:&fRLEI??>GWql-,?6iI6n&[j1jgA;lbog]/G*e"0YUlj>.JKn/pM$-gm.;Lp%3,6`[hm^(jE_\]<2UCe\`toL-(@?B7_c4JZ3i3cU9lt^2HiMlZO/bnM5tW<?YUiHL(::ArC<=*aF*[2RL/3B_+H:F"L@LYcBXu_OrMi.7=Bl:?k`G1AF1pe$rnKI%NhCpU"Lre5^QBPJR*t6&"Xl048a)4#CoOoG/D0ZpW[LB[7q\Gad]$*NI7JUGPRFe=J0I:b%.%W#RAO+1oOlgI?&YN8mPSdWcXdD#&sN8`]r;7L`F2GE:<]paL4?BrkM?VNJHqZ:3e$(-;[jdW=iROm\8HU,$O&:q;,.g,ap&C`9je*QT#Qkn6:bc<rF&\PWWf4(!O1.%hHkhOtf,Q^q:2i2!NBF28L+_EA%^JAiO,K/EO@Fh50R\6?;C_)f,)NO"#AScU2FI:V[+,n2mP?_cKOp!K+O9pOIM3aJF+9WgP^"NqZV#%s,\=Z*-YDMT6to4D(gSS;ZAI!%\I+ge1!(#oO741)4^;kaIbe=iR%G>F+uDKb=a2;ITC+Wc`GMIo5^Zds1;b*$KpW6cFA&WIRG[Q97I5@mmDSW\:D>f/DikVO!31eOp,WrBDbd^7#\K9_Mj1Ruqp#]ZthdVO>e;CO"F)muir9W,sP*\pJj"=n%,o%uV\kHNX73EF]7PgWafG30i/_-3q"D_Hdqh56>ce50S38mBu#e98d],J0`Dr]m@M&[D<nj7)5QMN^K5+),g@_!$q,fEl,4ppo;6s"Z;hiJ;/l]#9ZTnpJ$3kMnmt:)D?#>_qG)6JSX$JNY@gic+cW)<ui`(b^p.nKRE4S^ti>_tp8E=si3(CRN(dS/2^3b``D/OWrt`,*+(.r)d+<[DU9#T!MmaJ9YBP-_Xms<\<4%ej#g!WIud:EDY4loZEJSaeVGHBlf'LTk^*9XqKLLk3iF%V_T$%il1/eSH-ntG*QS,<Zt^skI/ji_8&S!#FBul,QCg<W:)rtWqH>'_4LKrKb*kGGE^B'lI^6]Z"YguO.)k4.6BB_fZ9sZnL/^YGktN`m]$*`=.9[dj[pHEi^r_$;8eWni!8j4=CUHB=Bc8-i9?+^IIgn%Ur]KJ-Io.R/0scSEdl?m%0I3j=MNQ$)*%*r70[;O+S8hWA4Kf<%?SjuV[nBp](4tA*e_BQ<on'l!guZ1''E]r(Gc!qP\;G7A1@A+-4Rg$2:'W.W*s9$AVNL\Fp:%s[tVq6_\r"TJm/tSS`sLplk-_i''f3s&sX+JOok71p\!:Lkq$C'k`'(U^]iihn'6I"#4J?/O($sc:U+4sr&@pCVs*DKXrQi#VTSoBlZ%4s6r8214'W2<3^md\FF9/ABa1pD!:;g/]`~>endstream
+endobj
+30 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1081
+>>
+stream
+Gau`QgQ(#H&:N/3*$?ZfU_(G5-tscIPGToEF>jf[QN[`8)V`t:PXA;f2IBff^<*Ug7:-rMOG2Xu%aU*Z#]Oa=nMtN=lN/_h&J,So!^\]&i[nIQd?fZG<$jX2P?J9XJq^*ri0KK/7j^2gH'TYr'.22H5RAbm+lEWa(X\UP+s6DsQL45MKV)J'o.::M,FL;b,*S10SOsSJAtF<UQ+m038X<WG3sW\YE(tNFhoVum>C@FPX61lP:qR(E-RlGX9FIgqF8!!`8mcd#G-p\-T>WLUB3aP+M9`X79+mZY4j^u@(+tb+Zb+8RQHTsgZ6Y(HR*nHnZ.9/[4X$;\8@9#.!DADIH2%mb-/QCnm"#8(1Qs+iUICn&bD"A7>D!I6?1]F(&=76d;OOgYL^`luCn0HuVSNltE[/B.I6?V],8L;mk`J\OP@V2Wm$d3g>uO*(jEDE@C8h\CJ%Bd0kZh><:Xs=Hb't>%#n.t#F1qg@m"Rrg31cg_F_R0O`UAQ<PIn\+J_j>=o_@-C87%u0(<Ca.LH8X(qGh/?\%"+Up\+nW+:Q_rF.X7C\&&&tq/7<o>ke1^4V[)B1$`dGBAn'mc95>\D*3<<2\]?T@h6Zna1\[R2KKotn(MnOgYj\H+ac%bg_3[!kMG%Qf7Q;\?k7ZupF`5q1Yaf3D<Ma[ebT1ODeiO<)si_=aqhJ$`NO,I\=X(a5J-`Km/?Mt^uTluo3[>RJ]MsS=+f7V`#GGsI2J[X6Df-nbT2d<>[EbG^-^dNgFpY@<sS;F`i<5TDMn4!)1(iO#8$ZE"SY..Vk0]&KQ0?8W#QUq6QC5YHCgub:Ln45b__kO+p]MtSs[_MYWUB,kkuRN#$U+^V-G.oB"*1T7Qs[f_2f3fDRY5uEU;t\LnbqI8[@+s>bK_7,U%8/b;%P]!+s!sG!gD%2;\13CGtDg\OG[2ErN^'%"G?0?"hieFqq$_a&`04SFQYl<\J=QlB#th>Hbm9CNls[D3ms[?P2#G^21u2nZ**V:&H^sbf5jc=)o7c'mXsgi.$dj*hHOXn)$Ma_.M#>HfSJ%EA`FP5.0tqo,+km9K^VL">G$3U;$_j1/&;~>endstream
+endobj
+31 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 1722
 >>
 stream
-Gatm;=`<%S&:XAWR$T"7&[<TMl7fFQ8Wsk%J2B!(?OR(E27Aq:E(MP26\"ubP3p>q',S93!S\6B_f'/$3QQ^P"kJ&s$@q.[HotoS3"2_#";*?c%]@5$Y9%+,QQcUM7EE=_M#ZTMbcFkIKnN;9dj,-c9#>'U6-'=)(^#CErQo<oF%@7`PU&o8%/e/ir-F9Q6,Z>3E=N<<KSl/7Y^jGTlS@SOeI5)-b#JWg#QTmiXPG+i\LOq*4dj'?iAD$.GhjC*,)V1a>\r]4g==@1WXK:g.cWR:M+A9uVEgqJ.0h%C:W3[>pJBiY8P-:rUN72H,[lO'J0uTVObfI4/l=]`\9gUp(lKU]E?o#YJ,P3D/jB$P[1C-=7#@]@$BQDY.1=,D],WGM5C:.kCW@agVO5Cl17#_OGWg!de.dK=W"0MVN:S%a%XeXR(W39u(i^V5hc67P2[Y6e1He)5a/JAlA)=KVk6@eC-E6'G">NP1TGZJW(jt]_(=>)R5U9oT`.53s)]s;."c+iY@8+AKf%s[J7g\Q2pM4lo5#,>Z(bj[r-bXquYU!aV!lI+`T4kSPUYlaWbX$t0ghn$:_U1>Eob;;E!^<e*3S"relN3qs>U+C=n-W+q;gm]u/X@nWdH85c;dJFCCL'V?FQ2"J.5h7>ds##9Aa?j\S[`!$k!hE;C]M@2\$1N4\MTa&S1e?61g4C7GA_A'R6iohfsrm'%nXf(-IK\obM!LckS=\H?Bl'9YTr[.UD:@(J1h"KQ+<=Fe_L_oO/o[hf#R48D=:j,0MId@fO!.[enBV5]"L!Z<=sK=!N00,PQd:g9=_&I_fu`u(JY:l_ZDE[TlRQW!@8<tf<YK(*)9-acI"KK[l.$^@Zb/)bPXYj`,]'sX<ro[]YS*NKI5G/(,5orj+s^YMgFW_Q%(M5f='BYb;N?gbWE2fOd%,#PgS-]7%9H;=h;aekb":]N_=3oclD3ddu*d)K_2(;%u#1$"MZe04G8P8^a'(@StV_!o?(5fTe8-_'QaYjB^B940uNR-em:E!CL8ri@S,KGPrEZmoU<2u16$6PgR/s)>[rNN&[_^n$WCX0UII%?Aq-rk&\WImo)\d9%\-Cmp%`pqF2_@`bh2ZfrE1e@I$:XmpE]\a_Hd3A^K"YPB>]D9c<68@_0t4t6eY&3I1J'2iUhSNH#TJtC+T,-po7cf:`!feI;\MG1\u'CPcs<HFEXrg5st?o+GN&mg)$(2./"<7Pk*(U*"H#OeYi)Mep2Ghc>XQG=GM2$#@n=^pasS"Vh&]XgW)>nrl7#gO>%$jYc4>p0BG!^pl`!Y5u=tCF_uY6q+55;Gmp+HE,M\D;+7a1W.Rb]<SPc%Gimc&M,oTa*l=h18WJ@7D/`ISr*`T)J"SUo#0ZsmiTX;'m@5G)Z9bFRq#MC).\e6rJY\,.R989<(lb+VaM:$JpQ;Us420eAqp%7<'Qt4BUkur<nbH5Fs.fK?#\`XjnWT5V%&<g-9cS=;dHLPe=\^h#/SLK'Dtm]FD#k%nV6$(>Q]IZbB'[HkiPWMKQf!bNeJN93^BO:O7/LUW89D=i=uO86''KBLST;,lK+#n#=^B;_TZYWs_+@Yd6$Md3996ZSfli1a7H75-%RskX`b68KI8t@;N'H.#T/"A(Q7gdQ3PpK:TA8(bO9hW\Nd9`iVK"!QDY/A_PJ6`->eb<Y+;4+n[-69sr1h#4]Q!+;]l*SPD`T(('R;r.HdMX+m">0:~>endstream
+Gatm;=`<%S&:XAWR$T"7&[<TMl7fFQ8Wsk%J2B!(?OR(E27Aq:E(MP26\"ubP3p>q',S93!S\6B_f'/$3QQ^P"kJ&s$@q.[HotoS3"2_#";*?c%]@5$Y9%+,QQcUM7EE=_M#ZTMbcFkIKnN;9dj,-c9#>'U6-'=)(^#CErQo<oF%@7`PU&o8%/e/ir-F9Q6,Z>3E=N<<KSl/7Y^jGTlS@SOeI5)-b#JWg#QTmiXPG+i\LOq*4dj'?iAD$.GhjC*,)V1a>\r]4g==@1WXK:g.cWR:M+A9uVEgqJ.0h%C:W3[>pJBiY8P-:rUN72H,[lO'J0uTVObfI4/l=]`[!P1l(lKU]E?o#YJ,P3D/jB$P[1C-=7#@]@$BQDY.1=,D],WGM5C:.kCW@agVO5Cl17#_OGWg!de.dK=W"0MVN:S%a%XeXR(W39u(i^V5hc67P2[Y6e1He)5a/JAlA)=KVk6@eC-E6'G">NP1TGZJW(jt]_(=>)R5U9oT`.53s)]s;."c+iY@8+AKf%s[J7g\Q2pM4lo5#,>Z(bj[r-bXquYU!aV!lI+`T4kSPUYlaWbX$t0ghn$:_U1>Eob;;E!^<e*3S"relN3qs>U+C=n-W+q;gm]u/X@nWdH85c;dJFCCL'V?FQ2"J.5h7>ds##9Aa?j\S[`!$k!hE;C]M@2\$1N4\MTa&S1e?61g4C7GA_A'R6iohfsrm'%nXf(-IK\obM!LckS=\H?Bl'9YTr[.UD:@(J1h"KQ+<=Fe_L_oO/o[hf#R48D=:j,0MId@fO!.[enBV5]"L!Z<=sK=!N00,PQd:g9=_&I_fu`u(JY:l_ZDE[TlRQW!@8<tf<YK(*)9-acI"KK[l.$^@Zb/)bPXYj`,]'sX<ro[]YS*NKI5G/(,5orj+s^YMgFW_Q%(M5f='BYb;N?gbWE2fOd%,#PgS-]7%9H;=h;aekb":]N_=3oclD3ddu*d)K_2(;%u#1$"MZe04G8P8^a'(@StV_!o?(5fTe8-_'QaYjB^B940uNR-em:E!CL8ri@S,KGPrEZmoU<2u16$6PgR/s)>[rNN&[_^n$WCX0UII%?Aq-rk&\WImo)\d9%\-Cmp%`pqF2_@`bh2ZfrE1e@I$:XmpE]\a_Hd3A^K"YPB>]D9c<68@_0t4t6eY&3I1J'2iUhSNH#TJtC+T,-po7cf:`!feI;\MG1\u'CPcs<HFEXrg5st?o+GN&mg)$(2./"<7Pk*(U*"H#OeYi)Mep2Ghc>XQG=GM2$#@n=^pasS"Vh&]XgW)>nrl7#gO>%$jYc4>p0BG!^pl`!Y5u=tCF_uY6q+55;Gmp+HE,M\D;+7a1W.Rb]<SPc%Gimc&M,oTa*l=h18WJ@7D/`ISr*`T)J"SUo#0ZsmiTX;'m@5G)Z9bFRq#MC).\e6rJY\,.R989<(lb+VaM:$JpQ;Us420eAqp%7<'Qt4BUkur<nbH5Fs.fK?#\`XjnWT5V%&<g-9cS=;dHLPe=\^h#/SLK'Dtm]FD#k%nV6$(>Q]IZbB'[HkiPWMKQf!bNeJN93^BO:O7/LUW89D=i=uO86''KBLST;,lK+#n#=^B;_TZYWs_+@Yd6$Md3996ZSfli1a7H75-%RskX`b68KI8t@;N'H.#T/"A(Q7gdQ3PpK:TA8(bO9hW\Nd9`iVK"!QDY/A_PJ6`->eb<Y+;4+n[-69sr1h#4]Q!+;]l*SPD`T(('R;r.HdMX+#^#qH~>endstream
 endobj
-28 0 obj
+32 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 906
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 907
 >>
 stream
-GasJPh/AfQ'ZJu*/'d09nkS@pTJ)S*Gk7Uk`&1PjC8D9Tog6k4c7ioFs7OpHCDYT:.\m)rk+(>>pG)di*+E7?4n-&$0,jp8;;OWQVGVf\AXRtkQuLL;!_d>TPQORZ1^L_;K-M2&3M&="_D(55Kb@)?66HhW?Y-RJ6o""JQCi7&dM6riqiO4\8uA\SaJEEP4,J!=<MV?-<NQ2ROf)$p+TUgcn='7h+"4L]Df2G`4[]#Kjf>2jOOVi:/Ymiu3HfDB@Q4()T_fnN`EoF"S>u_8k^lG]@q;8T5uWL.'Vo.1P[iYuF2LC`Elab"D7,qJY,R>4HthQH&C,kfWuY"1j='QqgWVn45S_N*L26-aP[oJEqO_spY-Y1qC\C`;r4'j?a,CQilM]$J\"Mkcc_.7/@Le`:i$28<n$YjSl*f=Y2PJiea*+l$\D!N+_H]5+EK1c'3X[>+"c:#<'DRYD@CaQ=R,OdD!pg1P#>YDJBN6bJGg\[.r)$-laCd5W./G-aGY4qN.KAn"_H=8f20_*&A)3;<H(6ncR!]"9g[t7f^%gtZUHcTZ-!^;d?a(r"A.]B#Ahf.]12aKW$KV;hbuQhFn:pYSG`M+$SbgIs:.4RL(otBC7sI]laG@+mc%<Rl#WFT#'F:>3[`;E@LHFc`4XT+/7keY1.e;86:,phl'H_4k+b*#]*.dOqcqFrjKpsR9p32.M@HdTK6=`'<c;h`Y*tITE?hN<s'C2KUWMj)Yj$,>,NV=I\W;!47ZTfB!LfGGDnC;C5boQUBKY-!7rT?#Wau;;%%0cJ*h2lA3.R3g@+1DR`I;Fs.SQ]d"PZ,k\\$,]tI8:oNhpV=?j:D%4Kkc$0Z!CX_HG;(f\VBbkqK%%aG+J(M9RaH6q\@^'[IiGq_cr"t&CnP%+o<4ZrcgC~>endstream
+GasJP>Ar:T&;B$7/'d09n?T]`Pkn9;Lc6.2+g+fJ-l+4ABtRoVV&YB0-N<ZA[;/jHdhDj35m#C.cHM(G*#rEoRm$8P_Cli/+]7&^BVnXT`+>3^c'Y^jf-Qg68gk(5<gb3!1(TC3E+XB(OdA(l2E+HaM*_IN_X4C?(7$@]?-\=kY!BS8/q#r^#T1[JOV3A4N,'q@mBMO*`jUp#?T[fml8SoS]`qf,TAfs,Y4h8-e9#?%^7]e;ZknnZ(oE#:cS\3/V`ME*Y63Sk+YNID>o$\1@(@o#"Ntjhl:93#TcsXhR5sA2Gf`:XdYIt1?qMATB!5ujOWaGI_eL?r!OG7"T'j]uiqKpMIk$%"R430ZYt(rB.tuFO]^'R.?"IBLVofap9ibG`$W3SMs1EC\Cl\0^R^sd,FD2"E@V,%HX0eI9h2\]Goo;/CX3JW6p1t?'l5>DcXN[LuYbG6]#TPUN%iH%8gHpPS>a.^.*<G?]8RN(28u=.8HH2+3MJ5]Y/ERI3?_eB3.FfX(+$NR>S'FlhLP$P8N]a?%d#lB0>>WeFa#E8%DuU^R#u3/4dPq/W7HI#T!PrE74L#aCNAe=6Fhhau<E9@;U&?[:j1=KPIe()ad<e*t]'nf"*n)2d@W]=iE4:jH6fU^gn@@t5Co+MK,Nn;G!Dbn2a]tdMQp'VcA(+0BiJ(P,GN@'^kWTFBo\_.Qe7#f#)gi&]h`D1-iC#_.$(HB'X=ntWIihIfQTh:@\ou)CB"f2P*UTg"Vp2P4>4RJl*7OC7?16p9Hlg/\D:8E))Ir/=**c-frI6c%>)pbOrpIh/6:)dKUJJprRO@3]1Z@_:5>g=%a5sdPJ/n@e5.FFmO"%N<MbifneM,UZR6lC`:\E"Y7q(u#mFe\QG1=otEsut9VF&f4cA(\(XNYos~>endstream
 endobj
-29 0 obj
+33 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 1876
 >>
 stream
-Gat=kD/\/g%"Q+U=7F\4)]G=pbAT?+6b9\;(;$\c!ZWm.(_haF]ZP7iP1QhNr]n4Dc<X@e6\.'K.In'B;'lAeHsk33<W\dCi:dT`N5K*69R$USn)8XKq.J]lR"ljhO,JMl0mN?46SS=(K+A:[^"?+i#h./\E>V!W4I.Z*#%@INdMV,.2KjL%l0L0u5Eh;DV-jjS08MTCKQGHU0o&1(-P!7_8LHacW6n.;)1^rci!abq*mnf"?7kJZo)]\7@.BCr%nqj/nc\"4d&&C"/R;6<WPNF_ggI63d_lYon3W96*5!udWTZVs64%KSoqH=G"(+.s4dLa-nAG]&,bi<1*".O`%UI#)YrDe<N^W6_J+C\>p>&.*@M#>AP_?c$'#K0G.1=)nR=b7qB(F8Y(V$8H'_Brb)+u)&T246mg4sAE8kEL:k,8L@_at:*<+W0g"8&&b[rLc2+cdk(=YfKii*jL\C>uM>NtVP#kd**Ti3bPh2T\2j,"TBip;pXQV'iAMiR%El3<gYaS"4TV<T1+9)P+Zn9#jS/_eGI/<.o^hlk]E=W*u8c5AuoZ@be3G^L3H+UP;p?r4HHa1hnua^L0#<:EF#\OM#*dGL8(>:AdB>T&7p]GNAem.1l\Kde&YXbY>?K5MbIh+*sII^%T"I=*K3,VUkQN$#09hB(ha%f(Q<#m:+:PYF-16i>*/#Mm+n@cu@$N$s71FTI`C[(/!@!1oOiSRC\p:Esm\Vq<S0TFqasQ7I/q/EeJ#%\_X80CO/*JRjpA&/.8#dV06P'1;fDo-UM=LN@pa-%[B'bdTn!%lc\Oe\jno<e*52:CkH>PKsN\lW4O/fetRaRI5A)o%A2ojl5Uj\"':2=e(aKi@QM-8Hj+17\jluUC#N6!qbS.89.V3dNLJ.YCErF\,SBOmD\1cAUs;h;q&".Mh`tG9b#S2$;BV5k"*5hqD5jc3$E:I1;g-R*V6r0a\3%NF>H(]-ZejNoMkagqXjo?HDo\5kc+:!AFN%=7$WT@*gHng7g0?gNOh2s)%EfBdPBmC>OJm5RHWj[IEBlfsU4H<qn-KJH'[Ub+qi.U,Y$*VkUtq3C7HaBOnNnUrT`V2EaCUB2#*lTpTp4]R`B&:Cbl(^F&"`[\rd`mjHe#_,/U+CYa,qZbc+j(G.>1,eN^<@HB^bGud]c&*<T[,1]Vk8a/nT;T"E@9UlWOKp(:L3i(2Wh@9HmkA>Q)hC*suAiigaC;Q9L=Lfl0hKpH+(!.`RHo3dLntUPtp!pHMMld>[%,b4GW2n[<^kSGlNjC'BZ@$(kr_b7\r=YW((o\pi8%lDsa$&(A#9@<)4`d]3k'BaSI2W7.<*,rHK<=JBug:WXX4SQqh0[D>d$X7K7Lf5dk;SAO&]k5-U_EBcQ,S$]<ZX./i.'YP^$]W';+L\F^0F]1SJ1qOf?[mjsKm(6R;OEmC6:nPV"#A5)o:%\ZGpNh"ppcLWm't;^dTcE%V2<@n"cV1Tdn8V%niBu_\]:m'QW(\Y>F`^=,h9Wi5Ari7$f_'C*eHeOGl(i;0FNb8Ar`Ud_pQJ=(P:LIP$R"bc-81YpMR%&VhkF9ub\EWjj\`[`X4&.MEh2JU?,>46'TRRWhq_G0L9@*'RNgLrVUbEdgIgQ=WhsnQ)U%PdR!t,ClJjbPQ>:DfKWS7'LQu"VF@^ORW>qD!ea1Q[\%SqZe(h,neE^OMVm55r_ViUYe!Cld_et8I9IKIrk*%$"9E2M-f01(N*&0iKaA<T;NR=[Z'`#jG6kdR*6pGmi80!G[G#%DELS79*0ka)pMYJ6FAqPYjV0`UXi(t-V1$HT+-jo\coQi_9"a^Z(Wum5O*[<\<8G3VB!CO4a&-i>I&;S.Wo^:28/N6#[^\=_%RIk(mPCEVZPX[,~>endstream
+Gat=kD/\/g%"Q+U=7F\4)]G=pbAT?+6b9\;(;$\c!ZWm.(_haF]ZP7iP1QhNr]n4Dc<X@e6\.'K.In'B;'lAeHsk33<W\dCi:dT`N5K*69R$USn)8XKq.J]lR"ljhO,JMl0mN?46SS=(K+A:[^"?+i#h./\E>V!W4I.Z*#%@INdMV,.2KjL%l0L0u5Eh;DV-jjS08MTCKQGHU0o&1(-P!7_8LHacW6n.;)1^rci!abq*mnf"?7kJZo)]\7@.BCr%nqj/nc\"4d&&C"/R;6<WPNF_ggI63d_lYon3W96*5!udWTZVs64%KSoqH=G"(+1L?5g'OGiAlN&lI\)NeKi.D!3)ZN5ZBRE?o"crf]tb\*kYi(PEq(U*T@7PRn&S93ED2cP4SN2j8_<]>u;cU6ru-aB/LHq0_</fKMtJ;T]VfG"5!j*_p0hV^cJY)5,k,\;auO%=&pZb`[Na"qM@O<tgW`I[g]56D((d"0][X[RgZq&4,RbYtt)I/Nmf2#`$u$l7iS?hX$KuXpfOIf'!89;`\7=)G[p:Ua#H[A@KWU7Ler7qK]t@''"]Mrrp<q+#V9jjQ@!$UJ\q&p]\ROGk)^KL#aQ?\Vkn[FlEW]p\^$]g*?WI;i)V&P,=A3@;^tqqWU2ar6XJ_n$UKd]t+T)0X]1291[eZFL10.ZF5>/DAQeHHd03"#e-a/>(hTlKn_\7A&(FK!bD\D[SYu'TKs%Ybgba=Sm*U"b\%ae[%dnO.U!A7QQn%Cc0\OH=juHjg/PVFAQe4:0""'QQ5R,A3tWC#D04a,Ff<f0OR<=@?!g>CeNN1PS5+Q?A/d?E/=a-$7bn6QYSItTl'm5=CA:ck;WmOO)n7AVSDKj`(Xq(1jXWT+d60Nm8IO.ug5!g1=CM;6D:E[9>T9(Q,Dgr+IY7-%,B]$Hb/]T*r<D98<3Eg9PQIfu)ONVNC.j8W=%K`QR^.he0!28'_VGNIgIf/*Sb;F=?5t9OD6:O_GWWppCY!(!Uas/'>c?oghA2:&fB2W9Mqg1`Cfm!:S^]1bJjc.Sgsb6aN<9Oa&e1oLKMP^[UO[etfPa`#ERgKq,OLf0/NUA=N>FVV%2DEF5q[5S18q9C%AboU/_8$2Aa\0MHLT]KpBUVngoK$!Dn14;4H:t,C];TQ9HbsEEX]6\5^S9iQ%g"lW\T>Jj?82uG;6]k+c)&n=P#=DZER&_[U@Qs@M/^"g?NV-s%rLe($>_KZ1N%#bD)4t\_ehu;DE(=e'T+b+(Z.'\c7M$Me3C$;kE_:OLNL3j7KNi<@`<q9DDIj=dH"UK>!s:fCccD<+!m7I[Ij7%ZB?pQ<n^T92dNS7%Nbi/?-1Q_@j8OIS0%dmc4GGWstZ;=e22%\X#mBjqQs\1>bmdNr.f*fVE@9?er@:U$*65j\:`s41pn@YF>lnUY5;g]/;@u@,LXGJB[=qKDH9'4ZN%@CT9%T\_"1B`TPo/XLPB=$KVOpY:76/H"Mr9K9&[2%j*:Qh@0qN7:f(_XeTC#mXG.p14-C8_lg0fY!s7S9dbpITOWGto@Hkh],tl.S6TKD>l\"41jQ?J:m>Nqr"dfq@92,f/s"uq?(Lu1Om>umkmG]oVJtT(rpJ&E20A6PeeHfW26FU=gK#eZ:c5AMcrbI8_t8R4;'3!@[Tn1N,AaLQ406XuUI2&V9'+^tXCcDE^[6/DS*#/7U0\B-3fOkU'*_g8S%cN8*d0oh?ok!R1nPa*>PcD-](X62jbP&u6AD4BDi@/FTu^#Q,+:1i,5Sh`7H-QH[<#eA4q'khO$Q.M:rN)F1`Hik/DXf4!/I:nO$PGu6W(A6T\'(7.+i%V>Q%C:p)(mP7C%])%N(p'JiFkaK/aj*Tm*-+D7L6Fs1M2Cc(m93R/@>^#Y%\~>endstream
 endobj
 xref
-0 30
+0 34
 0000000000 65535 f 
 0000000061 00000 n 
 0000000132 00000 n 
@@ -238,27 +273,31 @@ xref
 0000071391 00000 n 
 0000071597 00000 n 
 0000071803 00000 n 
-0000071873 00000 n 
-0000072154 00000 n 
-0000072269 00000 n 
-0000072955 00000 n 
-0000074511 00000 n 
-0000076272 00000 n 
-0000076732 00000 n 
-0000078748 00000 n 
-0000080790 00000 n 
-0000082604 00000 n 
-0000083601 00000 n 
+0000072009 00000 n 
+0000072215 00000 n 
+0000072285 00000 n 
+0000072566 00000 n 
+0000072699 00000 n 
+0000073385 00000 n 
+0000074941 00000 n 
+0000076702 00000 n 
+0000077162 00000 n 
+0000079178 00000 n 
+0000081582 00000 n 
+0000083893 00000 n 
+0000085066 00000 n 
+0000086880 00000 n 
+0000087878 00000 n 
 trailer
 <<
 /ID 
-[<f679c8a0d4254331594eb6cdd74c9f41><f679c8a0d4254331594eb6cdd74c9f41>]
+[<925506d20dbe107bae09b6163a195d35><925506d20dbe107bae09b6163a195d35>]
 % ReportLab generated PDF document -- digest (opensource)
 
-/Info 19 0 R
-/Root 18 0 R
-/Size 30
+/Info 21 0 R
+/Root 20 0 R
+/Size 34
 >>
 startxref
-85569
+89846
 %%EOF

--- a/docs/testdata_generator_UserManual.pdf
+++ b/docs/testdata_generator_UserManual.pdf
@@ -17,7 +17,7 @@ endobj
 endobj
 4 0 obj
 <<
-/Contents 20 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 19 0 R /Resources <<
+/Contents 22 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 21 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -27,7 +27,7 @@ endobj
 endobj
 5 0 obj
 <<
-/Contents 21 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 19 0 R /Resources <<
+/Contents 23 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 21 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -68,7 +68,7 @@ Gb"0;!=]#/!5bE.WG`8*TE"rlzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
 endobj
 11 0 obj
 <<
-/Contents 22 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 19 0 R /Resources <<
+/Contents 24 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 21 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.9680444cb5f21bac74f984ffaea1fb3f 9 0 R
 >>
@@ -80,7 +80,7 @@ endobj
 endobj
 12 0 obj
 <<
-/Contents 23 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 19 0 R /Resources <<
+/Contents 25 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 21 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -90,7 +90,7 @@ endobj
 endobj
 13 0 obj
 <<
-/Contents 24 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 19 0 R /Resources <<
+/Contents 26 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 21 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -100,7 +100,7 @@ endobj
 endobj
 14 0 obj
 <<
-/Contents 25 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 19 0 R /Resources <<
+/Contents 27 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 21 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -110,7 +110,7 @@ endobj
 endobj
 15 0 obj
 <<
-/Contents 26 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 19 0 R /Resources <<
+/Contents 28 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 21 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -120,7 +120,7 @@ endobj
 endobj
 16 0 obj
 <<
-/Contents 27 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 19 0 R /Resources <<
+/Contents 29 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 21 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -130,78 +130,112 @@ endobj
 endobj
 17 0 obj
 <<
-/PageMode /UseNone /Pages 19 0 R /Type /Catalog
+/Contents 30 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 21 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 18 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260513135316+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260513135316+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
-  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+/Contents 31 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 21 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 19 0 obj
 <<
-/Count 8 /Kids [ 4 0 R 5 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R ] /Type /Pages
+/PageMode /UseNone /Pages 21 0 R /Type /Catalog
 >>
 endobj
 20 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260513165249+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260513165249+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+21 0 obj
+<<
+/Count 10 /Kids [ 4 0 R 5 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 18 0 R ] /Type /Pages
+>>
+endobj
+22 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 575
 >>
 stream
 Garo>?Z4CI'ZJu$.F'/3lE.8i?2Ka-2DKac>Mp6MekLeN"IrGIDi^'g/*iQRfi"(+]B:0'TqK3M^=i\@-'gIuegNIb9,?Uo]ISnI"gM`R,=l%V7R6":*HGGmPMASs>+A*e9Hh?)S?TORLqSsZ5u)Fl%%91HSW9#KB7#q[+3>u_7lb'a\Lo4E)ENi.N$3\XG$Q0f1H9.?7KT)lMSascO&lk:E2\MgC[]`u/e>-_r]kaOPYOb,,.2h/e4Rfg"B^Kp7.^U%;Eq7`U&%ff2W\];noH/TWPM.%5?+OOq&!M!+X^m!Id'eNa/V:%]1X,rH,>t>*6%_3U1G*)Skb91f2)846EIhNM2lrho:XjkF[H,+*O]Zq<k)pcKr4;L$"GZ*\r;tkHXZXHD*\ZHM\aO!P]I6XMQC6A4finV>.O76*?IuGifm2832Mf`>.bS-SjAdC0B3430"M$`9M519`Tp=6(O7cr`<(0<C_,E;ea8]I<N9!SUtp?Bq<-5\c]?51MC(S.M't5W\`km+eBKW)D-*jJWCPLAn`g!sK2nI_5E>]2Eo1sj'LdoZcp&<prW6e%fTl~>endstream
 endobj
-21 0 obj
+23 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 1346
 >>
 stream
 Gasao?'!_u&:F5UQq&M`ZR#47Q_J=\cl`L4M;,`I#^FeOAg3?I8Y><u?][>GFD'L=0H^H3\N;UZ4-T^MLIfa7!.J55Vmc^o@_%*3=cVSK]NNO/ba>>>OZ-Z'cU:fb`MY9Feh[Dg>&[O4\jFdY9NFT=9JB<O!Cp8*S>F"69o@+sI2>s-rnKQK+&N<.P%CJSW24#eY9]D9k(.pD<)?rRAB:`X*O&WGIsQ/16^aM1?XW[=bEjsM,[+N?//L'k(s_HO;aFWoE4!#*9[9rVWHm'F'm[\C=Ad-d5@TT2e<*,9au]ro>dDXX;i2L!Am&I&A]j[CXU0$:Tur(f9!G>>.j"_#6A\M,B'.#qCKO^U4NDsrPH5@!I_XIooB^es@s4$:*Y28V@YG@Ng>Vjj9gEbN'$aT#OgrBqJ&#=Imu7\$*aqE<hA$%ZNWo3'6L"=IS>p$m+fc6@W$cfmp+q9o1F>_#eN$aJ78jPt&S@aZ!t<8WL1M*\nOBOFaHe]U"Fn3Xo#QUnOn5ThEXu#88u]4DU_l%2\2EEl%3Z<Tr6rjb3S1k`a5_6JN`7,3IkY:u6+;*BSV$Qa7n@:#)4*P#q7OX!++M>R\j6LSR.7>;WP_@&jGuq(LiqQ(K,_\Yfp9:K%\7dmLAl^m_\q%`PjpL#f9l4>k8,Qt(^ij6^Op3I:o5NuqQ\M03qd)):J0gG7-UIiQR'=A4Y"`L?8S'DZmNGfK@e#D:D--1g.)JDepUouG)qXV_)b<ieYoE:E9`aZVppVFXgFc35,^@7/,1]a%_'S$ZroWC;@Re^JqmVTk^d2C8@=rWkS7pg.^,sOI=FLSIA>NbHf[;<"_Ba%^%DLCT[6lKdd*H&2a&<"msbV0acgZ[#GfG[FC6%"/HMq%b.>g4RQAb_Ie;8^g^hE!3BHK5*#&/0agmI("imHB.>q<<j+,5B!BFt=X*X+pTiI]^X%,l"'ppX,%M9B`mDkOYqdd3t:XAPI3P@Hr7'h0kc)Cb'45G*f8"94O7F53s%Rc3I7/kdp=J$dR*I0C`V*@=3a/;l9V4;lQ2Kfn@Fo#.HLKO89S/Gu3.BZE[UWrWtpi"^dBD\8]oV>aI">[I?=Yl-G.3#u?]/M29o7V"\\(c/o&rE`sh6,;53TF[2P.B*m9oLIbYZ4F-'ZaSDg\3LTDpLC!/$M5riP_?-OUV'mh``Zj;rb`*a*F'<-cW++ZAW47HI&q\Dh8.*4KE^(s7]f<mephdYjEn)5$ir($hKA[?=,JF_03G^n7D$?mec32h0faI]XYh-UY?6(X1H[_msEu'?mkDM3BJJkB6\2t!]$S?*md,k2PS1H]6k$/(!HS-ij6t/$2V^1L=s>C_lhY~>endstream
 endobj
-22 0 obj
+24 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 1555
 >>
 stream
 Gatm;D/\/e&H8h>E?F"GB#IbJrO--UdB-W9`PmQT^d(PWX[Wq/MONj\5EM$J3O.TK-k+2$aLgVAT0$P=+U/pX=UjlL'!;ue0S*d9Qlu[WO7:=Jq@XsA&C+0=KMbDV5lO>7fQG\/$kgT/M.H`NjbP0e!6#4:N596WhF9dcJMcSMOW="&n/o:9kIhTI"@5uu!g4*/Z\6-"L7-MmbEZ$+Y'$MAElJ1)k5_,XD;f]hFK0WhbKmD?ld\b;0d.+GKH7+/9@kUoRV$I1elXkn74a]Y9`]7"`WQk9,\<a14uh!fO<QEh0YnrrTi>D+6mBbV'*7DgXYnHS6GbEO"JA/e,kg+:OMILWUZUJt9p(N"Al&T-"JqKka*/9R7CU[2kR]N&$RI&a*+K:XrGp%-7`R1nG5Cjhi1&'l8!jmuZ.eIr?.kN=\"K00m[Q<Ff'SS;8V0i8&ci<)'0@o7+q24U#`C[)$kSJ>.PROP]\p5":]mIAU.O_Eoe)hV;P`Bpacf>hq1oPFd]&95_i:orXXXcaPs+nIh9W1J9O6s2fD5B7ZgJkC8u;ggZhPD%n)6"Z35G+c^YEMT5(tYZXQji^_TgqS9EV<#>31*5F\Q3,*:=,)TJ=gYXg6)pJ_$g#$M=fN@92RTEgCr*c-iEmQ]Kgf'/HrfTn!"U+\l</Bs0E8MEYT6:?<nAfL<3$]QiOo=ig33'TfQGLY#a+*+cI2G2G>dTB6N?;a_puUK"1:.*>.XmS@ojPPP>?mg80\ZH:@o]mr+J?4LN?IcNPs;@_W6QCDbll$6<pfu$Zq*^S46BW5!TI<P^2\G@2lf=u6Kh[JUmj*FB)lE1nElLF54E%r=PKjk8<>MYgY;[2TLA^c(@?tOm%>s5['h+U4bNW0o*q"tcD+ptreU*kmEAY>PL9JjHn;Z2NqNRMWqQlZNQ3+-QK^j8$`.Xc>&aDcYamDIkE%R1/ngG>YD-_tkTS;CtO^GPQmkobM?T#]KFB,^@=LN+4>@pu>,GOV;VBs!,egR+NR,+u%q(=^KKDPXe^3*9mEX"[hCrr?r3iL^W>U$nXTHe>:s1p"'%`cTO-Q,t(h%]fO6MdTD2I0\5I*VDOo>Pb^EO8XVKCUVs.;R`ip][L"r9=KDQgnuLoo3/Ebhd.h,^H/DN#AUB`k5:<#PR2ahPEY/hrf4m`^quNY>1;.u6Y:@'N/&;h#MV0GA9PU/Ug-GViTYP'0:7EI'Spg;hK5,;\)4h^@00k6>V5_JTXVVbo,=4(Y*U/j0/kQEi]BW#K&8pV^IacOe$`)@^2,"0(RH0UTA"Tf9R5nNh%"$](/A)4<7bZM^?]Q72R!Pu4]"W$Ccak4Fd9FeAQ2Z\?[Z\VZu$C[2q:+5mYlQB.^SGTUMLGu'6^8#V)TTE-,sf/*An(VBm%mjIMp=OTt8CSk<%`i`2Q!9j+R/hTL'jjWRTh"3(5*Qa8]5ge\]u8DmMd0O>15r>Od='Q-'_?UllIHdL$d@>/8JH9\^qdU4!\na$</Gme;(pdsu^qI(f<"j=jf&CBXDQN$B)J1\OLRb`<L/hi?/UK5VujrWa6>I*;~>endstream
 endobj
-23 0 obj
+25 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 1802
 >>
 stream
 Gatm;D/\/e&H;*)EF4I3"i?*1ok"U9d\IaaZsAi@gQqm@,Foi4''YR$?2seQUa=3j*HskZ5dkpuF)S^<c4hIYJGNp3!kar<Y?)DdKBWdm-QK!*i9bXYF[To_&mbQH4Jm*&`'%6)H9RK'5u&Yf7<o)/OV!g).E%ItS5R]>ZWA@^bb4I8&]luA'\l4)SNL"?+_;oo)2"G6'(Lps["YbR@k2!,r>[+u@?h$V3s59,TSALo/k,@EVI*a-b/"S7Ga]7?);g-([9X,D.s\"3TsPi1-+q<o\,_]],%<g#KGD/+d01nA4qo9u\1l:KE__LVk.l!Mo9?.Zf<ptjn=bSq;jsOJZBT!aqfW;ah#9L#^%ZM4dQE@G[#i4b'K"t,[0AgUDFRu'IE:tu-t=,d.*\H%T24.UkQoJHSM!(TqrY3a!QHif*teKQqJ"NZ'jT8u%\1&^0d+Y1Og$BjN913M.',lPhN%q:UFbRnP)'l&"VM78%Qf1VG[-=iM]?&BmZ;d0*Y#oU/D>0"7DTiK2"Jp;c5Dem-tO*i.i:@O<h3<u\j<96<_G8W*taGHF#9P%YZ=C+mqXN55m^hJO;68RPEO0/1k&`])Cnnq/R#N[$,!UK1]aS6<TKD`d3?f!DM87&^hP$PHbFWi)X\Hc5Y2CH39,tP$kLKE6E@+tK8(?TINP/7mpuH+bkI8rqrGf8j:_l%hV?RpC%4Eo6:o1"`Y0Gf\"\8'VNrhTVUY8@)A"&4"O<K?\@CCT7:T1f@I%hq=*A:CMA?ZNd\k)4%)9EK^3^/Q,8bM/Z<4r\H8d:LC6UOXVCMg^JRpDODh3I?kbmi0B^8TXZ?!E@P[:c@dH"hOP&-VM?`l8@$Xg6N(0^WDI8U:>-@3e2J&XZ@(IBTSQ_O:$>+G?ndI>+9_oBGse_8[-rd!o`s6KfuQ!ZAj@.cR.mDuq=#:c7A_]h3/$^=-8dQV/W_ZkPDpXG<Ig-U[I>ASUs_3:h=]/+/I&si.h%a3M2YWF,MpA9=H7;2K=C,q750Uk0L=j5lCk=65lQLhrT@0*ojGt)#X4iS";KHis&!.<X3<SL%$KTq3lBnTooq6CpigL9.W'"3L9p;#Kd.[]#)4CQD%S2Wkg/Vm6sa)m$HkUq.anq<mb.=\9HBA[;f)dY\%7Ta>(U+s'G_ZS2"kupln/fOpt\!sg6^hl6s=m?3FG$AE?C0ik7%LqfG/]iO):`H`/7j=dE(CaQL#)KEihiB15H#CbI0s(6B*,r*.FmOI.Pe6$r0!#Ji*!+4RTd7s26(/8eC"`qS*t!60G;ePC&2:O):ejCAS.5EiB>_uVhTQYapT]?kQMs91AT3)[]fuc"/mQj$!TYM[n7ZLTNj?Uf$;A$BeujFS3Tjg"Ws5V2X]O\A,]"NGB&%b!M#ACYILA)Xis.K&MX>`KRLFR-^I%*Xn&&i\A4cJNGgO^N#Dhka.4$m9:UlkkYs:=;._&G@`LTZLXA*OYmj.P?h\o_.DC4SV?#)=LU4kP#Htq/YEf6Yqq]Y;=^J-VerU+k^ROq.ts$Sj1rKUUb<o_@$o%7XP4uRl=W:C7;s8J?ul:P11D3P1T.;Cl8gmn*X/of:;[?FhVi2UAQea-CpNES:LqGXlUTQ!&1Eq/U!0tpU"-Po+8fF1e>XgF#8hOMq;*gmZ;K_+S)GYh.ZL5>$lEZLO"peLZM.>qd>0>]Sk!KY),cV**!7qeNhBu9-VPPHA!\f9>PY30!=A!-c1FHcaK`MX6i/pe!5@RD&b+:.UZlYt!4Ija0;iF^i47D7OCk1@U$.)j%Uop,e&iVTtc.bOW2!2G#DKp`t6~>endstream
 endobj
-24 0 obj
+26 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1832
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2170
 >>
 stream
-Gat=lD/\/e&:hOm=56<TQoL6Q.4H)<[&>c+9@L7f;$8R,ck:1GeVcdlF7\i*8sCm7EKgk9Cf'3K4\+=jG:%h@")5L0*8pc.IQo2F-nI;B(h0_^K#Md(0LI+YS4.rVo8+OhZJUn!hTcJD&/'p'*!X2'NbH33p]Q_@&C:bBDeG&=$;mQ7UX86O?pAsQk?A8pJg+Pu$6c5OZ[fnJLUg9I8YhLKCfR191o1EG4FjW#ddU*L[ERLCnfF*8XkJ=a-3Re2ZE^tj2758T=a4-;95Om=Ld`K\,=%bfQic9;7]^+,RhJsI+s`Zd"'[Tm-k[d.)Btd[-5p)IEiX^$/Hh#o5QD,o$aBT;"t=rqCKC)aq[jGa`sd"H5"-(Rg$r2L\$ODeLKVB'@4N&=!-(=lM"Be:f`2qCf5THq6Q4kKgV8>#K,^e$Y)Lfu7;\8i7B?]2HlaF6!K&iG"9]ti0G$4f#[GXd&NC%6+HB#=#bVs8ES2h_Jb]oK")RY<mQK[)M"j6GS\r4P_cq$b&DVNJ)fOSE)=0G7.Zdhbr)]b`>\=DpV:e.<JCuCHlg"_q,([$?`atar@?qZ99mb4M&9&h-W*i-)4\B"_oL[H3@J$NV-u'Je/sIR"E>8+5'Mg2*;>>IVp<f[FcMiT.T2$m`q"9N^E)NkNY?/nRnE->:BQPHH?OmeNP[eof\?LDXKHn3l30-VFre&qG3ZFZ)__[/V'JU@4<`cP$p\$9\8.8G?k0e=<1i*kOhP&HV2d(EVo8BZg'WdL%c*_kr;lu55RjheonuX^3W(gHkQ5hesVI28Ok(bsn7f^NqM<oM!D>(AO373.3o))']-ht_gQhMsfIs0G*8tHVZJiiKuXjr/K0?ro!-OH4$FS=Y]`SCZ+-aR(5/gkVLV3e0Icrp.H*aqu^kT,;_WbPP)A/+E*l?VbX\=NbD!X.O45.C*ocIYZU\T'$*ar^!s(2K]!o/=2(]gNbBGB\7ThT(]6LC[=>:7,M54\Rt3VF[8n6L$+%Q%<&<VQ>=/3C\A?2N4M\/YNhp#RU2%8O=eD-#Eeh7a%Mu-OHP#:R[:;bi<#0Ye7SNS:(Kmcig/.5$-1^>+K(Ii-i:%_oRU%@IIEKL=$^F;fZ:ITER<NAd8R+DKht0e\%o'.$R>s-k3,1>%U#pkC1dS<*\S_9XV:#h>?fE:[aS_*][YfJdH2$n6F/Hg#QZ0C*hnG>&;rf+tG1/5\4bG\=2FmV;`A9hPHYiPOdhb:(/Aa-a;FL+a1Ct7E8^Pq.S1)!gM3f@gcVVJDBV!E@p55bdJnQqF1$OF?3=T_Acd`jZ:Xao4[qG=H`uhP@;g2"84lCA^p\_pg'Il2U!eVVi^cp9bp<g:YoaOnlr0LT"J7oFd^a!C+E2+6*99\F#2!UUs0[HQSS^;ch.plLI5E\%dIgkZk`:k_Rk0Mb-b"L926n@Aa45ldGko]9@9LT>D!E_m'*)h`+UV3a!j4C`t%tqItV6cr=g,XfO6]RN[VahKGZG",6AerYe`M^\"PTRCh%'E`%pt;is&D9gR,5:rLfY[I%hQhjOil`fo>c3%(hXXfI-b7E=iO":_Y[WYeCMmK6gO>NVh%UTPLR=9(6MY?uU9Yh3d*,@r2n1[$Zi#V\S@;FFOL%L7teN<G/0\4H:1ojJ.N>@6=5dbeMiS5f+lH@1Q8*6`[aa>6I]]41Qtj)?!.cI.cX2jtK!uUEHmqI&q-UPglt?2g,NXR4Ge[rH-k]D4@i7_K!K@Y8K0`.nTn7'.'t3YnNCh'c_D>p7,t=C=5)tbJI4TmE.J*4KoHP8Rn02>OYV,l-fQA4,pbnH9k$*94!qUrOSn*hG(H[$+'X3O-E_P~>endstream
+Gat=lD/\/g&qIao=3R!5gr5*r.>j:oMZ^QBA<C3PVMuB\!!<TuU2@<$kYh&!oC!27;6mhR7nsX=#rS731OL'\L&hGbXSn\i!5C/Eob@SK@Bfk\Lk*GR>V9XGB8"5d&h+AE65IR+n2HEDY%KUg8/NX-9k&q,M"!Be&2M*8`kZ=krA8:!F%BNIPU,*<"8oE>P]mfM,U];H*"pO''etJ4"`pR\QRf!5=R0-pjbs?K!eB/ID;i1.GH-#oMm'A[$-eL3#q:^=>TB5K$F`s:0QgdrelXlZ,pH&sQi`+48i_t]ii2,ZEH2]a+XPRK0H,isJu"PU^_7=f.:bNkX]fLr`ZrERYuh'aV2-T"`;quHrbY[HhM3PB8ON_]&;?XM//3kX-/?a/c+_MY.8)^uR)^I]/:jmKI`Y(+'S;VaQ\Vu_iTf=9>emJIWmXXHpoIQNl8mB=2a/6*`%ah.*_V;l11FXqT.tRL,>?NF&O7P_;TXH2BW]HkTE5_&,`F2+leHj06((1ej!^]&E$sq`@DHRB:"4L\VCZ01qpU)$)UtCZ.+L\aiPE#5'K*C[L>RHp#$'ho\n5QS$CbU(CGP:*(nS8>k]Rg5KA-Firi?N`U?rWBVtuL^1S"<DP_t9oae2%c8]*ZQ0/q+OQo6Mj%iFGNdP+=XQQ*q?PD1=P",=_X`FJ6>(,)(^48AtO-dGi)k<1k`iV]>,%sNN_6_6MU:WHu]L*VXS2Y;L"=)(fsU[U7CL7H1:MatIMbSFCkh]n,#0Yl0;*%'tqEtI\trO+3#*j2Ya/uN*jeoG[$pK_3M^3he,lrCdl_rQ,De-2#QW[K_UkJ[>\:>(cF;rL<mc>@d.jWn3&,L<!6m1k-(>4Ya,mQ^ZhWUjcP#Ol'u@lJ/G\lEWhP1/<h6/]e9s'=JW+aT]ujkXAQa*2r5=9\X/ht/.pN.o)&.%4bGS!/dCoo*0@pb2m8'c<cGI(nd!?1jjBR$C/BB*Q#4=M3D=6*RYl$?G5bgu%#H#OgOTDr4;5H=]is'MoQA2FZmG/sS!rh)NKWDBD3,5K?=l"67Tu$,((HaES7k&pf6NKl9.o<n0o!8][(oTX6Ks\At^h?u^[CH1;%D+VU*RqNY*!BCuES&q8Z=0.7.cZGnhT]qAmC]si$A#gaa]$b(]#0%Lun^iJ;u.]Bc#Tf*DQpRNdbSNd$Hp;\X=e[Eu`M\YFTlK7,r`KX;-S!&"'h"SIe.VksYY_0&Yfqt_"h.*B?NR"5;pnV3@l&p,`*5:W4S27^$!P$aVKLJi#^?_0ACj"Ro2blL[I8PVt[X@GoRrdNX1#0W1W2u!8(u$+WF27+5Z"8=/>AG;06W"We&RA4`KC5#L`s4ji^t!tTl0T?0V#@!(E5Pt2R%j<QQZK4mgf0KHS*ti^ehI_?]sT3EAHb8srI))DS+`RWj_<#M5J!+\Fc\auV%.P=fUOhL??nQ79s#e*IIDlqC[D,BK6B@r7AY!f[,We%V-2Ei<_30FkV`DtnD=C[VKUO\82V\]rGc[Zr_c8!mW'@Hp_W?!UmlJICY_!NkI=`:rFaNsF0g20[8Z!lIo*Vs3GiQAIC!$\I\++o]c'ZEe4[k);g\_Ig(jQO(P'Zt)OrBY]e8j4<N4aqUNT]+)GEJ)_h3!_aYub?>dm.`mqe?Hn$W/GS?_`K?,e8)n7VFJcYTTHFdG(2j"0A<$p<tD(A;DB0jf;eA+90%&c`5H5@fPEZl#:"(n\m9qp1g>pLVk9KH\Pla.i'2%!0LpLaI`[;ob"+RtF7h,E_>M'n'CJ(5W+tAq+;&5@@mI2\KP?&B.-VfGm<,&I(,u;0[bFbsB:.0X05gOs>kF!$RC?j8hOd&W"gs*)Apd4N#k^mR:Y')Mc;k>]uSJj[5f0Il^F\$$eS],G$GgE&fQ&OHe^a"Hl50OWffC&KqfThT84nU?lZBJ'YcTh5*o\%YHMDI[m0b:"WK_\iNPiKkg:-X"[lpgC*d=^0IaWG,=N!fjR92AL&!i@^`Lrq%nF).9I=7iL:!hWT@BK2$'lsH+j33'`;kRkK?s,DVmU4U8'44(sk>[I,Jp"1of!nmdB+j/l,Z=+ml*Xa3\HuIp-k66]l.a[T@+E/(;:_UTlB#<N9;d'jF\M#+CP)Q)t:i;7e#NANp>oQ)&e`3E^>HOcM2Z*UR-U?@3Xe4WRkA\D**!q`jg[?OQ~>endstream
 endobj
-25 0 obj
+27 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2116
+>>
+stream
+Gb!;d?*E!@&q0MXR$RuH,3Fd4GMdSm2Obo,-Fn$kEe/h.`Y'5IF@b-RrV)5DA6Eg:lYM*"=BrYn&r4AmUR=,4jq'f]4FC0m^d$H?pRaEa!UD?,KI*jO$U:d1T,3IL,#([;,)LT8"/AYSJo)8A+t.]Snu0VQ/Q4"e1kV/O?>pAi@Jek)3#5<p^C_tc^DuI`2RGY9_''ICc@g^7#Sn_sJ9;AqO3ZA*bMO8gBVdX'@'p(2`M&!0;X\2k!nMk:qE&^Zo9No)9=RMFh)XTkdOV(o(3ddpfj9u/722*(d\Mg)YV[)+Ef-!p.4Bt7ARc(RZUBq[1?/OoK#L<IADsWaZ9cRo-fbTsGm5hGP!#K=FJ+/FY8;N-4t]u=Ueq1VUp4;RO-B1K%NZB-(7uBVAAtc%(HG,K0;.U&Iq5mY,?TXZl1+8))a4//YY6tE;eM-[&+.p4^%<AJL3KLa2p:=#73$Tub#IF>jLgi`_Vr#_nFM8%/BWkR=;p]bj1pEE6JgdrLEnKTS4DXYaRNH"=dI@'?_e=4PR;&;&k++%oauF@ab6CK-onSl^c&EE:qAtQTQSCjLfhbkn1DM'/2_Z8Q!,Ik37[IZkn3jB:0"TP/V,,QSD=1*K<7!or$j5.$W>S(TH]8H'g.P%6=9!DVIf8>oGaV=JmEU$+i`VYeYCWplDa&f<Qh9@nT,=93%Eflfeu=j=*"T3(?+p>Dd[5&6.P27b$#\8m(G@3;68\:<MO]@2&9`S?,XGs*J6`JQ#7SR=Td,O9$^;tC5o#5rjlR8io%($(WT.(ENDk*,M;MLRLLbPa5trrAWfMo0b(;FY2:f-n(f>4?+8hhN%QHSpi>"t5hHMJk5<T@R"$Dp;-_-:AGo=.F4bWTKA>ij>,a$b^0<u39118,h*7R5XP2(cSF&9neS.E8'6H5C7;Xm<$$`iTnUMO$7VNB5BD2"h5f[.PV63N'TnC.]*^du8]a&IQfC11V%Q/.c^@SSF<Z[LYgZuR0aHM1.XHL0ZmKGdXY=IpI_5aC*&2%@#]Joe.lV8q)T3(1qXE*Nt;];M"T"l>m%L\?@Ic#FYlP*O\O$[C!@k@2k(C]0a>#j"G"%h<UTl]-rks7>^?tFY\)d6o+3i<J?4b;qC&M:VK7QPMP[Zg^bYCpHAEe<@`a99S:7iFTU9O9hWbSuY&Ibq)##cFG3LkY4g<u.W"b,gp-%Vs]ZJX<rr>RHc0+J'-iB[(OW7ZAIk1,]Di$(DD8fQ@=Wfkt_;&P"";WnTUrp'qG)nZQVS@$#Ap"1'!t4<X1nbuXm"\sh0(oCC#NkGG##kY.b2m:H%eiakBR2idHLH`@4,:h-C5BX%b18L&?*Gn=p_r'ZgT2&=+.+W^hPTWG-b<jbrWP>g)g"D8Ph)sOEs%Pi[u/(<m4*T/nJX$S-b%aFU1\.n-&(srf7#J+_OdrnN"f<aH*\;V9&!Wd3^%UY$Ccd`Z.@UjcnXu2N6\L-S1"J*rb*7is&[9/W^1Nq\NK>,$8.:U5f(EEF!:(OWINYDH;j:P[\5e<YY::H",_k!4;%7e@/o-Jj/<YY.jU6l_%Cqc!BdmB5A(Qq(jNjL`L&?"QHF=[TQ@CeFRa3.q:_R)L4SCTp[&0WL;/j`>!8Prf-OK86M$bab3]c>AjnuNWXUV/PV2j3Lc&Icu8=],u+Sj"f<Iqqo2K7m4lU^$.OZX+KkfZATo@6H#B$.C_^=ugNOAfkVrBIi!"Ki[7c.EbhLTGs@S.O^NIKALRSZ_lS\8:<rYf<g"g52d)hE37od27Fc.=a=$+5iFQM/sY_'(UqigQQT^p8+?'_6GK_Xd'8q>GiL(s:?M!_pKiCMIs'hN1YtbTH_SCC,F6A)9@K&rbho,D8iPY)!_4<H?DP&k*k0PEoBEA6ct7N-,&8$OM!"D$r4H*!Dr^^'9Q+Y?B8&DX,XLnhqJ,,>rUo]?],nW7[Bqg@GYj$m3/9JNcL8mMDa\^qUA:-j>-r71*S'W2&Kp%'Y@ZX8(?NKbDC4B3d-k_W;lb4/W1-dppH)N:*/_>t/Hog0+L2#eV+64nAHH+5q#Aq$'3OVj+LM`QT*Ugo15LI!Vn_4,s#`r'PMLBLqd7\eVdEg;`'@8!Mt*TI//?4gT5?bC@.>=i3XIM~>endstream
+endobj
+28 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1052
+>>
+stream
+Gau`QgQ(#H&:N/3*$?ZfU_(G5-tsceVEp*:n>7]3Z9Z6.[&o<5H:_kbqtC9URgaXJoVI*>=W#HGnBC))!sJiIT8O2(=5iPm%#grbJk7.`rJD+cnrOEKo1YGm>RDfuOSIlSga_PS;(tU_>3*cIN:8r.&<*iF0fXgIRq,4:;3#oN.JA$)im4adq$mR\i^>3?;/f:/bW2[5ZXA0ZFjPW?9Q-F2ecBIlr8EXQBAF*0I?!M5eXMqLP"dDp,ieGXSSuB<6Y$#CR>l>t&kcb<:f2gTZD8HcbBPHH(aD%0]L,9?rX+im]TApgX8jo0O@lOXem,BennEe_16sGP>fiMUs&bBCbK$DChHlF7'cE;#O9nZS-KN;"iqMLlGt<s['t^-/k9OQ=^nMcPVJ':,OGpJC0p#ZGce50d=bI[)_o11K*cEt6n>*ZjC]">1mF@qoMdt-Vk0>N[lZ<E0Snk8(Bl57G(^D_Y%S*t"&i%7JKuu9a?aU*-R+:jgG[J9EhKUTBmD*Fq?r>;I!-P_q%VsfDm;QWSmd?*a5b+RNFl/Leh;[oj_G`^g2Vnta6Vr(HZc@Z:!-dDL);V3Kk='17>!I@QMDY""T%_\*fYU,/GGD-i62Xd3e/M>=?$b6KCkcms612GR%kaX3/%fd*+,khXi[5]C%;O?MO2a&s6O1h"_=TVQArNWlA%lCNl0e4g+EF`Bq6)o<aQ'-hlbVu&i/$+-$2Q;[ne\jl"1^n_3uo)P<)31:Bq2puOS:!Nc"\9>nkmG&/Bi;\nEUAJJ"f`O8Da^5N4`"IY/gf/ai<s8cUjPp>X>;E0e6Ck99:o-Kb>M>+U+'br?E&Q.#H"o6RpW8lbna(,2J3L"E*"08,].6f/]$a5"ZG:BpL3)C($?Hcqu=6</1OBrFU\m)6\E;1n1kmR>7JU`a?0-i6NaOm1?FB/$+f;LW6)lp"#P+cHuo3VYb]3Z`[Fg]l)4TrS((3U#)6H:"OQ-phJCVZ&*CYa5BZdY/pGm$,c^7>N<oIKOi^VaR2fF9/Z.4GX/0MH=e4nG(tjoAXWne2F6mma8JFH~>endstream
+endobj
+29 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 1642
 >>
 stream
-Gatm;gMYb*&:O:SS<kF;&[N`Oh$iX;057[[(7V2X2Zj(*d>h+1>`r8<0DY;F7G3f5-SDVh!6:Bb__X+3%#56*'Wh2U.cB=qn%UP1NnFJ-&:rLpc=WhY,Jmn2MA1`%J-@Z`qrApmE`@Z8@?e\eM%QU.iGf\X@"]hb5q=MCNB5*"C$1hGV"`'jrq+XPpF$k&:4e:C,b,Mt@ZFTFYuSg+d`SVeWg/mYdD08or*tu2?a=Q\q%g;@bhb@h")fB@LgXKS\hf%WV(J-^U=H9kG$ms2Ra</\#t7HH8/UnsCbWH],VFh97"#>n]m(_l)R0E-+b>G;eEqB%QO;,ZLKH5G7j)ds@d<s)%66&UNp:KR5t[jsU]M:JJ<Q3$ipg0.+/A;"?__J\&oSKUR"UDEaJtS"2?6H+l#=6)YV%h8rH!obI(5\PIDDBE#bRQ#<@Y%gFsl+T5rdbGTYrQV6QSaR=Yde0YT>NH)\Ek53"[8VASK(J4N&jokFdD4;A-ptq=A#9$8bAmJTLRGmY)DPW#-B=U'eN2AiGEpnj1(H1i!2?UTeFT'!#K<b+_p=kbc3AdqjY*;&A@ajm[X`CPmH&/W7gb8X=e9<k>hAR3g0kBH'='mM+tp@eOQU[^?GH[JF=^$>bU'*j^II$_1Ub_?`0V_K^-qeY:HVZrZ9);TmtY&9DfD7i(eB%m"+!H[F5kQrH&<i;%bQD@AKfY8dF];)[_BMr/I0?$0j.p<N*\pUT/mpZ_"\QrY)D9)%5RP#$+b3_jr[Tkm'Kr[QY2ehB8ofJC-5m/9NoHr8>#>"pH&n?H7o.H*7ej`RPEpO1@Io/c1uPM:nV38@k`/[I&G0&UMA6Bh@*7]@Be^_TX[=)FS)9n$);DG='uOCb%6+rRhU*F<dOWm:s/!YKCqf"Ko]osYM^`g=iTV4F@8bn7rK(dErBdE*6k_VTALm#*me4GI+CFE:M_d]2jZ/>UA0`i'l_c4Nr2.oerK\hRe1,'=aCs%6QRXb!`tW=6V(5&$;[WI/4>Z_c2E2gLl-f;4)+OS(bQ;5rS2(D2""RI_j[FH\.`Hnqdh[;i4[qCTC=JA-otj!/U%6$89+s&]4jfG^R5bA7Vs_Esj,9\,-)ll?tNElVOa8h>itRA0o!qU8;`<`I5']@,ItjmqXG(LQ\'l-&8-%Q]%\6SWYI-sTD*%-'=$K:'A*KnCg<C$#1qJ"1[M^2Aia^[b1EEDRg.%3?TO[@YE\!7B*1F*K,'b^2C9O>IF[0"R?jhT3@q4F;bQ@u9XT.-b)S^(EE<Wla!nD8mB)jqO'sEiEV]:6F@FO7SiZK<CD(f!;qIb'6reb3C0,^HiA+.'nPY+K%<f8XUNE6..GZU&ZH57)6b'*l2O^2uue007SHgAoj%s^:g.T91j1pnVKK&HC=@fR@i<;<+].El1adhIt!t!%\*:KknET/]k`3pkkM.Fc.$sK$)Nls\Zu1R.IA[1eor@U'G$/Oc(K$5#=71Ai4noZ_U.qkSSnDZf;ZblBj64R93!J+VU?,7)CM/H>+H'242DY+mA<3]O;Gq%ijs7eqie9(C5*LRB:1T*ZulJk>3anPFl,kH+!6k;rkLmQ2tOK`Gk5djE;RK]J:q$C8MIX[\=`1=nB;>Mo@Vgn-\E]M*'$:A7i;10)+!+E~>endstream
+Gatm;gMYb*&:O:SS<kF;&[N`Oh$iX;057[[(7V2X2Zj(*d>h+1>`r8<0DY;F7G3f5-SDVh!6:Bb__X+3%#56*'Wh2U.cB=qn%UP1NnFJ-&:rLpc=WhY,Jmn2MA1`%J-@Z`qrApmE`@Z8@?e\eM%QU.iGf\X@"]hb5q=MCNB5*"C$1hGV"`'jrq+XPpF$k&:4e:C,b,Mt@ZFTFYuSg+d`SVeWg/mYdD08or*tu2?a=Q\q%g;@bhb@h")fB@LgXKS\hf%WV(J-^U=H9kG$ms2Ra</\#t7HH8/UnsCbWH],VFh97"#>n]m(_l)R0E-+b>G;eEqB%QO:iRLKH5G7j)ds@d<s)%66&UNp:KR5t[jsU]M:JJ<Q3$ipg0.+/A;"?__J\&oSKUR"UDEaJtS"2?6H+l#=6)YV%h8rH!obI(5\PIDDBE#bRQ#<@Y%gFsl+T5rdbGTYrQV6QSaR=Yde0YT>NH)\Ek53"[8VASK(J4N&jokFdD4;A-ptq=A#9$8bAmJTLRGmY)DPW#-B=U'eN2AiGEpnj1(H1i!2?UTeFT'!#K<b+_p=kbc3AdqjY*;&A@ajm[X`CPmH&/W7gb8X=e9<k>hAR3g0kBH'='mM+tp@eOQU[^?GH[JF=^$>bU'*j^II$_1Ub_?`0V_K^-qeY:HVZrZ9);TmtY&9DfD7i(eB%m"+!H[F5kQrH&<i;%bQD@AKfY8dF];)[_BMr/I0?$0j.p<N*\pUT/mpZ_"\QrY)D9)%5RP#$+b3_jr[Tkm'Kr[QY2ehB8ofJC-5m/9NoHr8>#>"pH&n?H7o.H*7ej`RPEpO1@Io/c1uPM:nV38@k`/[I&G0&UMA6Bh@*7]@Be^_TX[=)FS)9n$);DG='uOCb%6+rRhU*F<dOWm:s/!YKCqf"Ko]osYM^`g=iTV4F@8bn7rK(dErBdE*6k_VTALm#*me4GI+CFE:M_d]2jZ/>UA0`i'l_c4Nr2.oerK\hRe1,'=aCs%6QRXb!`tW=6V(5&$;[WI/4>Z_c2E2gLl-f;4)+OS(bQ;5rS2(D2""RI_j[FH\.`Hnqdh[;i4[qCTC=JA-otj!/U%6$89+s&]4jfG^R5bA7Vs_Esj,9\,-)ll?tNElVOa8h>itRA0o!qU8;`<`I5']@,ItjmqXG(LQ\'l-&8-%Q]%\6SWYI-sTD*%-'=$K:'A*KnCg<C$#1qJ"1[M^2Aia^[b1EEDRg.%3?TO[@YE\!7B*1F*K,'b^2C9O>IF[0"R?jhT3@q4F;bQ@u9XT.-b)S^(EE<Wla!nD8mB)jqO'sEiEV]:6F@FO7SiZK<CD(f!;qIb'6reb3C0,^HiA+.'nPY+K%<f8XUNE6..GZU&ZH57)6b'*l2O^2uue007SHgAoj%s^:g.T91j1pnVKK&HC=@fR@i<;<+].El1adhIt!t!%\*:KknET/]k`3pkkM.Fc.$sK$)Nls\Zu1R.IA[1eor@U'G$/Oc(K$5#=71Ai4noZ_U.qkSSnDZf;ZblBj64R93!J+VU?,7)CM/H>+H'242DY+mA<3]O;Gq%ijs7eqie9(C5*LRB:1T*ZulJk>3anPFl,kH+!6k;rkLmQ2tOK`Gk5djE;RK]J:q$C8MIX[\=`1=nB;>Mo@Vgn-\E]M*'$:A7i;101i(r7~>endstream
 endobj
-26 0 obj
+30 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 859
 >>
 stream
-GasJP?#S1G'Sc)J/)JGZFiJV&O`5r-?jHlJK5t$"H0K#L9:a=I./Wb[c;l^?LFT-8'>N^UN__4A_'/BWf`Nm.G^:tb,Z\+T`=uAAn7ktY'MMW.<=L9T.7su6Y#6M2$4i.hE+XB,TkhoKeHVjXU(RNYY^KF1@#6r-E`V#X$D^JMV>Cp[J<?oi;PK>;EFgFsHRp?MET<ejZ6N/]`BF:"VnhJH!o?"']']^%Dcf.oZ*Q8u$r]KmLN,[#7i0q:T*Dmp6_(8iWigSLK5">,$)Y,3eNIDW:6cf6B'p@F[:H+9D+"P1Yu2HNEifji8$MRl<XE1DQo3%WoUQ=]I!f5pUO?9$;e`D=LFsmR7B(b7fATYJ;;;l+Q;uBX.kT4:<+u"*hQe"Ua(a[0gEX".gAQ4t(n:iB)9Kqe(2(N"D/_5XOLd>X]f86g=J*g=/fkR,bA&W2JJH]D8`3DN]IfL)gf=bUF&<kW2Nd,3UjtU-=gQQIPW.:pak,&5JaX[J+6eZXDE60ofl"85a>\cFM?b>d1iu8e#Nn#OjLY9Tq-U7b>\_QLmdWdaV4K@D"O@oG@7[9'<=.o?`H`Q0Tm]-V&VFkIlZ^O2deY,uY0.KK.FSr#fQKOXROo]e1gg-g+fqNIn3*pAqqX-=BR8Q4nAFg'L8U1Y9mp_sog%-&hi(9Vg!NcB4*Fn9)+3;(ZscLY\M)^?5JVQrh$u:&LH!_i6^j8d>SG/ihBC7SUF&`l0oYatro2:[X.2%8(Q&+*e$>K>^q\a^qkZVG9s%K@k>@WP+LrbrI6L@j5LRAuIQIkMD1e;der-jFD\2drnk1fLka&`%]@Q0$=J%^n-__UQRNc(8'sg9mG9[ed!>"!th>~>endstream
+GasJP?#S1G'Sc)J/)JGZFiJV&O`5r-?jHlJK5t$"H0K#L9:a=I./Wb[c;l^?LFT-8'>N^UN__4A_'/BWf`Nm.G^:tb,Z\+T`=uAAn7ktY'MMW.<=L9T.7su6Y#6M2$4i.hE+XB,TkhoKeHVjXU(RNYY^KF1@#6r-E`V#X$D^JMV>Cp[J<?oi;PK>;EFgFsHRp?MET<ejZ6N/]`BF:"VnhJH!o?"']']^%Dcf.oZ*Q8u$r]KmLN,[#7i0q:T*Dmp6_(8iWigSLK5">,$)Y,3eNIDW:6cf6B'p@F[:H+9D+"P1Yu2HNEifji8#YScX:iAg0Pcp7krTWEq"VGi8,KT(VUA^X%p_e.Mc0NMYJ[9tU:;Y4/ZYa;<a)ASW6jo2]k'!5Nml4?[RXl;[/9<r0K9Sb1QmgT/^B)$g>HG9+a%Y;H?"CWYs+RY>s'78QIT/B""UAhP/*b&GZuk1\?-I4k+Xa8Ca.+E8-+(9Z=]rp.;uNjPHUtI"5c=t51109h/]CiZJBCIODbDk'G!SQC$:YU%aJu(aE@=1o=nHN\^[-"h;aPM8j-Sg#bEbm_N7H,WtNh]Mt9,?6i2=7+pQZqf'enBV=d2t?'cou;l1q&YjHu92-WHUBYO1W6WcuqiHngbp:G*XdIb/Hi.pF-$r80<RekIpl@H**^DWO7ZD4DcG3lfQ15<O/BZ#o;F'l@]It7-n],bS+%r\C\LGUMS\0d5[]gJH07noKb@i4GrrPbH@=#k&P/e\&2Ve%l\J:G8EpIg3nRTco_cD*-*5]TFmqg=i_I\_SsrH8g$gBKSSX;>LkhB;MnjHjQ"cn08)G-0*&Ys*Gf:II5,2+>/O.qXRdmm\^S!Z2M\hu~>endstream
 endobj
-27 0 obj
+31 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 1786
 >>
 stream
-Gat=+gMYb*&:O:SbYsW>$!3qj>P'(5PAYtgF0QPY@\@,jZ)iZm'p=I7^L'gE//]BsD%OLC28_4_Y2W:I^]W;>AgP7U)>nJ?JMNTEJHdBMfeo;G-BAg,@ho7t&/P&jO+GqZ(4s[V'mPg:O2P?;6^WU]`F/m5,rD;0'Z0FYU]k@l[^[AM[^[%<T?=:kZ(MX_i^\qn_AMfpR),kW,D4]$\Dc=dXAEm]'u7ot^cr_Pr6;9sMt\q&$*t-XG(:>r&IBinp>L+%)K#mbSLCS914unY8/'<FJV6>S0d'oGd\,W6K9KCZ;A*hP(t`:h5gkH8^_5W3;%U.DDL%8($n]BuV/ZV`Ne5oihprp&qlc2ukImLN-jdQe8dKi7;X+Mc1BGtHh;iR]$X)I!`@N>ZV$U\olR<d7p>Db.C"#FRhe`"ii@'Ga6>FcqB#+@_cYa_d1h:S/0hhk,.BFm2XsSfk?CV-`6B@uU"lf<aITh77!^@u[lrcI6du3F=3(+jf6pG3Flj71V!o-dZX5eO[l&aBqVq_-F60P/emZ<co!ja0KI:*foj1k\B"#0=9JSCSN5-TGl$607g!;=Hs8*LtUQ]1)[H:-tL?c_$g*pjD+pA^NnJaXuR*1<KM?_28e$ONT0=$;&9"g?V\2`P62]tkh<bpIS>lh#WaB!Tn0$\<8X!kCdf.:,t-B.O5s#'kJ<QRDK2K/TaO9VW/V$Ds^;pp,GV=;j0[gWL0=43b>P7Fo$Z[n>e?QXs%UE*4&X9:hhe<"DAc-T]=Xqo1V/]`]Q%YSuQ-eXp=%W5<B/!B76I$@%l1f%-^$+^>b>_u9CQ#,eqs+$j<eG_WepeQhFJ<!sY<XAK$S/qcDZ0_AP$B.I<M-tGM2E3%kO&2FL$">0gj_bHmLCLOTF>X>'+K.oMfpt-8f2;iQ#X2QHa-=f;iIukLg`HZRrAW0Nbfp%KSVKbG;&984e$>pO=ZDL]DmGa?&C5uUIS'"!UauYY0a<sqpMXk^a4]f"'6>Bc8;e$fV7qO:,=tqOFT]GB(pOV<B10N00%5)%;[$Kuc.HHqbBCdL`'BZ'rpb"KI%gS+AY+3frRD;o%fQ$3eb_d$AWFX\:Biuj$J7i_l*9I!Yj`"W3NWL'^696$@#\`9K]06-d1#"pta(2kMKok[aKG(h5'UDi=pjm]fkniA=i-pc#i!TB8'K)mFMHf1VG9OV;mt4HZ73f&(JeD($gU:pO.;H-Th5feb2cpgs%lU;uYZU*^>8^p-[^rAE?&$4(BtM-f1dAQ:D?o;YHuALb33W)fJa+)L7]O]fbaB7gN^i<Vp?M'lKL2SM:#7b+2K6pA]P5R/p>9BW9Q\TsA6N8u>\,G8a+,E_G.@Oib^;IbT7&pe6n3BQC1B6?Wmg$)I%%%/2K89*ikm]hgn8T-/Ysr-Z(nD^A;<$+gI*+,:=tP?>`;MC1_!O+f"i"9NUu%NNoJSUQI)f]DHQEA5pJ"4M`'C*)jWqA%JWsR)cJ]5`FJoO]Ih<6kd%>U9kAYZCKiaK8CopW5K]d"W,#NfZu('UJs8jSPSHa>NW+g%Gdri?Jc<8M*T?(DDq"iR*@pp;@$RG1:YYk,%,CJbe%YA+LIsK#C4L/fJZB*2T<Bh@`/"$Rl9EoMlqb5n**>,1a6oIE1/Kt2A64P[aR?t3JhRmaa\HC@Jq;#Bgkhb5:DCA4Y.O<:76s_e?L<Llf$gi^qLOI"4Ui@GTd]>Cf^&B1'_XBMV0j]^HQ)T14quD97^C&Ykt+9i*29#kYf@k'`*kk=SbY*b`F^Q@s*(HJS)iB.-N=,*+tnW~>endstream
+Gat=+gMYb*&:O:SbYsW>$!3qj>P'(5PAYtgF0QPY@\@,jZ)iZm'p=I7^L'gE//]BsD%OLC28_4_Y2W:I^]W;>AgP7U)>nJ?JMNTEJHdBMfeo;G-BAg,@ho7t&/P&jO+GqZ(4s[V'mPg:O2P?;6^WU]`F/m5,rD;0'Z0FYU]k@l[^[AM[^[%<T?=:kZ(MX_i^\qn_AMfpR),kW,D4]$\Dc=dXAEm]'u7ot^cr_Pr6;9sMt\q&$*t-XG(:>r&IBinp>L+%)K#mbSLCS914unY8/'<FJV6>S0d'oGd\,W6K9KCZ;A*hP(t`:(,I&=<^_5W3;%U.DDL%7-]qL9BTJV[Z`).(mp=ib]E;t&YmG.G7&ga4f5RF.184riRIjSPa\XP]VFtlYFTpWeEUbmY(Hp)*EefL?g6u@Bdl^U]L2&sU)<Cj7&g'kLKmFdJ/P(kNJ+K!8r0ST1Q_UX=daGZ5^8EeGXU-K]jekZZM6K"c[O$/EaI!QC\%u9?nV<E]9LHT'^>CjCaCNY$n,or.0i,kH\1^LcOfcBXH;.,\X^CSP_?lV.6DZFD+-nnAZhZpTN7Y/J8%D_sfngJoRnriOu7;k_&n-bY2h4q[*aSnD',4PQ,*@*F?ji^#OH6H^]or@3$[GY%Hi<C[2Z8\.]YM#^hGb*^;`_:QEGp*ae;'=Hr1W>7Zk)@9p_&tC,jRU6<CX>O.R;!@%;8Mns!adhs!D<NMI![lj@Ad8[U<$NIiE"'*nZj^G*%iaoC<88RN9YtmkX5YYCgS'X\!LL`"'/o:[e`qH)HE.64Q$F0;?>*!eCrV5.tjriEO\6*cJ\?gnfoQa"j^#SZC5RBQ>0h1PVl&u`eDbE$&2c%n8-(E*/2VW#]B<>#"%GpQb\:TD7F::A1`a`PUe/hD@kr#$6Pa(Ta#nIH+!G.e:c'/mgg%@Xr,J;^5PqS1n1c_g_<Ni(IG:`9>PJ>>h8O>Y$HF\?Hpm@A5aAE;->8e"Sm]X9Mlj+Woo959Lt-NGA<)sp;h'(>:X=)%?t*\kWVgJ6RKu[TYUfUO4I2l/;7=Bo5+DZGJ\`L(>n69j5If$`0KrI-5603+$4ArJQYho/<qd@0J*[/%IgG.PbU?*Z5bKu^ek(V>t@Hf&HRkrA[f^0.;&H)p6_p_W"?8*LJT2HNPZ;Y"$\Im.fEiS#2Ba[$s\A`Kq_$o7WGIkm;@UOm=c*D\S),S>u79<D;1A90L[S%]mDWMq$,#/i5*F?(D[C,Be*\P``DgJXNOEW/8b-jQKC[RaR-c*L<iSC%-JB*+]'2se4?u-L,nkB_pM"\fj<K?O&5$SXi\0ZeHW1%PrER5f`$56T8E!(ND-CROfN;PqA>=T`"(CkR$gaJpTs=dLIfCe?>U*@=EU)1M,,p-e-9f>=FBljN>qLA\YW7O2g1FnSF!K"B:Htpfa58FNJeAUSYkAgfK+9:U2g1ec;D5Xa:e?_`!n5',&"muE3\OED8WYm\cL\\ARk";\9[GUJ@B+c$XL2@]r>gd@;Y>M)X2PQk!th=$?[r$KshH:?'$fjR^*!o]$XmT&e>eA/'rdTW$@h&nr6hGZ==%[)ltg%q.\U@L4PhCCt^gSqbYB]?Oa7,12o+EnFO&aM>4=3?2Y!iL&G_pM?D$kpXl$X:Bi9RJF)PT'_snZ>nD`70A23K?8)rDT0#mam"lpqhK>1aTd],=fW4sI`-N?q7R%I3[&7=73#'=p%=;A&MSbs>]p'$rIS[l<`J5Ykdn'17,X$utO$hDq#kf)<K/i4QTei=<Y1P:Zmf+n>G*BS.^uR_P1G>j~>endstream
 endobj
 xref
-0 28
+0 32
 0000000000 65535 f 
 0000000061 00000 n 
 0000000132 00000 n 
@@ -220,26 +254,30 @@ xref
 0000071185 00000 n 
 0000071391 00000 n 
 0000071597 00000 n 
-0000071667 00000 n 
-0000071948 00000 n 
-0000072056 00000 n 
-0000072722 00000 n 
-0000074160 00000 n 
-0000075807 00000 n 
-0000077701 00000 n 
-0000079625 00000 n 
-0000081359 00000 n 
-0000082309 00000 n 
+0000071803 00000 n 
+0000072009 00000 n 
+0000072079 00000 n 
+0000072360 00000 n 
+0000072483 00000 n 
+0000073149 00000 n 
+0000074587 00000 n 
+0000076234 00000 n 
+0000078128 00000 n 
+0000080390 00000 n 
+0000082598 00000 n 
+0000083742 00000 n 
+0000085476 00000 n 
+0000086426 00000 n 
 trailer
 <<
 /ID 
-[<224f0206630b7b156156664034288028><224f0206630b7b156156664034288028>]
+[<05ac59c3d8570b47ce46056a59d3906d><05ac59c3d8570b47ce46056a59d3906d>]
 % ReportLab generated PDF document -- digest (opensource)
 
-/Info 18 0 R
-/Root 17 0 R
-/Size 28
+/Info 20 0 R
+/Root 19 0 R
+/Size 32
 >>
 startxref
-84187
+88304
 %%EOF

--- a/docs/transform_data_Benutzerhandbuch.pdf
+++ b/docs/transform_data_Benutzerhandbuch.pdf
@@ -162,7 +162,7 @@ endobj
 endobj
 21 0 obj
 <<
-/Author (Robert Seebauer) /CreationDate (D:20260507232243+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260507232243+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (Robert Seebauer) /CreationDate (D:20260513201340+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260513201340+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (Jira-Daten aufbereiten fuer Metriken und Berichte) /Title (transform_data Benutzerhandbuch) /Trapped /False
 >>
 endobj
@@ -174,10 +174,10 @@ endobj
 endobj
 23 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 565
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 561
 >>
 stream
-Garo>98hOY'SZ;X'kc20j@33h/K<Cm%..M-1TNi^*'&1(;*'TZ5_"3ePKY7g0h=Y+I.s.`(_RHDYK[PZ<ENQ`=J9KGL(((XpeZeP60sjo&Yt@tm6T4$/BV#S=`0u\jfLm(9Hh?)P0dMA@OHRX+=fH5"s#]OSVi/lA+M6Q/s;@:TB(sq.pF`4;p_j.*M0@7Wfqo:#:B.*^e.8$F[WXTS"\@-d-f*FqkbG"\#=bK\iM8f,);#RR,$Re`GP_\(`Om%GU0Fi*f&XPFEQHAa/6IZrhD`9a7c69p28TdS1<7,o'[PI'*AXnZHCG0DYd6ahUb-;W5j(P9'W<q4/RVUBdir+PVM;0<iP^c2l%7-r\O5j7mRoO,(hn=[$ID<->?u*%`US.9%rI?H[Is]MfULBiLJ)`d,#WnV`dQkeRbrr84KAjP"@,>k%'6r)!dmQk=%tWp1;#@gOAA+2)Y9ento1:<8)H/=^M+&]'lO?0p7Mk_cu\<b2\TLWM_inZPZThjo3VK$1IFpb*uB"9du.8<"Ajj6W,3$!e)X@`0p$)ZoPkdAg_I"`#fV!aDh~>endstream
+Garo>997OU'SZ;\'k[gtjjr%%0<&?@7^*_cfV13FR_[EagdECWlVZ*UX+2DI;<7?)F,n/"OPj\epV=A[lC,NrFU'g8:k-?;>20KpYH3R'AMe05RTF&tFs8S[)_ELW*J.],+U40amRe$Pl%9">ajDj,`&[-_1uoXGB=W&FN&:MbB?X0)M8bp8?EED\A8PVErA-DeZ.B"W>%4TYl94!_V9-dG;"ieUc.KZtr<)`C=ZI-UbXBG2r['+<1FU&k5XE@&ELlYWr_B;.nocgsr?_%W"]@Ij(Cd]po5<YpdI*9Lk=D!X?s&OkDAdURPbrcaN%(Ni\kOYgR,>M)'mrbd)1JHA.;uIdASCrq]l<S8WF%grZ?Qoub`S^/$lq/r)[#dfhN:^a5(C2^f>h9=aX&Auk43/lGK.gO%oPo?)(YoRd:fapP0/J)fl7k,AfM;k.d>QYN2Ws"`dZW<He>N>R^>_a96].@jh]Ps5Mal6N`!\unm9JfOR'HT4;UqUWU9:rD#8m0q'"j:.]=hE9BA,Q1*f;G0@72f?9GM6Ji9OA]%r9K!V$D6mDm6~>endstream
 endobj
 24 0 obj
 <<
@@ -202,10 +202,10 @@ GasIfCN%Zm'`FV1EP<#]1[D<d0>=M9/I2L5Kk;-8<=)CZRs9`PL7'bFq=UfS,d#Nn:aF)Qa*jJ!m_'5F
 endobj
 27 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1385
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1271
 >>
 stream
-GauHJ>Ar7S'Roe[30-fhZQr!)P*_k.].@0@-B5XO(`4+SaCZYo/kNlbJ,MXSEobkj;P4j8fEO"lI,B-#4:EW7@,6$5"'j(/okt6ULNs2"&-;B<GW27BR1P['.5E#N6nCr\KPrKZ/ggiOUl:IiV?t=;&t[/],">\W(g)I^eYG"F+m\JmP&BYB#TpYeq`P8j0dfiB3M`/Y.M<6_)Q)@@j3#BmrtNU+R*FOj:$]Qf>q&_-\,#:tk+?)].Td]/'6-\Kj'po7e%Sgg2eHZAh,lnQ915)o-j(Y^7QD#/GpW`O6(9]-a@NsT0_31]8Q[H@i$jLN/E4t,*GUWXa"A"@=:t^-@Zf%,)a&09E&fX7p/+<=<)N`SaG?%=7H/<hK"K.ljND']=k[4TGX<Zc.HL0r6T.8*@FbGgiF*b;&H-C3Eqm8OWc\gM\(3+X5\g_:1<ur#lI6bm\il(/Z9:<)9i;![;O5918.Y.h%bngV`c)39:WbuZ3X<5dU!\1*W6MNl6Aa/GPWadWpmY,IZSY;YbW!=JE7n4m%1pBJ$?g]VLDt(<:mH[YIttSH0F_0]mONBuUE6X8YXa%==CS,37-b/ldg!YI>$9r!DZ9=0`luFXK6A;pc;u&\j#:WY]d*\g)Xs>1*M6`a@M")K';q5C%QJmbVJ%mUr.%J%)'Zq"L\2]?C@=F>4aTHS=/th)6K+XsV92kJENSeeD-f6+X@KVWFdc2r:JqPqqdZ.2Q+t(df5Ridqt6'("mR#Q\cD[]+RC>5g=3.NbOB-\ZB+Ykmp"6m0%#DuTngTD<s7/@C\jAUXiFf,b':9?BOf6*(2,4hY81aRhC92gW>)e;LI*5u=g+MJb=W_$JNQp0`00/"A"0;pFZflk=TC2t!uSC0;K7aYpZ4;]WtEq*3A^p5C)>$f%V`;pPn8]E[P2BgB\$t#*\&0ckko^*Z1oCJiT\2Scn4*(YK4C<liVSk6?VoUpOU*WGQl@7+T0n0f2QEU1sVkE4q"/WINI=J7LmOh^jP6L#9?cJ5!qMPl<9V8P[n5oKau^V_.EQ*k]UUK&.KE3@p,7;?B,IJVRn>6@!K@;Q,a-J2;6%&$P`M6S,$Ir:NVr()Wk^KD,bXAgl]K,H+bl(><S%87m"rTrIg=jNgTm0m*,bQbu-$AAD9*flfXGu81.jX1*TUa&^3YU*TY3D4UM\V%>m6<-ldSM3=Xtf_AEqX2L]K<JWOrd?Gg5#\&I#nqD2<AY>?/KFb@la<7,S[3t,sDmV6>3?#C8!m!!<`#(\^M\bDPQ.m4;Z(?*Dh3-;@oO]6[r_t%=JpH(l;V=EFMX?j7sCiO$I38+"]A"!57KYchM^&Gq2KLj`(+fui=.cP?-$la<$:A:'d>Q)G&`1`S!k&pfirr?h2(/F~>endstream
+GauHJ;/b2I&:W67\4<Ha)3Q0mW@pVkG$Th49k%sf#r"((a^ubp/k*T\If2OREo]9!1*@DBfZ'&dqnDOeG[s'j!pdUZ)W2fpo3W=g%XA@S&-;SSplJ#',/OsF70\F'R)KAnnBE8h<FgYIas]hpRXiU-iJCMF1W!&0^`eq\U>@V[XS5@Z](=)fI,$3Q%k&8C:1D1&Umr)J&e90r1[h\fbJr(^/[a1aT>Lidc9It+CV.7FMY.kJ?Qjn4]M=t'V2/Ma*-uC[n$G$5SNGU`c;2^uOejn[J4Pf"%R`p\M%O4D-4LYEU36qlZ$7`)94\Gm-*^95os#9G4G')X8-EFZ!g4sod-qtuEk(o^fff3l,:\sX5RfL2,\+*(ZrO>dY+op_?F"Z4Pjj>s`_n5M+/`q,R_l]B)UcNLEZt=P@)h0O`p'XCd6D_rKbc_]KM1'G>ueRa'2I.Tj.Yf>O.o2qJ4Rg<`IJBdNo7-)S9PBr0_hAHW4TJA1S?Gc4LAegcd+pTknM9+5T/S+.A9n5V#p3>0H!4NSNm:1Y`jZC*S'-"\0^@=Kg'sH\N_bU<Mf.6CuJ"Dj%s-ErarCOb$^(O'DPrd6AlfMZq%Y&a0-FDT?7S>ojCM!p0\iS7CtB,1(pGbmqLA<"Dal""PQP>@QHa5oYoHoZYeS@OVokI0^mA^nL^,S+:`)`>#ub^kZKaNeAXHc2nHNVPuR(Wo4[l_::#fA8N*8aru7M4(S;L_%\J^Ir]VZOJYiWnD1K>+#_urcZ*gaY.f@t4l]6@GGFe,\.s)q7ki$\cBEE"G2>c4^cJq]>Bg"KrZuK[;QKTesXDcDj][o'?;ebSj%nhQEDR4nk/1Y6#"nGL[MVZ;2au(]IlZu7OZN+Mcs+b@dIUbRMjEp8O\^SUD[VRi@XR7SP9($sFV+P*U7UK`I,]9hgqmM7_\gsBr<A\j#mIHJU@V6Nsc#1'kheh2ON!J@i_e1Mn]?BQZnI%1:YB[=BkeP@[Ece^o\p?H0OaDoILD%#\k:qn8rg9i9Pb^o+!@"![Sn'ZNW;r+K`b78hmG3[j-kJ-\;T(<6L"a4]7[i@Q@4+:s^SCK`;0ZgkE>ldUKJ=g:Cc[LLOc[-,CuBJQPhWO2ggTF#@ZABRW#JuqM[/&R9oIuqJjlf4?PF!tc@7]0/.d'XPm>3=g8!VDit*h[a?r1nNf3/#9'+/E*EJbFL;lG/Ym0$lAVY'q7$&L4pMUXrYG^g+Ru\/DYT6YG5:0C/rgac>kgW?<bl+NW0\LI4-@iXe+Sln2kL8_~>endstream
 endobj
 28 0 obj
 <<
@@ -216,38 +216,38 @@ Gatm:gMYb*&:O:SbbJ+T>`p:RkrpCf)RS78gVf"ZJH,jjN?onajc\+Sc.=U>fnj`bMVZ."S<2aSn=2:I
 endobj
 29 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1917
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1671
 >>
 stream
-Gatm;D/\/e&H;*)E?F#1k!Y)iW1Y!S1sOCMle9?DJK_fo>A'G57!U%XDu'&.8_KDm-LQW)J7\&f]8-.WO?s!Td."_b!&!I(j#%"_@(l]b$&A=<GWh\s3?bb;))$OpT$jtGikJV#Aj+P'J=m2t&lCnpAqUn%%Oi]':^RD8otr%'Al&]F#najW$N=Pd?62s?a;IQj`]u4I&md8Z2_]ADC:e4To1(*tK\6bd;0VF<bspu5d4I<'@/^>l5Bs:4AN\9FVi6\E=lh^/<3'X9GHGk;]nD^r8P:0D0,"O8b?2js&A<"85=.s4rWE=-9Org69E5_OjZ1Y>XW(4LTbs4H32K%RUr[hDpntUBi7$!cI6;p]P$DN(LBb&KOclU>oWEq<aiDMqPG?;hgf1M0A<[F'2G]*EJ3&6a!:%Hh_r6"8hnbPpPsY9$RdI+mpTlAT.BU83CaC+%_1=e!'22a%!>mI_*gf^/BUSusK'CLK-8ZB0PVD"4FH"$T#4&K\j.=.p+l#_L8g1iI7a>nAFIe+E)hSniR.^o*SHYi1R[laBco;(c$DH_2>1A>f,i1#mZ6CfD!)P,O#gos+:n`G9\AfGo>&G<^X;BFg)XFW1;>\iO>:f[rGKO>'BXY<:j5:;Gm;`;D@o1(dDRGS^F/WWES4>>$0XV7]7Z/0G?,6RW>[f#($DcNM%iD`,C5n[P%g3]DXN6SlE$/:MbFAWj8b*uQkV4O7@8[Zj,<p+4V?=.LjXfrE8M5&'1On0spJW+QZ3@+DYsS4+<K4if0b+SubDefqE.H[0d7[;MKE*KP%Vhk":9L@%:V*HC48"N>:Q%<Af'?5Zh*-JbTL_;ooW'fQ1lnUSa6m">='LGPh``:S%aj'c=0P1nTa%pUXU-G$hM]LtMr0\16Cb0`^;pdsM9_]!U9Zk7ou1&B]VNFJ.^NC@.GTE-8O+.=^j/\\N%udlmGD\"5bc!)HVco8I,)%f)'86K0YQn]`qn[XmOs%DTtZo'E7G0V*rGT+QM'-9fo%d-Nk\q*V]+g(3j!bXltU?5]?pTVlA':AR!*>ng=*4*<o_.LWL$]tQ+[GfVq9)D3('Q-`Q&"qK;EMY8GQ]m(rLu3YNj^4Fq6YsU@WpLVn`c'77'D6;\!LrMX8eJT$dadQBI3).EiXp@saa)JHq!L/Kn]T>P<]QjB5B<_k&tTX-W@,YL]?G$+2!I_B)JD*6L7VY?TJs+[m4p1+c)_7t/5H&hE<RVq6R__j^5"isCWmj>;;:\p.@.Bk_t!1ZjH3_9\=]%+MRKrB*cn8fHBb@#^0$m9JP.#[I2.k6Dj:QOSPP0(dl"e?)bp\NpLYB3mXc=<m08UfK-81&Q-.]T7^5G?fh&gI%<>lh_n$/pW:hV;oLZ>Go2i=4/WrGn7f0XLg/!DP'(L.h/gsqVkJ"hZ^1?2?[[?h)VF0^"5"@Jk,3dBKhaOGF94B]B/.k/iRoc/_p&Zi>XE=[Jk>9iQG/9PGGEI<d&Pa(B;ub9J7:j`inF:ph$bk&Of"p,siRTGs2r'q,+s':r"=Cm43N+@&t/@RRRO.%*(R;$m-SUOX\WU7s;i/'<2N,<ElXO@gNaSB3R5DZiA+4.A8%tX>nYiB^s/$%\31p96R?nXub?_'&C_ohc.jO&jb'9jee@"l:>*7^CJmN9;Nn0P=.g54LD=oVLhg'-Bu]SY3B]c.i>GTFq7YHY)R6!Z]0kW_Bg+*DR?V6$7uZAgU#cl_<Puj`pQNufBC=[J)[YFp8BM>%U-jBnpcUE$LblDTPpp,/')ual1oZ=$f1$_4XoQ.RE!%Wenu_;Nh&8!J,P_Kg3VYdcGok@a84Y@.UHYcE52!=`[Y7WLUCdHpMO'(l]*4[=dfmWg"DH0SuTC>IW)4Z/JBumE%A?i^LBRBlddfGk^421`r%u([:V'd2==u2AMEobL!NcF~>endstream
+Gatm;D/\/e&H;*)E?F#2AjqTOUnB,t1s(i]kh=$AJYBkE>A'F^7(FRCYPIhn8_KF$k&)RK=LO66cbhj8\I4)o&tn3)h>j'?iUnK#b$_d\apEjfHaoH'^5WEC=iO)WN2JMWJbW$,JQ\!i,Z)j@j@PJ$<b@$HR=LM7>#5P1@I\@P!])5lgk6Ai>RLJV/A43PTHG(C"_1@_7M;:KQo6XA7V]PK:%NQTSV5)fc;8`Q%a@W2C=^X2049).e!E8`+;boHE6@ra1ojk/SSIi9i4:d`i(J;t,\[Q1j(6)XA/QonQD2]"iO;VrdI1In`JTW$+tJ0Y,isW9J9?jo+ll"HS5Yja+M$EUih%9S_<9]FHFNdY,bi?m%Llqt,:-([r`oubUJIY'UKu$"k`iEDA<[i`Dk8W8J9:pW5h)-UL<]PZ^P=P!F+s+[27JLTh+Z+6TsXA^Z^#X2"rmF2-lGmH"#A`!4Fh$8KVh"u!1eCK6F27Y,tp6O531XQ_)gr0\6#n3#knfuV%A)W7S^+WFIe,dPsGd"9m_N%c@XISc.\ghBH2S=L!XpT/aD_HP(6^bZj77=BrKCoB3\mT>0U+Y/ClWC!0),'f;SXn$n`=pODEs^"uNfs7-!20X*22Y[5+]>Zs1ab7ulb-U^)Sf8R??Y=[GbIJ],,`W$C-K0cei-clVp@/5M=m/DG^a.Q0IXA_.:TPG8s4(W3A?R4(H1pRa`P."_Z4?_:1"j]5$%e,^l\V8AGe]7(9o0=*&_:EP''?ZoU_II[Ct-\&9rT1iHKDZb..I=/&+rPL+3Ei!4=rPCVG8;G`Eh,UeaYsIc/R/#2Bhg@9Jd\+!pYObfTaZHKb=:^%t$"(`>b1J+5j1"Q`Aaj*lPs,Jf?%9rSJ_.NF[6<s/__X>[\9))fTfl1B+U$oBfg02AD]"]c^pB894AB8$=C9fg6O6D_G\d[8A)+@kd?8-6=_rM>3#\+SruRK2B>Ydt2tjI5#Uj1A\84kaL](h0OD.9ah`ptFB38U*3kZLa+5TRBS'N5>4SBjEQ[!OS.qr^FYTrX)7qe,+$EBC$C'*R3UAD\2fcV^/Jk"Thh.gNa.tlhDn^aDf*>$G(1O^!4r7g.KKN[b`*n7a`-dAb0F/VpQ)(q27E\24#qArs71IL9Q#[cWR$G-60`KRs_d$2Ogp=JW.aRsF<EYdK%K1ajE\e#]@M-i[GGY`er\p-CjV_^DAeXa,;[D2[$Uqg@$ha\AuSsrMH$CflED>%&Js7A[82]W_F?Uqm+B!C?Q5XdE7'ZJ??`6]XFcG98&^uM*;?f-EcZ/.`[)AD<pm!`b2I!S*bH'8*Bk02a>WYOef>;%]Nh,$Ca<0,KZ3SLR`m'6AD&m@'1o%eg2&Rg=3+.(g!Z_o+]`=`t-Y5Hr&gT<e=NULe0BJ!2SRBLAY/Pu1mL`[`k*_]UfdR%Ig+:eK2b#GV/d"L0Emd_>Y]mZRccHtKsV>V^Cd)+]P_[I9%3(%3-VUJ2fW:+:ONca1+Cf"3sN_a"2j1hh6.=;Cgit<<A?FtjcoI(IJs+b:(dkZn?^<gaDZ&U"Ki%P*"s7c:V\^%nr3UY(:DqL'PD\\"VY:!B8l4kl#bhXAS;=0-pR.;oYKTaI&L9gl0TlREf*i\kuL`0lM/%,*.U3>@8b?/Y(?Eg4[5:2<>Co"$?--N1p7fNMlM97m~>endstream
 endobj
 30 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1992
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1860
 >>
 stream
-Gb!;d?#SK-&q0MXR(%;V0it0LYJ);A8N4?=G2%7#0*M^:)Hgl%b"GWTOC*K'9"$$-M0jg5!Z(m-QsVXjG\6(l'ESPjqTi^^E&i^2DCA<co)^<f*9Q_KH9V.;6>44[ScN7^UgX>CIBj.NC8)i$PQiB>dKH9q+tSR[#UuGrV4\EX?RPh\#+7\7+DH<X"o"cnDSG^o6Hht;1Bo:<,iAu]Gn!]QKec)ll`[k'!bO6u7+L!=e>6";U0X)"_#,.qIs%Y!%c_P&3+[JbRZY#n<]4]iESY:ifLpIT#%7]]i`X'I6kRW;ejY?gl9`Q_gda'&`R9Rh1eN=q,ig\@]raA\(*O]e83!G;$m^[T'"HiE,(n3[-YaHGR#s@f!Y.(U+X7j6q0oDs]?-tm5Ed*uBt#O"$&L')@9L?oAHT+<R!D3XohZa#]D_IXNSmDQXL'CO=dB=8(T<6aT_nW0o^-"p?[`jqp$#V7i\VT6jQ;%=o.9+L;kS\#+$&p<aatX.@D7<W#I,g'`u=BIck[NN$AB7S>aBn<_$ql(;*uoe>R?=/G0ub<.')#1<]Oo;%Nj<j\ktboEjl9hGi,T7Q`*dL\J'4/7>olfZE:+2b$28?78AUVLEl0G+A"ST.%j^:JTOt5"?kR,*tFtlZjR!O#T!i6'ro_8nF.^Wd;r\khhrHhge!0(+tQR%YLc[S_ufPUOZ02_#K+_+=J`98<XmR1PJ-XkM_L]Q5MdXDVl&qN5(8lE&Ghg^VCBaIhj%G1oH&q!J?u:W02'bH92oR'NdK"JMVD%(Jp1+Ng%D,`G6dF$7].')EH*lt=/c)[5IJ9n5/IN3"%'B'WJ,J/!8ea/^^=0:1aA`R]ncpnDrJ3EoKuJ5Rhm6Y*sCp_E@m,8Pp6k;BP6Ami$j+ZCA:^dhsb%_aNFU\d4V*NHkMMtN[]`3*&<%T6'_]p8ClCdXK-\rbMY,E-mTB86^[DRD\PRi%VX".NG&Q+!6</uWsO!X0+=i'kDnPK./,.9ja-mf#g.KnHPH3*KVoTnnOW?.3oBMg708J7aoRJiCK=QE=B3[fl.q$0\!QC$kI2*;_.JU8]gn7+^,ri]?oT3dLAe8m@'JYcQqo@iJc<l&a0l8j6_b"!C:-J."8+8Rq!3=g@JXL4d,>TJq8c[aa.5Qe;"Nk9ODI='P4?V9Y'pmkY9#b<7U)/heIY->AoXs>H&Y1*7RF"7qN[D7@r#;V)D"*HX&nYA5(gjTnV#kMbMT7j>WYs6S:ae&$fdF!f-oVSEJ[\^8uQ-OB'knY[XAo'f5akDFT)IK#=4ArOG1SG)0tWHbOcqG??!AXqa&`1b\UMLI7\P;p4;sTO1=XtG4BkWp#9eWn5&,.J04W6CJ9Y-=ed.$Q$GL\LZ_F98uF\\EF0HlWIN`/q4V4FK7n_W*0RPPpir%nnIK5Zr-H?nNo>@b$9GlRF*TIU=?f)cfE(:JgjP#d0-QjkT3+EH`u1Qe-lqio32-*L'dQJ-K)(g(6F%kqUNkE]Nk=tX)EI0?B,@[!>')7Tm',:W\.ZfhiKY1$%@'=k4UiFfQ'862YX"2kdRdbB<=&>t/UBbNEbO6AT$KCu=/b)TdFKjA/ZnEIn97j_2'IX"Tp6G+JD)H$l1D8$$0BVS+cMW:CN@M[!-5YP#AM>t./[GN!tqn!j6Uo.YXbI@!#?uKV;2L;TjkNtC53k;\3LKq/kZR&XMoL&Z%#K`_H1?Vh=S6.OQQ?'7SGG=XB'##AL4uB`Y/;()cs"U@C!JL:[Y(?Urr_6Z=$i-'?^H4]<rFB`Tju4];u?%a^E,D*fTH=rq43#SC2qZ-jmF@r.1leUM@#]MB:1/Tg>OO1@hgBO)>,&fXcJ'ra2^+jjiAqQ_hO@2(+a#Q]<.k(61*GU?;hO8J"9Ub!!:]P*i-9DkI?iMFneDg(O0R\JOn3Y9't9-m-2A^T]+M=PqH?+%!B03XTiuE6fgK2"5klmi/GH:r>6ITWF+D:4>D5B"GZL=i7(R2?rgt^L?[TMjD<G~>endstream
+Gb!;dgMYb*&:O:SbZijHk)'jqlW^Yd]'8o0GOn_*TV[dI7\[O@eHG^E"Y&,jm+CP(`<(qt:<_J:*1erB$j@/(T^FV<!RBltgD'n7@%IJ^KZ!^>>g=^H:C)q^^_7iLqp^[WfM<95>#$>f&6"WX?5u7m"GB30#X0OkVA'_2rc7!.ArsND4VIMP;QrB#C$.Q2."mQS+_)'>7Q__HR+F#L8k>L3WrA:j,@EE^F-NeP6raM\/_[RV!V>b6Iq_\!*6,mXE6@tN1gQPNR'Mi1Kr[\2_-Y!Bf^fb!!Dbf^,R@Mhf.L6C@N.X#_ENR&/J\SE`^("a-9_rck\T'_Bb99tM25(KKg;Ao8"TZr/Md,!H6P;qq[!Sh^uJ6Yi%pNmT5Vb"\=%`5r&r^u(3c5l(6O-q(t/9UPmtD"@-/H:f0`h_p@dC\1k:Js@AuY$lEihOYX"IT!q"lPVm!j?Isj$WlI1q,KlJkeaNf'Xk*ahhVa*CX5-X0@P^$LI_u(RQmmUDFL,Ia'TaWcFk7S6f1+`K!$!/O_5m;CFi'J83B4n?\(I^3n_C@o!:Z946?8kJiAS1[E%<%`tll6b+>OHa]>i)3\VG+%+XKkkZ;3L*0%K-n4TbkZf8Dql@Ud2MlfRoc5T_F5g'A<VA&qg\tM[JS;0)4;=Kn1Bc\uVra3^I\h?Jc#^BAeeoY.1IqS!srWB?lEaB"_mc1\e:+dlWe5;^.#ULQdWsV1ig9!p,7@\Tcc0\1SIfGZ-(H]6pi7ZVbQ^SY!68.2LR79VQQs5:V50q#L/f15CEpC1/Y(iCBXY=Q.^+`0F1!+<LI<_K">/]=_nH%mk:u#WO=H<^LSd)$2N'AiAKUNap[pJrcr-Nd"tu%L;'KRt-7bO[nCbU`=u*a8hBJ8aLF>8Y69O0(JQoRtnc]T*3sD@E-2K;\);X&1-(1JdmMWlm'-.1UkKHpSem,-g3.H>En=4C@u<Pb$1*7'XoWH`tjq`8G1b!?1[)!J]>R`Toj$]'(Zm>l:EVAR8E[-8B@E1:IkK[CE2XlP!!jNfhQe0EGm]#G'*n>(&Q%!3l$EakJ&_*YVh#Of>tU0[]2`<,iNS7`cmU&d2jGNnr9oGDjqNX6-5a&6BVq/8\tR6)YuUU*BeSqH)t.2Cc<L#RK?\DSo,`#9o*]qHb]+k1Mfc9Q\4D3Z8lC?G7#4#]k7cJ>Q-t^B^:p7FdGCq68F6@>X"rcFZMf[D"WsZ:t[?9DTP]aoJGY,a?N`TVE5,Gi)mJ^]r4fn=hfYm2SmMgkP;TnPDqut[r9l%[l?$VeE!=O&#]Bqgidn<XjGn6PAiJRqpgB>)L=JAkM]I!pq8f-OZ^ORP\55GSqCN4+6g6"c?`q0-5c%r..o[gm"(WZiGlPP5Pg([pFRtM>$u&I%,/-i5LEhWO$-cEf3+^kOWOed0^8%mf%nnc\'U_:[5r6R[L=Oq[=Q,Id'dO=Q)JJs9%:k;^bT*I`pONVW%]f>K.*`,i>.\E7ju'V6GRHMhc5@t)S/0;=,esr/Q?FXf/`gqBl(aR\.qWIedt[2rj]>kAN=KUT.fDWZ:4E-"RGYr`OF<c;BEm&&,cI%PS9[C$"q:/q%er"!a)*d$\NK7]O-tFK-%D05R"Ge$Nj&'`G/tgn%E/gdO^i)q@k]Yp&<L$R%.Y`/Q&E7-(HXB&GM(HF)BM&e9t(IW\KS.?"*Vfs(*/-1[c-W"V*IA-1(NSErD')b4/U=gIL_[S3RBR,0tGda-+;^%I[-%\<dZU&%=\?h)-U_jD5`[]Q[.N#oD5t]fQ0Hjg&p/hE@`i`_$m=,4.1+f7XNR4j$9ud-4UIKKJMs)0dN>/#jW)[bMk9;R6unCA=S(?\K6:\SCOiWa3c`j<%.=B^c~>endstream
 endobj
 31 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1911
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1804
 >>
 stream
-Gau0DD/U@P')o%@1#M73&\EEnmV[#-^kqGGdU&'S.LI-s"LN>'dAA=YjOUScrINa0C#qlh-Y[!S`pSr[$tk=@4;*>V18*lQ^&iO>K-)`p:^47ATRmH:r<h_oae'55$^Q\X#SWa!!_E6"3Om&H63\a\8<K/@jAerWO\=Vsd#q:G#hM:7P%+\rnsbcIo1L8+\OEm7;,E@5E6/r]N0-dJ$t_"L#u4WQ]lpH;[0d8<;g=/-$'4;9b19Y=I/,qLDIE0*oK$q<Ua1OIZ0T[#d&<VhG3\R7mD<6a&QP7h$:leLMuh%A<f'#YR%#iPTd$d(_#TCY3MC"j!\4Qn;TON6M)lbY6\n'*>"Bci'L`f;7mmRMs"gpLe+8I<1=$*)+Qn\_P`+oj".,3qP<UFaPa1X5Je]Q/["S8?Gf^.eB/!&2`q%Ju\6/]:iC(PN7Q>8_6="$%!c#)p;nUj(JLmif"OWN`L<$S8NrmQ=?68VbiDdmg_sIB/Ehe!"AeC\ZW8[['*6n,W%>_qF4[SlK[76&iPjr^qD2]I;)g$&LBN'CsX6lUcFaoQ*iVBl9!A.D:?NsU]gRp9?L!!]?nccNn=/.)%kEgRo!\u8u!@6!),q4qa+J0C!D@417"X"LcHf*aTYL&J/`d\oI(OS(>q7cKn`+%WEj6MC0]6,K?W=dL3V*Ygq[70j4C4gKgenp5IdK,ReBVQlPPksS(Mf7Vrg5CoS;UX4hoQ`#/=bm@g,3L3fSAUSrNdN`9PLcsSh\oD#NiVSc<[,kiZJS'NEn#*ap>q<U1%(F8YAd1A;9*8DjaO$GFXtCs]4K"j[kg5#kL;#5Z*L4\4(SK]*sOP[>@,_%in&@Qb`MdY(FJ"#@t7_*mr.%Y#3TD'EObj'q"`>pkWKjZE:QP+&ib;(qfqtrqu(CXcr-\<^Ym!8;SOtmbN\,;TIFIM#af.,(ZF=j/=lb9fu"i[kZ^OG4l?LDco?CR0:Tog\.!0IE!0@?iG`fT<+u1HDR]E52FP8K#B-tJdpm_N6nX=c?9(sclSLWAE4RXac3H2'YmXp>d&_tWeM_t#6ESu4?YJW?F!/*f$.6^h(7YjXU=:+??cgX/j%1$l4@ps45$6VY>bMTun2prfgNX#$[=.Al$]!T""H^)un]Is3oCC[RL]c_@Z*tn<p[fq@(@P0l)+4]oK3cfiYeIh@Hao@9VNVcTD/$hH"OM"2KC+V52l.[a]_hp4e[C;qU!89]f,>-Qd'h2GoP;pom#Srkb;TZ,/q@^7e%U],o$)j)bqUA538AFAibHZ=nM.&aBZc'aD!,rQYC/3/EkkNlWC%?R3fAW3@#C!a;^$?YL"r,;Z"(p\akI?DTo!^*La-hOU>%BESLDWt&99-&\ICjk6m/o=Yha^#n2*c+=Mu&ok+U,L]*%VZbPZ:CM[X2p2s]+2cd[lCB4%XiM3)G%8,7Ph9>a:3J$"_#6(tFR!os4bNF-EBekT_<Lp#pbkqq3PgN&6VoJ\?YrZ:5qO+tGg%>IBJkKB[]G?'!L6"sgc\gU[_1(PFCFSUa4DICIQ-th4Q&^!([^'NPuWcf*)IM$^-+mi?2:SdA:MPuR2O(p(H&K\^Jp>b6R,ZMhYLG_eeeLc.uBh"J>HPo<.mnAVre-b0PagsqHhfU.%]Cnm.*F!Ze!?V+uFa++uN1Rbu"gto\M5+@)QD?rZC\W>B,"<K'44h?!of+p%KL^g6B&3Ghn;m&fj_[m.TCrd9dNLY_RJ\#gPf'P[Zff^ac/g@5o"Eqm)<%*DLcOPDle$)6(`VlZA^K#lJm'FG4gg>cBcsisbAT&^CXjks(!P1%f4m6hO4n\4]Tjq&4\6f27V0G*D&4$/7VUnjXiZda9@W?GZYC-#[OCW8inX0,"oVM;f?LKUb!ju].hAi["hWD7(M8(+B3HmW>!:t[R/A%74pr)~>endstream
+Gau0DD/\/e&H;*)ESm&t2()99,n8UZ]FK?md5KjJTg6Fr(L&=W\Ko]^rq-@Bfp3<+9%+7N*(\,^kK#_KpXg0(Lk(6+Ba&H2JR:&Y:^3,!TU]tg]Rf[rkf\e/PU/Es_K\c7'Sud"$(0C:6Ne9d8/c%g,^D^YRL"]uTc'\7&?_Xd6=:"CL`;JXMbCndR@1On=\oZg`.B_b(aBVg),)M>E^jej?(:+X+e=;V(f!mdDM_sXF`Gr*kKdOV"-_n3C+gD?JoJm-Fu3F77_5nV@tT]n\=PA4Go"@ZOG)d/"-Oo\kGo<qfjoO>3>('WH<;^k#gJM@=@QaP\-Q3'=?;,J&!:m);ZS-Y4H98gO3$7s?R*8@I@Lt5,nYn>P*hB%`dIAQ_<'nZkf[XfA6J5_ZBQW!Ah^=sQ`QNr"QPTB0+SM]o@8<m7fpt.K]C(tj:rHY@>VS)Mt]:h&6[l5^tYRgGV!V".*sC#,p&,1Qu\>-0Y)U.DDY"&Ae#0#-(KISU)KZ3#n`f*7Hbed-rH`DW@XR+g1LoI%2u`k8l^7RX)4QX`G-bt^pCFH%Q3Hj3d4Clh4RYbL!j6%ni=3K;kPJTq\Sd'"[nSe*(U^i>YlP[5op_jXpYg8$U?,Q['meB=eR/!Pl8$,5E/2\"QdFuG[(XO>K\u.T#;o5E=??s]$%\!Q!k,[G-)p5)`[;43TituB.G?uB7kcKg\1qJpi,/Y4WuM="p8MkpW""X0J)DE+-mp"g_S_OLK#RMZ)je"KiAP+P:)?"OsE%n07Kn`;YA_KJ&2);4p2_1I/)":2`PqIM#GkrSXn&+K@ZcKO%2i`6K%XVjO<Y>B=l%eTG\:>YOQK1Bsf_O[.36qTJ:$J!AM>J+l(m_kVuZ0-[,qHd'f:rXoL+O]#NY93,)tXi6p0<mJo'SA9r@^Uhf<.DR]E9Zh+*L#%!QaNXtpmn6FtD:(9gN7:=gmSBg6O=GKL+H=dQLR]=-U;?u]>W-MVHMpb`%(s$TC5W#)/SLL-$-q0!^H\h9khs"rQ,QVW2#Lu.LL"Z]]n/1N;E?FmIrQ`nKK@UMXOL/;5WbVF@F7(%I`R6=VrRlnr4h_8i`S/[9$IQX2T^1h^lK`68qcbLUGL?o?/M61;"?MlN#Zthped3+hL(NH*pq,%8T<%?^=>[-g?OCZ)HpCo:`h351I(Od>@;-_&`np/759sTq.,5dT?6k9[ogl/Bh!,upg@D,>Dhti.[sm_6hNC$Qr(-4EfHut-S3<'c>anWrAP0q]Pjg8'dRqI.0^P:g9cAKAohBOl7^eRN[Rif%jWHH1n?!,o-3:Q'Sh#'NV5c2CcXHdV3i2RtjAh^?5>b`AR!>0)qGnQ^=6g!PjGE`!E"N;aQ^d0lbp=hU#i]X%P][U];9mPG&(fHZBjGRJ";tmaj37$Qgb[c,N1@"fRVV7A:?NB-J[Z*"V(/D7TR4.JDLkQK8sO'0_QfElcD("UQ`0NpL(&u6-KsJYk&/_VV1<`IUr*OQ[q`K%?%5ZrFj,;2,LN%"r_)-`I/JL_lM,bAAm&Pb$h$`S!G:4Gq`sqY8aob]#To,m!Y,(UM1Ase03*^E`Qa?KY3++1):L?apcd_K[2?u[?%!Ka6_b%aB5Th$(irnuDkB_tH\q/5frs#pk5,+30592_9&RnC6\i%0/m4_B7(S?9o]#4W1s)KUM)<=F*66iEp3AF#gC="6HS#ut!f`DM5bH)C.H_%cHa`kF,.s54ii$6/B.GQWK==s_Nb14*Uh*%IoaIBWY?,P>$Zb]+KCt9:dWh$S8.2=ieL9\)Y6YrE^4imkcA\jm1FS4]")fNs>6~>endstream
 endobj
 32 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1881
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1615
 >>
 stream
-Gb!;d@;jmY&H2$(E?Cagk!Y*$Ug_o[2!M6H*RMfAJK_fOgLlq^6tI&IU]0og8]d9-`t#>IfFYiT8a>^an(kTS-j1(]Fe=R)i-GUb]V.S.bZ6thi@oTd\$OIh,=5lUnIu8h+Uqp(p6.q<o9"V)&fQik87ID'Lp/iO&5kh.8jO]'?B(I`#-"pJOJK9W_>`ZRmX#W^"='UJ$kgQN^gdST'#mCRWa8]:r,\9o%&Qt57b*kHl?/tio4G8AK%Xe(]s:[c`jcS5;oXUDC2'-\a@]/a5#g8.Sg?KnJhR?@nMFW=U55YYK4s^#Yp#o2Zk;qXZ%S6=cidH;68#ce^@"f9"<-o\`157X!/Ul?"8giaAFSQUOkPR4VF2\,^nHE0A0dup5HGT=2gR^bCUCj_`'4sBQpd/cYUIi\X9Uh;WC(Fl6X=dlrGQ*a_^C;F7D2(m2jnAPB[d[oYQ62?UW18VU%tAug&$u37$@7?ftH;L!t.3q$8c]=,)_$!8FW"`C^]8BM)ElRC\Ak[(4^^0A>m`U<45oH(5p-M'n!e:$O'?$ZBPX`:_p!EK2PE^1)n+/pl3e2Z*E6j?5HV$b:]0tqofK*?b*DCM*$p_3,L;KFX`<d_N;qW+MpEJ6kC^c8/0EM:`qqp7p2P_XG$PR&3@VsXReCoM%Gn='F-99Ke)3eGSH<sLET>/CWgp/VtPoXViHkgRn[+)V`Y=7UjIjfMe3hgHXrclm'ulp`7u/6=59\gJb#2H+UbpBN\J/AI<o'XSoGTm2>Oec)[+Zu_4iUsaQBEe<Jr_N:b%qce'qT,XQtG4;j^aH2\KDa_.0<LM&L9FnODUoQSn,udeeB#*O\j!h#gPH,I>6/a:WSihUQD6Y(L[[=+]J+`E`QoPmp8:ecp.GZ\O=eEK1jPBeAbj.5G^?#,Dd05dU&SZH8?bgOu]j[>+SKlV-UtdoE6RR9n`W4UXAl?@L[s#)`P*HRBW6-$s;H`u[^.,26q&Z7.&6j2#pUDneCkC1CK[+&QZsNm]a6mfTq>preK1kAtB66J-H]=!$"d,Ym:b7aPKQ#0ZE`^X,&^g5HUA%3bEaSG+tPmjr<5p,3b'2^kU'qQ-UnQe'X_BB1`*r*P[Q"p`\mW4Z!SD`oI/%O5C!LbuM[msE?R#B`pPq`s!/lH:a!g(J$"FZ%L&V(EAM;U?r?G?Nng/eL]i^u9Dj3="U5gk'H3rm1&f,9;LnPaUB1(:M.$2Q4&X%>!7P1d:+3CK/<Yf!as]bbamlQ>MS.FA!tfHi!_dHFU_Rc,EQ@OP;T_PCNa,gDm,Dk/."dK8WdiT.4_?!-FBNE(U4W5*;'`&]IVs:F&"ojR5&u>sIOBjf$PhFR&;egS9\A7\ce7]u4)#CurJB*VN[/9B"NmSNsS`BF.L"8R7=p]J`euk@c[j<0Mr`hb*"#f=S`MAAs(OO/TOdQ:!h(P1V81kt8;!'=G]p#K"9qbCjMXm^2JjgX!tBIkmi!1H>`q_<kf[&>nfW*cR^h4M%U!4h!UnF-PcMEA+9ehS=EIloVa$E/i;pZ(>&.6W02ZegjD<*%P9r'H/pCk#a:f79.s<@,'=bIKI+if7e-P:BC<PGQd8KYq@<QFeeL00/%*3R'?0#&r'kg+\BPf#Y8DpaTU>6ngd6:Tq'OR4g-!#,VDs_Y8>quS<Aqu[.Oa5>c`8rP5.,W'#[RH5/3/Dmd%tL3BBHOdJtiigmm'\@nRU7St%\+mDq2:mL9ADNV-=*es4-LB(g@>URU`m4oTYo&r%2^`Y*9s:Jj3=fm`$pZ`hfT;C6XMS7gMndLN(e;4f)$?hZ^\f,X5!9;upk?Q`qqgf2!r^%NGfZ"npb=$o%%s/-QSE&jYWPn>A]W7lHHG)UoL<*T-R7CA6>bC?$A0_u`hWQc7~>endstream
+Gb!;cgQ(#H&:O:SbbGii/4i\Q<>7$r\J-L@!m/"[:]r1WHRpt=kRAi?&V#3p;NdlX0Dc:`/JdjDMU]k<R<&jP"r&I>s1'Z]DW^H+.gCsMHjra\!V88>E^':]+Y;TW8:b^lYp]Y45'[PpT,=5o(aTJg$,gOOGS3Z*(h&:VYR'Qm'-ET/lJkd:g:.RHO3QL,5f#^+&kUA7EDEH'36Y$_ei#>7H=tEN<`u!0C^)h3RehPXPF9sq=`0hHr"I;H\u:6h6:rF=(ZT1oY+)ND4#=3f\$Pbc>p<08UD-6M;TaR/0i(4CdIfu>&lKq.$3n&NiZsd_!EUNZ;FmGG(3PVPkV,LN(eZ-97#HZ/h_$41GJ?jG?[e4PWF@?MKK.s:AW\r9/)YUAG4Kq,pIp:-&tY2P0a5bko#q<B.EjnP2]q1_F5q`Pdf_jJKK\$()L.Cp9aQe^_;DC<!t2KGg_d,B)-$>'1b-X;W$G*%!"r4r8d6PkHiT&sTV<SX_VhlJEh!:QB9O^--n1Pa8_)jIid%Uj`"@hp'Z#b"QG#FUh%hG8D'<U!S$o(d78-Y1]d(JGYaf(U1(k.J83R?:#^ksJI9I1U,UA4ke89\j3>R7LDAO>?rBe@\M!9%^2$dlr)N1>=#2'&0R,)cb>L^Y%X)=q#/iV</d4%b+`"s=TbM[h^@"fA&L>\'5@A,221hFc&<HQl/]CIUgUMHD8@7-&oB_%1dj>7&I&In[X76EDWg:2b,E`5>cATi:L-I2-R3Gl^KS0Gj_?%WVU'j)Q0OLCQ3I8&9T?<d1aI@aU=A[^IKI:cP&T:?(fI$S-KFb<,6[dD0OCoW7+E:bhf'\RZaPYIk!ecC0MGk]NiA%&cui]Z#>/l:/ZabKke%Y(*)piOXE8-JfbFleba8pPo-$Zu06NZS),_Lo[bdp]$l/kFYK#VfQq_,so!%Mh$B(RSU(I4eIu:RgV9)>f=,s+^6fiK^iOm0n9]^GDk.n2qO6i1?I/6kP\u$M-EbfVS*#5BSD:.tHlBX;YUY1<ZqC`-DR;DNPYa-PHbd0TbH>=lJVJ&P?>]a6RO3$)Tr_#?)^*r:tEGV8G!@1:(3*_NpQpaj_K*[PAk[qFi92@jb"m'-\G;;CP<T'gU2j>3Y7<&Ap:haO[H-p<HK$Dk>"FN5GCQ&5%WfHoM`;?m:*Z!c<'m)j@&50V"PLd#S\uG_<ESFZl+RZa<cr-<kB#P0_B^)T'?`>MRfUHB0'Wih\Os8Tj7a+Y-$X\OX8%Zbhp4C9?L&1n7L_X](%<P(e:R;tTr^4%6c/:;9-8hb_'"4>1jmXr\ru&^ec'NX1n,H&R7YBu:JuW(Z=YpB[1A!0>WDk77]5:d^'Y]?ZG'oK\ibGIUruFACeO=hu9!9bEDOY>Ksol9X:]jegC,<K5+]jLagbK%%nl&1(fH#>4M7#,9lV:I0?`q]9nl;'*n2G47fX$LP*jD*(O=_-/o46D^$<JKnjWhK-R'mWZ>f4Il8T2$&3?)_C`)ob?`Ss*msoP[#F;(FK_#jt8X]_!osGn%fEtLmVOX`h1sjmD9n2&i!\trTuN!BbHBAID7D)4pSt8/+0I2="Ba5Eif/A*.\;h`35'S*o:D3>O)(.J"-m#q%m2Q0eE~>endstream
 endobj
 33 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1591
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1430
 >>
 stream
-Gau1-CN%rc'SaC"=.F2KMO5'VHbTu'/mX2IBP1fUL&_Bg*D'K]b2jqpr9FSc:+QW>SIQM=.'REJmlA_;Q_Y0X!7X6"*PdF6r,PM_10@L@,8.iP'3m+9h^=)S/<4`n/.-*Y!c_!OK;p:3!m#%?dND1+c==`>3.[/(RSaD!TmAZf'/R`.]E--_o29OWWcmET$47(a@DWjlN0,5T)([h9)TAPUHI[Eo\`#63_$?4UCeuuoQA&U&Vm,q8(@U%[UWK5U+VA;5rbPaTbDk`I9]<!QB(R^4ngk&f+E<VN$qMAE4F31SHBYlPEft5h(p1b47e24E^bQNl8X0"XjsUW>V;jG]Lse*\OsX$E\GpG<#(M#jaQN-3S0V5W7*n4>16U*?g3qSiI.DFNIIc1"Cj7C?.>]Lu@+kLGfgp8d1U#<uTtWRCrtA'^pl2&N7#c/fG`<?;/7B]&.m5BElX:r&r#^U=5t;!@Nc\O@LFXP,7Vdq/E!,h_,[:_R%:!q+c4+QlD"m6m=\24UZM)j]JQnX40oOKd(2KSJ>MX4Q^o;<<$p`>s4b"!/>`T#iYs\bl5a]e*Y7Y<[C]K/W(d=9knmqoIdt_8G7GDT/mnNnK6Et>8JK"oL'lEb`n=t`G:utV5JQ"?n%D:51ZKU8Q5Cj_3*1PN@j#&3rRLbF6q>ZCg./9]Cm9/WaX"\-WI[nsO*pZiX)ha9pU+GgtgeI%hkm4$1Amj1k'hSOO;g*?l=8J$7gh8[+Y,s/c4PCF[I9u)j?8eq9Nhs3TNBL=-7,oVMh"!PA$klbp;!F7NnnGG(L0>:D"9cEtBM`P?Fe$+fiZF;De*ns2hfS@eY5snp2CP@=2S^nGd`Qka%]&\XeCa<Ab4n;^eZYp)73eX)FSBp3nK@2?"+qsf&uRQ\idlrqV[KlhL#T90`bNjeQ<RcaJjX\8X8Apaf/(HO5`(bf!gOq#fq54Q.Sps`QJ8?G<,XZJ*C*2bdXWZnAR<mMr6T6Hr,q=A-t+_>Zrf6%-/:<a,oBlF;Rcp'31"rfE7q>&1(r+TfZn-R$[!Ec+t-F8;/T4EU9/OhejJIpcJHtlY'K22f=\oI8Oj)&<3?g#pJGXWm;"I/MR0(,(dd5Y+"2u/1lp:Q+20.]eUZWfqSM:MC@"qL;#rifD&du=,Q#>VRkG_7U2Y@99=hu;SNHKhXJjG<d?ImOO3j);Y$4H,H<apkM[8dn=0s.)[Gg%'9AYih/[d9##MVD7>!!OQo5A2;m@Re,o0(kbf?Z,Z8OBa3HtMRuHm(Q#jK[6r50[B"^JliZNVD-LOgcpZB/E69UBGJB7KjU[Qc),db6?$0NGo1d(V%e0@l6c_EO-/HQ!D4\m;0t*GX/cVq__Uc?7XkQV\`sW"rnUYJiBMR&GjO7kKY>S_2CB4\%8m/;Wnk^,'oL0_)V.u]$@c[atm.p*;0cT2jUp>]8\^Nbk(?j4_!u>Y(f0TmY&EG??^:tL&t#T"q@)-E2EQ%<P;RW<Lt3!,>6($S=eI:,RD;Hq9+ibl!GidNjp=CHZ@3Nm4g\m<A*351`Q1;JbNElm4W4-NNLSsRS0=,D#a2PpU>`Yn,ZO)odf$j-0'mh9`>1q\&:?~>endstream
+Gau1-D/\/e'SX=!=.F2#MjP0WpO!k,]Q>#pTO!K[(]kD9FX;*kW0F+C/AHY,jMZ6)29q<"J.7DLH-Ugj&&f,'!$Ar</b!Y4T.W+5^oRTu=G5?4SBiNh-]FrINcHfcKfi&Fr3qJjlA7u\N!CmCZ4q:"1QfZ`6I'hq3=MU-3uK@\aG5$CQEB<2n/kU+nPKH[,$:3<JP6=b7&du'`M#(cgT!'sQVol$knNSWp[3UV6L(l?kDM9drJB335O6=";3J/>MeIGqX'@<KlL`TQ?"_s4ZRj8*+O%[]-k?G_*/cq*PiunHGmcW*<Xq%=&t*-Q_D@",Ki&I/_cg-;*.d_+2:@<P1]^75-k6*X?W,gkpCmL95Km8n`Bf.mE@=r7_e=J#_:@W<jQkm+B%crU.T.%'SmgLTR+[5\!7O65kJIOK*rcHbB)"em?`BK5@:W(N]e2$<GB\5JbideKK(qP9iM2D9S8[W$36&MW\?r[l/>U08.?+^HXM^HJjL\hL:#GsJXK3]/)mZp'(4fh_"aQ8c!ja1tlrP:;6f?Mi)ZuHGLF:,%PBK=?P"IJX'k)FMA51G,Hi[-60`E`%QMuarUui'*E2c_,W[Y]A%;<"GV?C&C`o:CWiN,+cF;&mVLG_4c=u;7&D_bIbgc6G<s"g.nVR'79(sZ1.4I1=1V)=JL&dr33jO$f%P@K",W,C+46$R<odNopok)eK5fq>4D)^0?(7@N2t:u&_"\_YeCIP`$7Qb=gS"3Zk]D*TJ&SM-GgHBpo_eC7>qC"`ZW:X't)Mpq/QO^5Ejd+'7Kk6k2ANNILYNUCqKSdI7"^/7a+/+;o]d)W;uHT9\nY*VB^=e,%>M'"1</+'+p=(S2b<N`g88s_&:9#K9U\hgfqdk.I=PX7s,dY`un3)bLfa[f?lEo,BO_jouH_`uMiU*^DSZ^15)*lZjncLE$*9j6Dq8T/BI;!D8K`fa"eH;t;-ekrbL1.5>`oFa-R77iq<iXsH`do/[R=,N$b'a'AZ`m0g;%-V##k>;Yc7T]@hEA_)?;MCh?_YLhmr8,'VlGpGCrO+RRgNZ>)m?"IQj<rhWj8=@$c$H,o%C/JAP'%XcN^s")q-?qZZY8^PDe,.tP+^qF<'?Z:F5ZkYN4,2@74FWmEKiZSY9=0aW[5jV)gae;U+c)8b%IUk>&@4eRtgEpS5HbefBL9-pd@EZ,H'fA]8,68EY&06n[VQOD31ZDgGdQ[DhO%G>N/>ug;ru5@UZu/]lQ;ae^odr7Hc4Veu-'foA/`1ltt;%_N95<<u<=2nqqYM)AomL:e.XKYTuB_=l-_r2Tkm@27AeDMM@q^@'W:&UU@J"j!&g"W_/2$9'REW*1TW2rgHlY=\;U6lqtedh@BOmNdm-/o"q#?m<;'i?Cbrn!TA[4+nsou(N_18?JSKU#-Z-=f3UtYfK.G8q&<4RC]4~>endstream
 endobj
 34 0 obj
 <<
@@ -282,21 +282,21 @@ xref
 0000003319 00000 n 
 0000003654 00000 n 
 0000003792 00000 n 
-0000004448 00000 n 
-0000006079 00000 n 
-0000006819 00000 n 
-0000008360 00000 n 
-0000009837 00000 n 
-0000011546 00000 n 
-0000013555 00000 n 
-0000015639 00000 n 
-0000017642 00000 n 
-0000019615 00000 n 
-0000021298 00000 n 
+0000004444 00000 n 
+0000006075 00000 n 
+0000006815 00000 n 
+0000008356 00000 n 
+0000009719 00000 n 
+0000011428 00000 n 
+0000013191 00000 n 
+0000015143 00000 n 
+0000017039 00000 n 
+0000018746 00000 n 
+0000020268 00000 n 
 trailer
 <<
 /ID 
-[<ef5d1984f001a0fb450e61cb561c5f0e><ef5d1984f001a0fb450e61cb561c5f0e>]
+[<714be2a034515ff5c59dc3ec6e6a76f9><714be2a034515ff5c59dc3ec6e6a76f9>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 21 0 R
@@ -304,5 +304,5 @@ trailer
 /Size 35
 >>
 startxref
-22806
+21776
 %%EOF

--- a/docs/transform_data_ManualUtilizador.pdf
+++ b/docs/transform_data_ManualUtilizador.pdf
@@ -1,0 +1,308 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 5 0 R /F4 9 0 R /F5 10 0 R /F6 17 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 23 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 24 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 25 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 26 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/BaseFont /Symbol /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+10 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
+11 0 obj
+<<
+/Contents 27 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/Contents 28 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+13 0 obj
+<<
+/Contents 29 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+14 0 obj
+<<
+/Contents 30 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+15 0 obj
+<<
+/Contents 31 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+16 0 obj
+<<
+/Contents 32 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+17 0 obj
+<<
+/BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding /Name /F6 /Subtype /Type1 /Type /Font
+>>
+endobj
+18 0 obj
+<<
+/Contents 33 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+19 0 obj
+<<
+/Contents 34 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+20 0 obj
+<<
+/PageMode /UseNone /Pages 22 0 R /Type /Catalog
+>>
+endobj
+21 0 obj
+<<
+/Author (Robert Seebauer) /CreationDate (D:20260513201340+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260513201340+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (Preparar dados Jira para metricas e relatorios) /Title (transform_data Manual do Utilizador) /Trapped /False
+>>
+endobj
+22 0 obj
+<<
+/Count 12 /Kids [ 4 0 R 6 0 R 7 0 R 8 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 
+  18 0 R 19 0 R ] /Type /Pages
+>>
+endobj
+23 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 555
+>>
+stream
+Garo>>AN"J'SPB:/*=)Gm"pbjH4@68cpH0lGqH%uh7B\i7.sOBY:na*2VGMU,S6F5b`'c-OPp)k%_teklh:fgB\$QY#0fZNCW)DZp<&g0;F\"dTOh+=FX+o>gdXrZ>DHUR6APY"@soYZSb0aKXQ8R^FPn-].N3>fbuq2S,U8:5ar/B(2e$]"61:r?n8.Kh3VmB-?t-;AXL,oL7l1>)bVbC/]%#\CQfdoUbtg/t8**(uYRhP5qjXNp,c=mtZ%7La#NDX<ma;kV_:Q6Tp:jO-l6Z0H,uQi^(_*fqbAQE>e)jX7DokHj?s&OkDEmWnk/UG"7@1S@iO5orb5m>[f=jrm12>[C\^\>e0<G(ajQ@&*/:NEfb`S^/$lq/r)Zp9]mmnmAcY$I03MhW1:m/[EPWtnU1L;\\O?0Db<$@?^7Y<"N>RFbG:&V^tF'lpec&\^H=CK\)5Bbq`/]76ub*uYfH.uV3?@6&Pq6?7NU5$/<]p+9qG=t`DkBG&^``+YTG3ms=@C<s>Y#A[s8;\*gT^Tj`33aKU2M^2$*Q5XAp]E$na=.~>endstream
+endobj
+24 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1534
+>>
+stream
+Gb!TX?#SIU'Sc)T/)JIV5WF3aUinP1km&tc9A?t#!<u;r4Vj@IOO=^,f+4)Z>H&:HOLm@[9ZV_nOtWHFF*MrJ5XE5tB3>8M9_$">#0&BgK1R7AI>?G'an:<@`A:YIE%./N+R.!(KZ0_kKk?PtWYMf`,@"e?"=$SrL0u`c3U$b1.(XCIdC8-kUeb*gs48_;E_]$J3AfoP9#WNeE7+kfa12`2+#D@_S=\_!;n$@qRE)5F/_rX'k/.R#5@aOFNSGILjuJQ_bPNMRf<hDp^-3!Lj[7M_94X`q-pTOj:_&Y"]T@=m'-Ed2;3:^!'tq/fAjjg/K52ZA0(Wt`pL`B!"5]Y;8]F^>U2m5HqG't0I!e#T2[Df;Eh-'a$CThJ?p\a\>N0\o@<+NaE7=,JMCXiEVGUC3G3d8I3:2qW)mO:'Ba_Skaa$$jV=!OHnF2sTS!'o:9`NK]/k3;pG+32-D9d'Bp?e,b,"9MF2Nh0$J0<YZGJiI:&+n^n\t3UZms=rArHbMjE*3l8Pm?N9,BY_Gi4?>#n@66nIi8rhBmP<^Cnt0nO7p/-d5=,)_UYnG92c`n-oEMuUp?L'bll)S(1d0W`-+T]r;Z-r4=jj_A_ENuXlpfIEbEWsYbd6^1Q,qa*N5AJ[].o%$q<,5MEOg5hj>J*H0n4:!^'N"07p1I+>@tpa6"V;5i@VPs0=9PR-\VS-CEJZ:0EBY_fA&QI]=IY7E\2i<"Of92sI:6q"=4;pN1NWlG>5+`HPa%JdABJ0!+SnpguI]bqubJ=1coU6u'GPD[%GeP_Yd)C?5A\\A3L)B!-;6/)$ghqT51MDc7nJ09_%,-F?LZa"(j&*6s</S2`.<bZ:+!#ht`3M*ne+c?=168sCrg!7uHf!gem\g?9brj&)502)@IU.VAth&Nqn*AG@%FDJY]0dUEg4gm&(F-Z;5??bI;@.sDY6`\O:<'0[JOBR6J&1W"*FQaV"M2IR8PLX"#"k7BVm,NCcTp"V.Q?igb2EPom:0D'63CZA9K:&]"<GL:ij40E`;oKj+\'h<MAO(Th[5'+FnYV;^(4^0HN#DClAAB<$ahcoe9Jp8CMVj+,B3t=d5Zsoh2F2Dl;@r&!FZB<onj38]#`h&5=N+^-b9sMU46L0)6XJ!o/4trS"^tG2Yql/\hf)[=A,$=@M&VSPo+[k;5=!#b6P\+(,99[eD'9VRFW?O<;K=MUm?&:\MENn09j9$iWHDR9pjI?Ci@j(O"=V6CfX]@Vpjhpp]1C/p-<k=OZ$N.s0,mUYI23SRj]J@`>7A%u`F&o3kEf:%p0Ot5t9-<P;0/HTJ&m3f-^nUAUL.,=E-o)>,]!ZZj]7An`iL>;q^i`IpU/]-pXn@Qu0CQWiKcd).oia'`CJ;4K[t<N;Leeajb"0,0I:K=L-_r\s.j(ou3uE2'DN_kY6"I"-5"/l:PZH*:^(M7>9nKq:7&TDHHf@'hb6<K'\Cc%*4uU6MX^M-Od3JKPK110dL-u6H%(gjYjb2%M$jlqS_RM24Ci3/lY:_gBmLa!oq-els^C/Sgec~>endstream
+endobj
+25 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 659
+>>
+stream
+Gb!$C>AqtU&;B$?/'_?lV/1?fn%9coBO="]@%OF<EIq%s2f"o;Y=H%U>a26A#Z98Y94#l21Z.OM5sg1C[FbJ_F'N#`Llj>V>%m!cn2AV$R39O>#7/n<P_0fR2FsmML4gp'SFd:<(r=L"-kbTtO@h&WZ;Hu$7U7J@]e3`<dV@F,>S&FoAXVMFL")-FDfFR0=LZI#D/L/pMjVcY51Y-eA's4U=08O\ERCQuaM/n5(mGO6[C&=7lXRoBlMB.59g)/2?'DjP=J:A6.R4gk,XWEd5sO!Aq"UPA+RFLk#J&KNn2bfu(J7nKa':QC<Rh]H0Se+Fc9aLkSK,@29#ep;XPP*s6!/'$`Weo;#c.+lh\r,mH+(t@h#%jsN>I>jUY',3CtOpVek(lRi*Bh7_Bl:O64V-]B*ClG0LHkI=6caV#Aotui.&F.O*@/nA=D"UF_?-kq;s!cI>MN8HnDDKTPke)`>$_X94+e;\'qm$?]FpV$0Fb!-+#gD`Z0YTiAiUh)`DW'%CQA2<,VT=/uj^rq7T)iZRkr*-8[\'asT3S4$?e/#YjGAE;J0;5E$lBC/n?YWe`Vb@S4CIb9m1DBlWhl3HYBuCF^)&L7>t5LrQ,h@N=]^C?!8sb:/[qCNqM:%h,sS2f0L4eXUq)ep3#:%srCpTE~>endstream
+endobj
+26 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1314
+>>
+stream
+GasaogQ(#H&:O:SS@:IDQR+*G[P%fQACCZcCc?@j!X'0nG*kmrQDBs<^:k_$Hf_r:K`POOC<k$`B8.2[i"5.dl%._Nq"6s=88P^GMCE?onTqOQ=YWdr>h*4[AKiY@ik*FnG,kW`Q/Jb)<JeB6R4Rq2R:)a%!`!8&@[.!fe1!"_eNU-$I(<P<T<f(W,g-ND;+\m>.O?u9f"obl\(:5E>7-%i1]0h^6lfHhO25r##IW,Ga6"=!04O!25ZJLl$)pZEH4qV4`XZWVO4K$(ZV8macYB[heQd^f\ZF=)c,`ZqbG\RKY@<&//&<]8=-+0?<2#2&ob[#>5Yt+4;@-29?tH$(*^:mF`;;KoiCH78Z_GUQ6B=6mX;758>O1ceFhP@h*I4^JLIt^T>_i_]s)[!3Blff@9VY'$<>R6+M7(,6DC,f%Mc1(6>82/WBHfmE(5\QSAU-[R]]-S%fR/Iq,@'d\O7;Z^LYFsg4si$GdqdtpHJ;2c78%<meV;FcCpe?6lQMA1I>o*s25VGk2ZC#PGY>13LJi@jKk5Cmf6.#&ro0e_I5IAD'>3j$pB`.5k&28&5-<][8"ZA?@s!#B7u6><:o%GT:hRG\BRS7Q=N>@aVu>*KMI@t)W_YEA.O5q`>LRtZV0]egD02,)h6F=^g@Wr$7m1`:)M1E)rFf[V`qr?J1q]`rYPUj(5mJ;Wf!OhAgI+AIoS'l[QMn:i10\F<;!B]Sn$8Ikbui)'=lbFk.u_dA*;(#p`RGRF&@C1iUTnmI2%@BkIdD1;ps$jgT:VZbTUE#M2`fN#X@HcUYIZGcn4:2U+]>UL(?HV/JCorppn0_)(cuE<ep&0KrWQ#/P2UaMH[Vra.?Jll?+2dMCQVL4SSb8Hk.ZW%1^2W40MSjIrZB)LqFKsn^Z;IG$DEPo9BKA/insg;o:d]iYe!`#:ks$q(/T:rEg:2q.uX?;?HT[;7imH`!E=##f!RN!_B)l\5%rJl<88Q0H]HD?GrN%65/VjBB_]'aZl@J0cYbgoHf+>Uf\"h\GP5ojO.KTD;>n3(20q'Sc5j$VrB;b$"R%0ZCuV+4$M=qiK6=&r&T@%.4?S"a0_sckK[[S_MYH]$eIsnqm1<s/#ERGt1NQE>#``(l<&;i9McYYq/o!6r;E)@\qPg5trctl=hlR$qXdCM]=XgSFMn0I-o+gfpc&1WXIP=TJB;)V%[nYZ9bB89>S=Z/c(+1/X\UL7VEg]/G!lo`*T=RhH`-M1h\U)o@471IXN_MVVr]k^e\iX4KpJq)GRBHKNh^!9T0.1a;UiD.EIXkQ3%Au:F`j'kXgrY,t^[<D-?N~>endstream
+endobj
+27 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1222
+>>
+stream
+GauHJ9lCt0&A@C2]V?H71s+j.j\iI.)ROJCfN-CXJRZ8b.l>2@biRDnIso.u<aJ3ljVC</?j4c91[iT$+Xt4C+o6+gJKO#6rCK7FbjQYg;ja3;rI"/i@3V&;.`%oQ7$<2AY>!mkP6N"\i%4%[NjMKJbgQuW@%n26?K:IuU^o"Rp2N)C2K8o[cS)#BNC"bO/BO\U+XQ.uQ^CuNK;YT[F5Hn&;]s:rpde+L9@OHd#.$.9;=48fk4b7XM31:/<L,?cUtUg\Ra=ncY*jRKE^#HU10#)P.D\n^EXA&/Z;^qM=J$ec-s<ue1!1dM_$X0XO9J9VVQrD;B3L[WOH+DC8r,S3b;5FTp`EF,>^_trgCbbXbDMN7=JUdaV+B+BD2IT#jlBjUX]r'ePfoSn656Bb5PK!tRq("oNBIn;]-r5O9I6k66YBR9>RM"i["4NBOW.0.r&+s9G$niC0,.O27@=Id26&eR@Z)EJUL4->Gj$tb?<=!Me/GI_".n4pG8*i=AKs<!=XB,3'?3J8&rHE/6lP[jUVJ+7\<=`_p4TAakBs$T;`dt(3cl-#Pb(7WGIjNk"cXoc$>-hg&##m0T?'<nd?STRnqPLo)O255rsW7>1GIl%i3_#bnl-8a:0\e^/i'@r>c:##B7!m41JR6XgNR"g^r6L(mKpH6&V%4T@TaV)9a,,bgf!dp\uhK.;&.1HW\Th_rrOYo4\-mAp>9kp<*`bh'^)@XT(X%ME`dTs[IFaf4Z*b@IN//Wp=AFSk^g!.jdJ9;kWIB*e-0J6R#5]b1iSo?9PNVE'8(fm9c)ShQmQM(kV-cMc,oK*Udb*:P9obj])7A3h85APit-815A9>`>:gkqV2:D>pBPItbi0KD@^d'F7dE$r1jM5.]qG(5r4"(M3=CUH(W`:.?CTl5PH(.\eC8h"2[6ZEXAM`2A=@qSFQ45s,X[7RDnY]@TjGhk*[ZXI05,8u6d'\kSobA1FLOO&QfFIpo=U%\3G1dH#mF=f7DMN%(0lEUS"$`hhpe-^Nln#hBN1.&VR"JDAtV/s&2qLog\91*:)o%m+K"^7jSAQTP'_=61DSk\R$sM.Q_%Flf9UfoY.W<p<j(#XXpptMJ#N<S>/piLIRBGDagAZ]OD//?W,fI4WmC=151cC>FRPiDe]$jjlIJ!mgD]r%\c+>r\3G'`?@A3F'TYU'm;jXTf"\,WK9,DIa5$,e)b)@O_aH2F'28B0#8tPG~>endstream
+endobj
+28 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1376
+>>
+stream
+Gb!#Z>u068'RcT\E?8fthUo+)d=%`?7>jbe0R['&;IpKe&2qWN*!];irQ<Dr#gBZW<r5^Q1o'T]rA`usF3P:?!Y=0W"2(8d[gsH`@(lW-9Odu5a7J!?N:BjqR=be`o/HpFha5.3B.Y<<4CW#hV,4^3,#nqYc?R>hXMNo`//T/DKAD>pCV(ScA!_XoLk6i`/5Cj`-3T6;.PPeFkH&R5"ki$BWL_&F!R>fAlP_).MlZ..].V4>_>G)?\)-\oTM,tF\WG,hG*VC$X/J1cAjt9FmP:2C;4N7fR7@<P.?Ve.9TN!3e&Y[tc=5d+A=R3dcQFtYb=!\nf4Vdu>)d(X,F+ds$!<Y;2"JE<V8237XPH,Qk:F_S,gelrK&o+\:MVhjAf%ecf`np%\<Ml8.F'^`c-L[)KH9"o7-Zel+Zj$4+0cXB6WMp/b#4#C^pMDP;GZknfGR&>jc^PZ?F8fk7"[u>*X.VIHXpiZV,Cb$YXQ,\GJ178O4rj<[*G>?Wl&9Sn/Vesd;ql=]fQ2SCZDe-)@!Q/jg-A[U2$_q'1s0AM1Wc:h*6W=cK]1Nh[m\6F%mZ9:$>8fMMbSC;MS<5jNF1^FX3.F)&l/3AeId+4ARrh5gC,_Hp^@c-%g1Wmmus@+@PoFkn&g:64+=O3UWDg6/QKdp.1=$K/ut;f:,S_I=mf]>N83N)gE.k3c'NqC7T'(\>_MZ[OPV1:f+KurUnU3F5$:-FniOLguroqC0H(7Z]E*c>m;c@]u):4fB`9?O:k8lj;ABKUG1d.KZ/`ap5Z'p/</2';J]-O<gp1qPp<YhL<@4WKO=kH_:7>i\5:K:p!Lb8lVX_\.I-/H)R1hb\:db-Oqn;Gf=def,$+64eM;\T0iKifE?LIQ6;OXk;?^Mc!Ch8q_Cjc$qAGD/>KD5e`kYTTWh=PhF3!8$r7`C,mASj]fjC@)cVKU_k3N&e'a$?8S-b9uh<=QELTs(fb-\n-$#SReU$%3rr#L]g,/3u,K%t-G;2;LP]APoEESUPlB.m%m9]9DJ[!BMf-:+."7PnD3Sh5_%_ntKQ[[E$q<J+-JUTfQ6cG(&a"AO9O3+]*rQ'b\@Or2L(SF\QHSU^W4W!><mJhgVTk0XdPb):r)"m-l^f/L5*f*uE]%1;!k?FWN$#T[)p(%7cO%82jp*&s^.H*qS_aolumC#@W>YB5PgQ;sV?DeEX\0O70WF5:)jAcU*6cG)ugEAZAb)?c+4[68?G)$B9+H_2Wn@>Z"M>mY&9I]`g::ZjCSUHFIqP9/f&gZ-o9K*S]305>h.2@+q^F?e?-,?nm.#MErUkFQQ*e2gkpJhoi"'a3fA<S5%%RI6TMr]/Xj)Y`C+2_trII9:@<0+D2K@s,>GRpS]50`)*!^&DF~>endstream
+endobj
+29 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1526
+>>
+stream
+Gatm;?#SIW&:F5UQq+WqYTuY7PYi.Y29DO\YA#Z([fQe8U/Mg?ktk8BmaiO/fs4R)EN^bl=LOO-1Yh(%2[gB7XT'hdi:f+#>V\!no`e)$Jb<e`X;A>R_D7^?*/'6',oK8Oj=.sj_LY$.8i!D%Uj5RWQ:`E]0Z=l\_<19^&'U11E@Fbs\.%m\gdM%TJjFF?8C!ng-WFUrlPdr)B\.'JW;e;hX)W<;5IKg!L!o#MelMKO?2F$rlVCVINfb[iKp4tZ0'3`bgNL09hOOhVoq@rO&s4]5j<1GC.0iFCSr5bVQld'POV>:[`<;)L7[1t/\0?ck6M=N"oo4)4fb>YEN+EVIP9Qdl)'M$>qIAL('I5]$.]!2(dY*gS-0"Es_Y)pEic['=9asi8cUc3G6;]sP[g?o/Z^tm4&aOWWO2,N^"g5)7`CFEj7qkegNHM\V4sk_WF^P)X:[d`4,?6qd'5d@IS^RV1J^GN%NTcmg,YpD?q?rU1*^)=en(Q\MNPa9g*oEM$lWOt1_6b,p6.>,-COCb92J@\$51I0DNGAun*k+F^Y\c(JD0//qK%0n!C!B2!SDLSGAi5Z,;Z\5@/=-cU.*5<mfN<`9=ouQ[dBoT_]:_qEMr\EWdh-5Um,c2f;f=2$3XLoU3Sdr38gP-us6PGjEDVJ$5%P`0?4CAn#pU4T4`ZGWIZ5_Ako^]7T3X!$46K;FH=O[jY-u?PefO!A&L7&3F/Q'WNGV]L*QIOa9l"P#Re!]NA\G3>49W>3`7;nHh?JHC9[auocFl$7(YTV$RKe,mIpHC7cjXs#Ho=+\%$$XfFL0p&olCU5?8!eclu;\?OjWF1-&9?3m273B8gY\UXKi@05%>9N9h6as"D=7nC-,%6Ik@V2QB6KMS*qUV(FdVZhFG_P@>4LV@6&fkm-K>`a20Hk%pFE"FebMMhXi)"S0TRaqo.1\`n?>'F?+K2G%K19#=()ma15mV<j/)r<]=i>n.Pr%N_pk\nqUCeN@oWHE.r/5Fg%jkf*2Gk084T+ftsN60JUdNp1>T!iC87L+8fb7j9]ukO,Kmk`C?ssU#?T%(Ydh"D9sAHp!H.9p9Vg:Ts&F<>P%jA]j-a"-<WMqFOgs7g:9o`of$/M`k319r-QiA!'W7'%fr`C'+o$BMQ1H6h"_NMNig>CI^NSYo[#]d&ptQY[Q\e!r#(9GBUTh$Y6Vi$c"+pZJWuU,PSt!/:(:*]"sKiJ0aotPNh%"Hh\d8(L=AX%j,Z?YGP>dCT_'&Wa;e9T1c7n]$tX3LMJj]fT,`L/.%uf$OnPQlo0";Wfr/`9lH$hVpn!YJESHo<\2BuL+kYZ>YmnE$:#eeb-cY93)I7)oFboGZipqI\$(8V-kc3hr*TE7"@Dm#\?0S8?m#CT[1-.QD,t\(D99S4ZYAd86;;b3UT].?b6<KBYOnWS$N_3`o`d]93TWiDo[@^/Q#]HLrbg0kujc9Z#hi;>O;qolrX._c4jtM&j`OS<NlE,hmDM.o7g!W6_X5]MQPEWkqO/B/C9YFp_YkS`c6%_]~>endstream
+endobj
+30 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1727
+>>
+stream
+Gb!;dgMYb*&:O:SS@?!sbS;R)QbI%[Zq/U#VN(1JTO9)"ARL?),rJ0,IR-T7BfgKi7BsWPJ.qN01H[d4Af-C2&ZG^\.cAW%rcgq!)5]2d:,o*mEA\b"N!N.Gi&M)'0o]*CpW3R)HrM=W7O+'c=UL9!_GZL=VM&QG_CEc9O1\nUgtRfZ2V=jF5BcJWq^<j*7cK(UA;lY,V[V#]j4;AaR2K4W.qL4cRG]`$GB/8_i3(T<rC`Hr^;BL`e(;lc@#u`BiKWk<MiDU9fkOG]XBHOs#($[&ZRF*b"OA:s+p?*b3_Y<)k)PRfA2m$9Me/,`4O:eu'(^c(hUdaWlWPJ?IAEC]1]^/]Sjr.WF33q5rM\R<&Eb=\7)Vqg`/Nb6k1d-EDF^<h&#0SO=hcCs.1qeV.&tbj(5*]:iZiSi7/c?i"[6BHDuj7Rb0FOk0Xl)"$]2(IpNP4r?NnLGr,a>!%mk8Wd=GfTqk]sJpFEo6Mkt,qTPIhHEt8$%W_&u4<>,&3<XXc$<%);=es-T%>,Xb+pZG3d5ErURJQiYck.5:*N+uO!)Y.^s8Xf#hQpbZ.5t"-4KS&iH*WS_i!6-14K]:PdVbJc12Rqq&i$&FNE((Fi72;b&k8(Wd^)0Z(c21oHeG.kX(E[NZrB3iWpPgoDj[)1R$ECtrNAX.;V*2]rX#@A;JQb(%(js\2&mSfnRoXk%V(O(LP,2/7]eX8s=eBWFZqAlf%pbV.Z>3/\>@#<BeZF/69sEt4#lJ%>i(10;<os].elUs.Zb@rOG1ApFlCjE<_,=GCK19uc>'$n$QS=<EbrNZ:1a6(c:_&VB[nZEAcQWj^&)tk2A2,?6Sq)`d#Th$Rn75(pTtCFiYtYS_?l.c5cj22nJ<E#,6?#U?#;'g*gk,E((\5fOI(*=s8;j=pQ%q"Xd]r6\nepj<i63+na9=DL!J*Fn..3.Qp<3=F&U7QU=D`'=M,1'f+puAcSRK:6*sbmeRe_>a#D2-R0s`Q=RX1jo:9BU@Q:IpaTc2h3DC=ar&lO^oJSL[[m;_2_/Ksp"F%OYGP\9;FN1Df;dk.X-*4?+aI1a59"lSXF:MES`9P!Ic[sD@r=1uaq_nKeZ\;\*b`]$!/IE)#ckH21m2-(Z`\l:?m>-"*b;I-C3[ID\<GLDe_1_%9\<Mc.p&h)!DPT(S'StJCblpU3@`;$2Geh`HVXE?.1;^o5P]nqp1m,H4\gVoT(HY)pZrnFpJVWlT0=/mFE7C,#sL8V1ae#pOPa.\6EbBIn'5T"YeguEepM$N,h43C9(W8-I@EW\+fmmt$.[0G=h'9!A6Pf>kBcJ[hXE]OqS_1#lDLiMfc-(bE#]s92tFnfWai\YHfT<&;\'hP!P(#cCPDB"E1Z?pc&;FT20Ha[98#X16uc)n&m(1%fKqWB9fU?E@*X`4b+%=ZHREKX1O5RoZY>:@.W2YL/"(aqLg;E#,WZB.:nj8+n7[&Qq;C:!=AT<I?=g&gtYJrPt2Z$4Zd.\:3&(@clO`C\A832WU3pdG_1p?[PLrN>FZ6=[`6Kr1,PkP%N"8hQC@/cVYMB3.&.*8t:T2)Df<@64.9$^8cB)/r`_Y^/!_8i;n3h\GuI(;E`&*7q#FQ"uWFI<VF,DqredO,'Z`D]RI"?/qBY9%DaKO?Y<)UO&Jb*:`uHeWnRo#Fgd<i9E!,>e%l,UO;gHpQ^SGDuD@G]^tm2T"E%56Il)L^c`2KO2"ojfI4AX(6&4nn-:JC~>endstream
+endobj
+31 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1681
+>>
+stream
+Gau0CD/[o`&H9DY@_P]9lgn=#kB(n\[.FJ+V\YS:8B<&o)jJ:!m?GJk5M8VOP@\se!iJXp-(^N;4<?`YKE)2b,lZp`^p>?bG#!Qa=C)$eLr8cu4C9^)0+^]h_D=HA1W!$TiKkm!Y87XUO9D<mb7p*j5r;:=0S5*+"K[?Y-]8h/65JTj,l>(S_OnLOlWk8/"@Z!\$Be;?GtMLJ_i_F.EEC02*t%*ES=IB1e[2?._SA6?<ol8?)#G/9T4%I?6llNm66K#OT13q!Dj;tMF(4gb=?l@F4Hl.DJ.eG^$7JJZ`eQB<I:Uu"L.&e7&JgW78Y/MH&hu#KLfbJY\ni'k@uQWcOpXIRi$f09"!iRZIkR75$!;q89JD5?&k5_f(uN!,i9fNEnThCBS*ZYCR\GHH$$gsogdZ!f3/O&X1Epg_T`nc=Ob!$Y^X8l8%LNY?Q%^.Dic95IR#a!.C\U!(Uk9mWE.gk.gt"3`X=;kAi2q0A[Edh.?*5\kLJrDYS(`C1]N'Z;Q*L`\[UiHdkRQ1;fn;dD-RBEcPoNVP8L=_9Y(GP2N3"PL`YCiD?9$R%AQ`f(mOEFi(I,l0$:-Xj7dbJ4iN?$QJL:jPS2!!s[(g)9]+f*1hIV>F/o]B#?cEbLah`gEE].lUH[+J%cNe(S#6GQ$)d(7<`t`&A/E[NS9+N-"KI#gVj<B+P)%#ES<,FG*La+Fe(eTsMN/S^ZgVSona*0:D_F'Epk:g[8l.jTnp=?-#l;e.1?3N9+i;JeP6h'`mo#&rNO*:g@5U;EIs6-XB3.p<2V[QXEN,h654+JTf.1gEts16X"GeO']>a]H=F00h*oeAREYE.YE2tlP<@#e`i[pJm]c(Rmk62>uh]e&QB_\Wkd,Z_p"j`LT:b0Ot.G<$&$>A2)pWH'lMB6+nFld#F@[*IP6YID9NAZ\V+f$rM(csEggr"2<p[1=qXcMg8GWcY?^+34/)J:#<=^b;,aCTad_DD-=aFi%j(h#5CM41nTPO6-&G%S``A2bdVd:5.GBX1ji'rWH4ZK`^pE>As4Z&]5h3Lm'j]5M&]EgUfLS#?P"FgU[:nFkO.Y3*7Wmi`L')F+%KjjjEbG)sp>LL-q?EQ_QX<iC`8lZ,sG#/'Q&#$Ncq1M'U$tbBb)X)d3]35oGA&4C5gef:?:CAn81p:me-?-+XBuB'*bU4Kb#K0j.,fAgu]&V50;r_]0XLYtZ-Fg5VH?-4MuW6>hqtP8qLf"[:%YD\A_lH4KEiaNAIX+c#a.:o2>ub)56?(FgpBb9.A>ctYAbC.Nlsj9N)+*1Jf&\1*t-[`hGWR]@o3ZQOrH-[2lKRrD_nlfccNc]bfocqClZWq+keX?--NH!NtI#O'%\6>%KGG3bU7U1Lg\fi";(WG?fh4t(2;L6tZq`qF%E:!^rYKuSX$Yl-t&bg>pX8S<YLpA^RbLO%7kT_CsRKh)+:Iaiel.&aVPa*LAH*te\1f%PCLY@_em8H92Y`i>-JNir=hU>AO?#AJL$\!s5o(T&FY.nO9_iLrcq7s%`.8tog7H@C$%Jtib#&fcmZ[`rao0e"F1Yl$8\h/V%aH!mbK<2&8l<U$AW[PZ$4TP81Y@lO$ZpUSfpcWO8#Xuk7<Ob8,0+j?D=E.j[-S:eu=\ucZ[kI#qH<LN?a+4Do_<iTr9lIbmp<I8B:1g9eIenie_/H,`C;1]e~>endstream
+endobj
+32 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1609
+>>
+stream
+Gb!#[?#SIU'Rf_Z\;tN)F8QY>%E!q'CPNB?[O0k&!Xq"#PH'^4Q_Y8$^O@:O4*4rP)-./5!%6pL]nc?RF3$&.5_5cX\d/"M%H"g,^c8F!J4Uqnr=3/;(S;IrQ+W1n&2","-'7oD$ZO^U!@VVN8P+%279'n*(((0h9JZmu^t&$F$I#29E@K:V>R'`=?,uaI"Tu`#:n31#S5<@/=SK$.%L7Jp?2muY!F`Bf?Z?pfK>tbMU$^PefN@kVefS?!4@[Tt8u7>S>jb,SD&>"7G$$c2YqBR6M6&NK'p(a_PQN?A?HFeC=<AQE;%Y[X,0RsKMC;eEi0jqNUe81Ha6Rn6?o1YW9#aI,Uf=XqnTW4!iU#aHYcE>RLscHlcpJs9WL/ck@i_'mhCh&EG(nDoVNR:A?q`rD5MimY2hb7`)On[nnKJ4p_6S_q[^Y2B6B,86G1`GmoFUoX_*Be;]F_B]&?7G`L[9]_&#5n9&"TGkQ9Yf".`Hp3?lso/4)cAK7i8=%^Teh<eq".;_4q!&9!hJiJti*Uoh!*Q+:CIB.0Q_3TBX#KD-WgbTd?M'_H(`I.p:4kDtceJ1+_UL0%j/;J&k"]V+fr3O$p2!*Yo!E,q0!6gXTs!g>t2NX(Y!$8+ICYYhj[j)Q6r"NJ/E:Ggcb<_75:&)?W02)#Xb'F0sgI`!/S=Ht*.Tg_^5_r3gT^Dd%p!Hik3jHTANo"e6tAmEjE9G3!U7"bNUV0->e!%6B0IhaSM<SnV]=_%ZV,Qs9Kr*C;iH0`m;>BQk&(4+&`)gE9`PCNT"9lH6\BFNqe2UNlI]fEi^U&\A]aV@>2>A]B&_`sua\WO*FegRBA=kcc"=CZ@RTJK.Zhf.RL9+!7gF,2dXFV>cM(=sjQ5'/Uf/Hc'RL1m"h!*(HoT6E/doPkg!&XE2rp2So2O_'GN8(,P?lbaI<00t'F?Y@q_lhR(Q5p^)R5l)BB\*If^C:GcUXP"K["lW[ac9TcK')H1Mg*k?T`1HN.YC5444:Ep@/Ks?CkC"j'4+`'i=$1Pr^M:A,aeYB1MM%&\nJPQMEfp:NlJRut\rV?E)A.*(]@i12MQY0pjN&O*hY`k:b.>,N2lomhO[PrQ74AmGE=/:KCJunZ`VM\EC8g)[>aD10MOLaUK27rI.\"!r8ZcftVN5G+&&]lHaH*@!q?G0*fT)-uD&(Y0Ahqg"3S==k2F"lC;)9.U+5X-U9NccAF>6dmg9M!kr0*(`nP<'`OEp(l")r8<nB+ijU=GIeP>KC6p6jG/Q#Ea??Qg/8pZ<MP*60@EA\sBAkMRjSmWjCP=:D:/NoTZRoq%R7M8TSI`qf8RQ5LAg4m$N#Bl)m_Y+^Y0QSA@kYJqY.c/c'nhgmBb7^PG!Tq08IfcSo-2%p8d\F=H)\/3n7P\-3.Dm9+tj>SKGFI)K`dT6.CA#aRK$?sh"VMU^1OZ;6N3^T4A!+aG0`)rgpR@!o')d0;41Uo-pVNJoUl9!X'1=qg7:P236%/D5=FQt1n':@q[g#HaT:f1WLKoS3/PXF<U5J1Feeme1_VLN084HgtNcW;UY4Q-mFSb<5LLRG(o7rgjkCRIngr*C>^p0@7PPS'Km-T;Jr;)a=;Jbo7FJ"-`Kp<<~>endstream
+endobj
+33 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1375
+>>
+stream
+Gau0BgMYb8&:N/3S2]1'[,iq/IOSG^/m>(@,tad<"ClHtDaAE?h50/ol\hSj96,_W%U9:4J/r[mS2kXnM$O^Sn>ogOf*Qo;OH9g5.:aV89KqD5A@*0[RB&.n+]K)t3/7c8Q,:g9*?l1Q&p[I;8BXu24O"F1+U]`-):Nf)_6H<epl.]3jB!Q'ln$eU-mUPoi_1d88r4t<'dbMm]qs"KNGZG[j9aj$rhQ]p#.;9[Y8dG"C1C$nq&>NA_=NE!,g/S"<O2#>C#>-+VAia2)s]Gs'hMOrE=%aSAY^Hs<0bQ4B#ma[BTs]f@^-M<je^$t>!NfH:9l,a@U7ATG6B?RKB.lRGm9CD8KNTc&6%QM[o)miK=DUuO[]X\Up1Q/N0Ep;K289.d:2a<\7582Y&]Xs=eKNE0AHd"#ibr#&4mB(64J=XEIfXKZbH%l0X\RW\b#1'W-(OHK?s4./5c6G=QC)e"t;L(>b0kq$gh3FkfCP\M[OBma#SDT2).%5dIY\2;.[;n5d_>173T+\ntJqe-=7qF&:E]!."DUW7^+Zghji\H"fLf=!dWVHF:SG"RM.`"Z08/ioPC.[k/M\Tg/roe#'[aul7^?W$TY=_kG^A<9P\T(0e4GF!-3I)Nl6B]fp^ViHX-QRJt+^<EW(2P[d%Cgj'C*7PuoL\Ko3/u<^Va^:2rYY%(hU7V]T$Q;qrG;gQQ9L89ZqBSL;c)>AjX^O4EV(55qIUJgJ,o_1g:@]R1YT2\%L*R<!Fgp1k=Rj7foPoCsoF\V0(4G2AlLc<EWmJf_9TE9>G$S1!2Uis+mSRPWL6*P`jnp.CV<;C\X:9/Glq[gr@l[PYo5Jf*!"eX`iF-A/;#mTJ:`MJ:O()M(Q*Xf9r5C:Wr0;7`dl2*+(IY,)6I-Yr?9m7P'k#4@n6$ToEnH:cbO6"T^t3DYOl#MW`.$)s._o2U;<`E#e-U1ZFi@8<L0SrrQ<G+LE*6Sls>[bA:=;)Nu3A[Nn:1U_bsAaDBYJj6TXFh9lh!\^$VOSA]``Q\G5o/633p,%+h_6/,k(LHP=k%"cO7eQb+Q>Di6CBP;BXQ$Njan9ut=qf_t'9A-""N0"t4X4mHIKJ\,9b-72ZF=6m$_1LmY?n,1=5%cGKT9J_4LEH+a"MXqVO=9(W/-AYF#`L?^*0[%%N'/A>dN9uO3?`=[5p*P^[gYr;X"2Y_13W<l9/8eCu63+lP=Ep$sksL5&iZnb?gQ?Y-]DmnlUYg#PjsWf2NP=X^U_d:M@CRS&]HZbqB=g:<tsaeJ7&A,&@2r:Q><F[QZ_pI;2^==/PFA9UrXZf=+N`@WO>Z;YF/Kot!%(oSqJilCq:Hm[gI5^W'c*gth_lP:mCZXOd%F`>cuXp?N;[rrP_R;hG~>endstream
+endobj
+34 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1395
+>>
+stream
+Gat=*D/\/e&H;*)ESm3#1FH)MgJAUJR\jb\DFrl;$W((Sg0l4`/kMo(If45KCeJOaV*b7'jP;uF_n4rs*$U2hGFt]4pi?VRT5icj<bpWV8Q_P$ldb"\K(2M[Z2c4^bi9*KI>S0_B$ijH3KI8XjV]=4_F0]c&9Gj4cG:r35?i6F!f@IH@ekPtJc=GZm(E`9WF0]q"QVnR87hp(##9cf`ilL#T.16Tb9agAVSsH'$Qk#(oflP]pCpY8@.fJ?7t<?hRH-\0&\SZ+#&Tj+;d8S).$ht!O5^4C,)\tl9+k+CSP71%:<+bb3h0Zt-*i-!,0<.3/=*8/40AtHkQZTr0hE]PcVe.R.^Os1';p?kD\gS]#B@T.4Gb=#87KCB*m;H-%9JJ2`Ri'mEHrXjM2WaNk>7V&$THKS_6T7s7H3.nW!CW,UjtD3ocB[4,Oq*6i[ePaRW8]i8KPoG/L+.#Lfkq^(m[JsS[*0jc:<baq66Ru/qt&U15Um9+!dR`?s_p/%SU*5^kqt2^p073k0^@7kP6ZHRf5@LHpm';51*m^L`c(_$6k><]<bD\N*C5]`8d428\t/8YOAs.0!W?7!;T*ZbPMjKa?,nnkhPpog:D4dW]BJjAu3`&6IQkB!CQ1H5mmn+$7cJk0KB$AeWg;k[LV"6W.8**dPa%ae.o9]';ZhGIYtd!4.Xj+o5%-*A'fE,c>*4c:,Qo/)B,*bqVVnre=E_r&hQgS+)H31>O-T0*md5jRn[N(FKhP"GV4?cg3Qc8.0_XSEYn6Y\kuc_8jQUhT!TnZ%;>37Fdt2R#Pa^15!4^A#T*i4JZl0W$c1e7XD]XdVY\_`bYVK<9%tCg+T$>/CUUW+WX7MMaJ5O>O[l6I$7b.;F(af#:!e&i%F&Zd6e^_u#N(RHJhCtAJB!2m4t+l[U>PT^IA6-IQ(gY_d)%m3nG;BH#t<`pn#lZhCIZ+tH"NV`clG'Dq`l&JQQEU!&1Xc_#N^SR6gJE*PWA&VkrlV@*WU.R?Z24AIQA]a#X$_`%=616>*h0?]2$hdDXVFDRS%k=C!]+,]!-oA[O^_en@WPR(VdfX\'9W5)lL?H<IYro*0m)e*I6Vn>2RY#\#D/hai55&PbXd_:T?SC$A[%mH21nAl/e*6C).=)ZTHY/a]6-9Ra'Oto[1Gi]r*$Yd:F\>lYNP6CH(gq9""q?$O4!\VP<`h0-+'C\*)FoCG@("a/H_QL'j5Ah'kV(Rr55Z?^J.NORt1U9L^#8D;Hj(I!OqD`a\_OJ'"(qcQ+V%D+:C9CksFmI9aNCE]F1h0;5XBMM"JoUVq_=SiJ#/0Cj`E9.-Sf4d_DSH"a`I`=j,rgme(,"tb%rI%hfLLe&m3dXqZ_;'8ASR&4:^cfr\IX[!fuMd6DK\U(f:`P2t;/2[~>endstream
+endobj
+xref
+0 35
+0000000000 65535 f 
+0000000061 00000 n 
+0000000144 00000 n 
+0000000251 00000 n 
+0000000363 00000 n 
+0000000568 00000 n 
+0000000683 00000 n 
+0000000888 00000 n 
+0000001093 00000 n 
+0000001298 00000 n 
+0000001375 00000 n 
+0000001481 00000 n 
+0000001687 00000 n 
+0000001893 00000 n 
+0000002099 00000 n 
+0000002305 00000 n 
+0000002511 00000 n 
+0000002717 00000 n 
+0000002837 00000 n 
+0000003043 00000 n 
+0000003249 00000 n 
+0000003319 00000 n 
+0000003655 00000 n 
+0000003793 00000 n 
+0000004439 00000 n 
+0000006065 00000 n 
+0000006815 00000 n 
+0000008221 00000 n 
+0000009535 00000 n 
+0000011003 00000 n 
+0000012621 00000 n 
+0000014440 00000 n 
+0000016213 00000 n 
+0000017914 00000 n 
+0000019381 00000 n 
+trailer
+<<
+/ID 
+[<1c1e7245a5ae9faee75f71902c89e965><1c1e7245a5ae9faee75f71902c89e965>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 21 0 R
+/Root 20 0 R
+/Size 35
+>>
+startxref
+20868
+%%EOF

--- a/docs/transform_data_ManualUtilizator.pdf
+++ b/docs/transform_data_ManualUtilizator.pdf
@@ -1,0 +1,308 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 5 0 R /F4 9 0 R /F5 10 0 R /F6 17 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 23 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 24 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 25 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 26 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/BaseFont /Symbol /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+10 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
+11 0 obj
+<<
+/Contents 27 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/Contents 28 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+13 0 obj
+<<
+/Contents 29 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+14 0 obj
+<<
+/Contents 30 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+15 0 obj
+<<
+/Contents 31 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+16 0 obj
+<<
+/Contents 32 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+17 0 obj
+<<
+/BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding /Name /F6 /Subtype /Type1 /Type /Font
+>>
+endobj
+18 0 obj
+<<
+/Contents 33 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+19 0 obj
+<<
+/Contents 34 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+20 0 obj
+<<
+/PageMode /UseNone /Pages 22 0 R /Type /Catalog
+>>
+endobj
+21 0 obj
+<<
+/Author (Robert Seebauer) /CreationDate (D:20260513201340+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260513201340+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (Pregatiti datele Jira pentru metrici si rapoarte) /Title (transform_data Manual de Utilizator) /Trapped /False
+>>
+endobj
+22 0 obj
+<<
+/Count 12 /Kids [ 4 0 R 6 0 R 7 0 R 8 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 
+  18 0 R 19 0 R ] /Type /Pages
+>>
+endobj
+23 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 556
+>>
+stream
+Garo>?YeCM'ZJu..F-sSaGmA%la<r+ap.7qm<**!ibHDTW[J;Ll%bh*BsS8""NKVKcT)V*5_/$GeH<94QL>\Bd;Hag1tn"8f/?D6Z'.W^OOT/Q"&6Ba-s\XQEYAjQB.U]-nih;_K[!4YCk_I!A-<.\THiWqP<kD?X=nU.")4Ib8^<](l'g:oKUT"ls(q)24o&`pB4@c$N%i1B"ggGLe.RQ8Ah<oTFfb*bg7N%s:<JF7INhB2q_qBX,V,.82P.Pi8)gF+*9%b"KWd7OoC#f%Em=PQM%ksZ#0lN$F;cmae@j#_4A!^;RO&hckCN@RFg:(tZ&U\Y'CKmtfVP:-"8Yti?=iIZ9&,E2eF^W%ItiFOd#c)IAcQlp@15MK7D]1g*njb[;OGY:/\[`rKfPGAIu`VcBP4^de*2PnniE-3,_B')_'GiLF0L(qLKO.-/5"WUV.,!.f>kc>>)iLO/uC7d:"lb:f0@!Pqf5to===\ma>kE(6gg!u*M2^L@i0ti9om3AgL>_PWU0495Z"-C!r^J.2.s@O=8M]r=+0\eT_S[m+NZ_~>endstream
+endobj
+24 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1490
+>>
+stream
+Gb!l`>AG0<'Z],0.K5BB+^3]ufp@D80;N-fmDaQ)/?19,Q1<MWBM.Kd?Slqp$'U=k33[R!bSXf2FO'@=gb]ER'Wc`.=2:Far:Z#!EQj_VP"<eLnT$P`1*Ok\,mt8:"VV(c5Ij+nSlDAeN"SL[JLVAm7VN,tQt6]RA,1N#$K`a?\Wka;>_`.mYOh3e/Jp;l6?<X[3MFl?bZ6\rd8fj[*EW7n>]Mega'Yua>`"0TLD7o#c)#Q1L=p4`SnH.cJPp8-)41(Defcn'KlqMZrFR'KB.]7"V4mreZCi1*.:1)"2)?>Dbp\D)=jbo\>=P\F/@ZumC8ot$hRVrK3UlGX7P\R4LsaYtr11=Xpuh=GqMmfT6sE)+<`"C3JdH_s^CjV3pQI7on(d8QOl;$C`[p8Q@D?s7VDrKObs#U=Fnl;Jib[=b@]8RPipRuGPdYqEmAB\<g>U$7S]LL]h<h9=:=65^'IQd,%eEsRed;ta'lb`FB3h8+b\:-j9.i<ln()X+HI+8O:#uD5acVH89Kdco4RSj:5DE-;Q6)^!)Q>4,eAkB3O#eC_F`O=:IS`g?o^lZf&Ru6imej?e3T=p<&0/UN&R%kH%:Eq/CM-+l(27'DUAr^GJ'0>Oqc29UQl!fTFf[q%%\'uBNc*C39c2s1%LH9$1(FFnKf]"mF"I`!ML2'_(8C7t/dSrG1q]hY\l95qQT)J+2C73b^&8n.:uP-)D@i/nI9]Y^9A*2&)Gc4Y%TLo#2[dA/<CjsD@9GKIqgq)U6OKh2)$KLaS[n"LChVQIfjjaGnAgJM!Ko-AV:a!jZR7T.mY;"C`+X;CU%+AG38VYDW4[aYDWApr&F]r[@F`J$eFBUCY*)FPh8FidYM@-o_+H"14!9g@Of:b-U.RU%o:1"Fh(m1p5+]IeE:NJOTX'`P]PHn*f;b>qI-Kh9j`Y@Km76lh!dgRZVj;:CgkGFCQuPgOeM:Ag\RT[d^()k+egXqX?Q5ECf9=O/mIh,JrQ8FP_GtT-Q$kbRM9E."jRT,54u]r0<KAk5ideC?N(gk[G)RlZK1q;[_<Sf>s%0e_@\d?g@CW9%`m;NEfArg1D[(bIp@H5>G\.r%I'j^[h<TN'XIqf:BJ?$L_"?08rR>q=16>BI_29=*+cMH*+U6D-L"^&)b'?p3pW[.*;GJZ`5ROPd#_P'B9_SAT64otgcJ+C7h!8E:(hP?KD#AIT)'m6!G@!bG\,@[Dlm^<CX-6X5]\#$n0\S1b2J8:R9Z;c1':>*Og+W.T1W:LdKoJbT2G\tQIr[8O)?'K6hn=$.QS(.8YkccZ9SAiJUC%L=eQCURQZkh]ILI(&>Lf.o'&+:CVtn=#peW-p[KKS4(O[YXnr(tNa4q2;@G1*JR*gRaEQm40P#s(WILI+_pVL/N6l,';7!8iu2bgAYfp$I!:q).kWSkMeQpSLW<PlW)S*3`DDNr6#V*k8n.8?`ua*b2^'L3b-Y4?;-RjqhfrPRRaoDJfUrrC;aW]^~>endstream
+endobj
+25 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 645
+>>
+stream
+Gb!#XbA,ft&A7<Zl=S)@mHJml/qJ].";6M(j_VrK>,.aU]H]!Orq\=s5-aW(JJa4ZB]uJ]lL&'d#k/\o/)Yi4b:<ciPY85-NUekhQGpEXG1,RSP$5,2TH'do\h@4mGS]@nG;-jpFN-X%Z"HP+Ye2AR@#6Ss$M%D+7Xid65+be.X<_ARKU7jTFqWmDk<k,D^[0D6FqKLcfaM4s]86t4'n-R6;a89q95dZ+7!XoWNrZSqUflt]`4d9NEN$KmQE#]m%7dt)K,6"fN"/1+N0-EpA7g==/gHJ6<cQ&(4d4L66[DYaC--HaNV@Q7ToM.'Ap+sNXEGe;1Sr%!l_<3>TE887KZ4?g8IDQkiEq6+`D*Tip:g>OaVms0fjh`GejVb98((P!/WfkLma;9?R8T'f@:tFNOtaG,b:@^5q@4J-+T/F0q>%0d5Da!;V=(0%1k0h0%i(CQ?WRQWY3Ge_TAuV[LU=nRVJ[0Ydq&+>7YWM6c&(Zdg-0X2=CMcDd'^VD.h6jZ(0-D=<HjqD66D=J:%a=komG.?l(7aJ,rtq(VsN:N?/>3S>dY/Vo9dtpfs48c@To;8BUjD.S(<m)Shi>$-G_f^\"[lW&%!m[f.3^t*q/+k^`bGj]'9&Nh5i!@EkEhtquJlo:6#~>endstream
+endobj
+26 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1306
+>>
+stream
+Gasao?#LZ@&:E*5R((.&`KE@S55\<ONbp%4MqCn`$j=e2''SmM_BT`1^V1gdP#&BK('754O1V`gR9b]$JqBh3h#MpWnbWatj&iJ#";+ab`:\0EI7@>TV5QYhaB2Jn`$^mjRop,VP#5-(Z@K#%iJ#L<0u?Q&i&'#'B.5Q*Q1@gNmd`-OO5%VI@hfD4-X"_T9$R_X"impbgcO$rlcq@p=3<$E(ALP16!:9G^3F/4POb9V_"&)\[k[J"Tu_:!(`141#NLI-VJ?uCpRUo>=<ac.Aeg+9($-Q9nk/8lN;Sq1(_t/:VjLl^P*&XA-$W!:Oc)>1I8V$5.YoNC+W)_MO<PJENSb>2j8O5Q*[o)ZP*_==1lrS&(!FPeR`4ICh<b%*^frf''tbZPYnD3NCY^=K;_1hC;'VB%(G5+gF+u1S4a;rr"oal/jmLYSnj6$m35WgK`$2&%\WBqm"HsEK3KHZ!\<4XF?Kdt1l()O?7FSAj`QGQlWqGn[L1pn]6DIbgE@NZYQ16:hBVDnT.>FpgfDEJ4=Nl@0RRo,1Ab0gmGb%Y81O'pk=$Hm%,JC)Vd9bjArkUSeE.PiuGC$#RPaL*<oXa]J5d`)1'Z#+_9W+C)\CXNmH513;6L3U$2FjSh3>*S.[2FpH)V<_IgU-45XuU7Y1mEn4e]Pe!VM>NB[<K1l*bH7@?3FnWj9TOr;hXkE=&<#RYRNLXGUaYI(W_*LS!=Y4pOXFObj">jI@[.WN)3hQaV2@[>dn]&Z5W&n?s9bi3hBjAeCrCZK5#Y4n1_WUo)@V-&oAK-C3?Y6(fZ:!)gi'QjnE7OjYXedD0>625:1Nel@Qm5ceks-[Isg42)T]>2qQg*Qu`$te8r+DmYDsY2nIO7GmtL9f-pY`f](6%0R[;);W]tQOCCg0WE:,J+I10o49MQTOYO*_[RCZL1Eo8R@8Z*t&NeNN_Dsi>n3&1pGc`K-;JY0Ir'`,B-$!(\5+MkD-[(GBbSSp6*ZY)AH>mR:4clcd[\k1\`3P;k:9@\)1s4A60aa"'Y3D]2NG6;5\_LlX;1^UFb?1p(UYm-aqn[L%eA7mIRbhciAMM-S*+C4bgUFFPXmqan=#]Tn!<*uWjatI8Z)t"GdH-p>-@0WIb8oS(UQV>2Sf8WW\-bs7b*sKVg$Zb:iGh=h:5`##8BRs&JW+fgrU#P7r7lXtH$3&IVs>VBT[S%0[%*l1Kuo@AC$s8gJJ@b,/i^N,o%]LmDN+2=`6ClC*]c.NCY8SO801CT7^+PQqA,#qI3#MKiPg?':N=lZ/$)37iZ/-!qG'&c1W$I:R/IC`jG*4~>endstream
+endobj
+27 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1174
+>>
+stream
+GauHJ?#SIU'ReT:30-g31F,Ce;I9VZ=c3aRQ4FLQ#r"%gSM6-RQ_KqO^ODh,3HAEO.1cmh,_/tjhK/*4)(6n8s"8*Fk64W<1GFj.$;;"^`<C]n,bG^d1+kur_F;Vq$m`QtKYL;&-uqdK7e7%oOG%7E+_?>gN56I7hB]dCNhX!U8Ntd<Ll]<3ndPp1`C['h8'X,g,3)eTQj'[!]4u`lpJM6Uq&CKalZ@iW_4SPEp8\[_5Jc=kM`9&S`1Tqa#faid`R]c=#MZc!2s\J=M(TB/:=B84MLoj[.=!(+Qn^dMUeq[\YaG4F3?u'_Eq#Tp64)3>]%$K*Bum979JDb]OA(Li`c#t@EW%&#gCU.a;7WJ(2.Xj$_,BfN<oGC98j4QU\E+[+N+YO6QD:P]4)Yeb'_<A[bRs0o`=f\rN8r-,l[hE<@9jgoV7i;d\GAAnb'#HeRcOT=;H>1MZ@T@fJScR+;[A'8bTM.Of3'n]#X9=5U%0Xg*EP"B@PZ[+l^^Lp;+T[7pSuKF_4\*+]acGJHH/1m?>[.%jb!kq7ATBg22Fc'1P4MrN<s5idqZ)64GOQO=_f+m>lGBX)Foh:;?pki"juoSLNq)<YlA:jZ?^3BI1(?dZba=3NuHT7<S,)K%".5Z/Bq8`+7*V\Coi\?j.-YQ"Vaj\O?tM5+6-2`nrF`[iki:pb<D*tNO?7'hSAaF/NS[@/8_j`Z>A==hKL]p\dM67")_atm@,a3%(14`GWQP-`K'H5KJB=4-SHT:`@LWba5r%NACoU`?$B:]O+NJ(r#^gZ]Xt5UH!/f5CU9qI(q]*=#>OW.f^"pb1fXI#2#@(%-ZKp\0>5d!TT@PMS%@0g\S#J5&Au<gfBeerp!'[mA5l)i$g4B=+7.Da;tn>L,[YOj*,)N_*J3ghFh2lXlGtQqe(lF[&'$D_k;JaN1J2\aR"-T^\L.P4E[j>3@F#[X]fOqAKS#:7OWmLS(M^I>N&8S'5%K1^D`c]5;1*;1E7tOMp+Vg7Ml5qpiHp-g=nRthk`sndQOKg^>5N8;H=IrGN=H/=AQp/[Qi:fKY\e5^+F((_'.aVNg./gs#W..'eQipL#*&H*_:k[7.M#SG7^D4J]'G\dj)*K"0.GQ2&r+Foe+!3$66r/B9\.P#'WSqJ6iijMe",N*CND3*A)Br_F-RmD(H*YCJ,~>endstream
+endobj
+28 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1379
+>>
+stream
+Gb!#Zfl#P('Rf^WS4C&e3?gn/SYn;M0L=/6FWUen:iL+%@7R%s/kOEn01a3F4E6h+?lfXo1<ejOHdB5b'Ld`b1d,CT]NF1&f+aHX\H_/KA,-nDQEtKc67Z++#))N:jqUF7Z3#2*1WWDAN)WqcTkFeMWhMmV$*>Y1<EMJVV8*L6MOT`SN(XaIFqa%o/1=+[nrb`WN00'#%*K-%DhW2shKE7,_@%n13#<ot(+Y*b?FTdCn@a7%j]="*`lO?o]IXAeN#tN2g'?SZD\cAjHg<&+$#f)[Da4ZdA.57^=Mo>s7XjW)7RP>'M?t'!.B.SkK@M71,qfq_#I2ZGTU]IjSC4D?WCgK.nM`ci>eHJm4U$*ub.>YR3YXS!%F+_)=Got]O0`c24`C"tWF?Sk.'4Z)TBeC,42W7R)E"7g]%@(&1!fAn40>TA6u1hbY\I(Ta.jN:FYh,^c=Qb>=>o)7cn+,j&W`)+Dg947\Ylu8;E=+Je?+fRX$-fjLZG$oh*qi@MmH4JhdN>jcEn=*H<_(\Vl\BO)st%b^q'uaTa_p@I6h"fD1f3Hi2$6C[0eO8>:$rqhZ^C'S'QSG`u-;s!tEDSW]<V4dAE]^K-^1:TR."9W<@n6e^<q/:P73t;$]Wn=YWr'7S]b"Oa#t'Jf2+RB]4RS[^XW/"gnV:\%RdSH+O=d>MEp>rLeg%Lf+SP8g$+\NRpWc45X6o6[L55m(7,8&r?.r#<)k%SBEEk2QH.'QVX3H;dQPY=&J1$>mhOO1B(X:PYD\2!@^IuA74DWR2pdET8"sV`^UhW;d\nGDr5hsXHdhSC);fsqGh2rMj.5i35qD+PY^[0Npj47O/H>AGNhodX,PP>8NDZ[:?nSsc"I9'c13(9=Z8"MMjtJDc`uEiB\:dGR5>0'?O/_QRc,*96X/q+AG7L"(HM`'[otuqBB_Cd=FN7R?X7TAiV_"4([o[VSM&B@-nbg;+uL#P?g:B(Vh7k@_nB#RD:7[($(VpH@,J<*6`cMN!`F8k/TC^K)#%Z!MQ[P]jGPrQ;W).WB6Qio09]2PM/55E*=SiO_n]g%r@f<8C'@Z9O*8E1c[XS'+72d/'os8/?5taBda3a#1mu-9N<m4ATY]+9eZFVUh6md&S.gD<0:tK:]/t6E1*4rYJ#M=>`\TZ%;iH.l#[B(_^jmg^=d'Bif84@OQrZItYuPK7NKspG<ABG3/lG%*1(oj-FF)"P/f3`)Pum#5+k8J=cud=Hb=>+,YMo,Iqe7:YoI>11j#4]rio`58l1?k\:"If3^GCLSGRsU]c/>J.J$7W+k0)Zirmj;I!iK'*O4=gMLpr@7EdMq?["K(nT;2o:c@tl4`])$]kriOWm&iLC_$V-`>HbFK8$A.aa;6Q-!F)2t;?~>endstream
+endobj
+29 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1526
+>>
+stream
+Gatm;?&oXX'Re<230+)_c.M(HGTqf/g"d!'$ZsiVUrlB$Xc^X;4>p#bI:Z3;SSWI.'VS(hFh`t*of^$_-r>HVCYJm)0(J"cJhen/TU]sP?fPTUq_TP)Aef5L(b]T+K;:#ui3-c'"XGZj?-!pa;\<&3![T-l;@9V4IQYf6)4Kp$+EHe7,5qF^P)h">"='aN%$E>Cn=!e=@33(%_n,Tuh^]EUcHbpkE`#u@2#[j%RVs\JrXkG<Z$`'(:E4Bu#cEV'H5oV7.[](`H+iHjR+N&.aJ*K9.c(jJUoIP7G;)sEA6MGi`-)lZ=A2U:GpC-N.Cn@\a*OehNDldR0ksHt/O4'elQY.`8;9?YS%3qSb(^1)'c\6oP*(Kbr8sKfea2,YdqkX83?$GL-5E?iD>/#*-EmlJAYc:p1p8NKJ_-91>aiKB+*4;\H>T/Y7RLU$j4@t>RB5Z/STog(-?t]T3/Z"=0ffIiEqChMVkdk/WYh%/0V@>qZ-i7tptfcY9qglSdD@lMb%oed/B.k\2dV9@3Wp2W&A>=eYDcNck8O:(dqSt$GH305bi&/LBJ]nsA'oV)K#-aD5Y`t9PQsVg74gMj<R=33OKg-&25'gbPg^N^MQ>ZF)kpE3,P1J:\uU7L8[ddu?Zii_EH*a%`Plq=9dQS`EVl>qJMIqt8\^u.c&N9sf*NXi\ijIol[Fg@Qds.kpMXB^0;EUB0)j4)(2l+b/XAQFq[>VrT0IPBr]?KUn^:kGHnbcQWM!<OH7umieX^k,F$\5<rpnY7f3T!*NR`=Co\tRFXgV/@:\3WEdeI83PPMQT[R5#0qU-BDhru4l33mj=qdCFfB9<ar/mN[#\>d+nL_PG]E->(2LH2!T!k^!S`QJm,N,<@BkOa-SaLbDB1\tss*8'b\B]RH.Lm)^:s8QsSHdM/r$,qpm?(`(Wr3H'fRN<9oND(9hb"D)DYB8sOg9`>sBm$:YR7QdtTJb&U/qVfU`H,hE5fXg*JRE5K2BMB03jhgN'>4"8M\[pg)L;ZM5?WtH\_`_ib!H?@d:UOI#8e+AGF1V>qu0`YGQQ[Oid%TT&6/@q!;Z>\bgFG<H4rZQYd*lcP_!S%q2G&XDrFq)rVk3XJBE80bb*a6f6<qBRN8+@[cbY=94e>$`g:31Yt_t`[!XPLCZAA4EP,=s^[;"^Ef_49eVrMJ6dl2fnR^Ulh+^P<f/-ANd=L6Fo4U(3RAep$8BRo"b.U&rWBc9QJFfajO(6JDI4#*9[K9(E0nTeMraglDh*"0IMrH**cO=aiauDO":>:CeoPOZ*W.&\6,.-L&2gISY4"I`(&7'fDWPs"KK).'hh*@4d)s,i<LTI`MIB*U)h1cjX`qGJJEEZeG?18FZ0$b'KU;?1aXg2fNd:0C/:Cfs,g&/eTQakaH)k7sPm50KJs'YgdWMHI]Pr!E_=p=j^rI9WHUt%;fVHiQb(/Af2k+);@XZ?*AgZ,;;Rj!!(*"W$sg=9j'K,G:,&M-YcM0>tf$Jp/d-6V#M3c2lRLc2hnB]F)$0`)B?&;[t~>endstream
+endobj
+30 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1764
+>>
+stream
+Gb!;d9lJcG&A@sBbUm]EF%M7`Uu&CO;P`NbC#dtU'WaFB1=0)O1,8Xk(SkT2[M,Q@'FQGn-kIiQ$m4Ar)4CR0$7n<_)W8q%r,Ki/EL8D1#pNdV!A<Mu*tuLHSr*RT(C<_i+TBJ]0R&]b.-->MN92"R77qfj8k9e-3FcG.QEM[P0S^k)V'I/M1@TeUcHd"u0T_eMP&n])-WFUrju#i7;,+fA:&Sq&XFf+6r_e_S'eBo6Xfh:lAR"a5k4^QZm4Cg4Kp4tZ/p8i?g,`efgWU(LXg-8W,)Vm;"cu[tPQOKU?AN`k*hV5+UEFU47HBBiN9$_SJ`e9j;TRe^>2AF45p#pE"Cmi&P"Cd5s51HLnE&K%fg(W57-5p5:d^[j;QrQ*a""TeI%L8'CiIRQ72aEBb#f-bIJhlpYURd_V#H<TfU\qU#FMB-eQ=Y$&,Mho93j%B3dl4!p%;=lREnY66:DTET;)X/e%mO:7YB;LGWg8AK!$tj2L#Ql_?0W*DnSDL@>P1gDiK@s6)j.p)=:SR@tgc0#YWuh1^Lc!f>,'Ubs7KL.YHg$W+D:`^aEi^$Qpm0Kk*FQ1_7rC)t]:14i6,(`2*mBF_'#4;4i\3Ueqhg0.+R;e\Hbp\'V8IL$9"tq%-8fRU-3=nG_S!a)Pk-C'lc,<$b]WAYi&`&5GEh#CWKYSp1MG=I%Ee.k_Q;_0^#5Jb-<O`W]m1p3H_O1Utpb=$c;DNM<:]>B^fcAJ(05D6<.X*!=NZ"[N"/r@\_JQ!6BP_0ALOO([N'+Eh=iC^p*/CI32qcEnK_lRJf@n^.<Y-J2oDnU*et/gV0mB(7U>Jeg?]5`/FF`K2=a*%N:j1a/hh&srtcB%C'cOc]>bF)QT(E/5hE:-G&9Uc^.q#4ol4KNn5[aPJJ5I<,DG\LLUtP?M\INE$RVSp70;G`a`[D+g0P][R0D4i3``'*e3W8bL9=#ta)qNF9H=:rn_cr</,#l-=6M2%2l[*1H^$$jT[-r5O-$iGI=#opml^UBDREI[5d/U5?RbG-mX[QtW"N7,-5VJ>@GT'2n2dQ4tO>7D<*Gq,+I[/]*sjEF/_1:q>J`\pM$:1KKS_:\47G2cr#mf.<s]Cq>uU8EP`O,cG2kP22G606ghWdKWA!HHPOX9'$BJ8`$N5_<8ZJ.g0X,/JNkr<J_HAX1G?RWU1X,Ce_"MjE-J^XFm("6ZJK"#?e_OBDea0TQ)i8o@l#hi*83[EqX)DmHararcFE*&73+WotA8RY-B@TWaD<W_fO_6C#;u$j'Lc`bhL>40G6ksWV?4;La8aCjc4`M0?R?;QZ$D(L`Kb3/_8"uBS,hqK!AhddMpuSaQ*(]V#316K*8?42G*`0<+<%kV1VJN/8c&l-jMP#-n@8gEBQ:_[!S@]Ib?lp=CLHAmrPdA1^I?Up<KVj<D[Fg]gZ$OM\VgMWN+BHW.$5#XV]-4W`l0u:bTJ+_UO-_G0@iQV;MN(=+TYL!;3oJI(=J0\cq??S=7N9Fna@SZCU/@8X'1KCm0NE.E1hWI:fbSNH(d[4eT'kYHb?W=NGEMp]KDqG<TYBAR4c:liq7Uq#b=Nkb^jM2[[\Zo2+h>Cr"mVlYgS)S:YbRpW:djf(BqRK?E3RY.,iNqA[C)i.J2I.o15/mrn0+chOF1\<&jRBiZ4?na1RPekfkO?$.:N:S$%=)=gBnQjt'N*%:<c1EUo(T*0&epB)@I@7TWlZ$YI,b#>j[@%8,'q>7<j6'^),W/"^\i[^a@G$4Ur[#[A=I;Zm^+1uAJci~>endstream
+endobj
+31 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1682
+>>
+stream
+Gau0DgMYb*&:O:SbZiO?k41->Z+E8j1lHJ175*N,!X2Z&>o(#]'\0)Vq?;#H,fd3R[Yk,\j;H5\%Yn\W63%)l;L^#2^p=dRE^bLT=D`S-`*r<OT!&p%(PkIYn/)_uN3ERapnRuHG*)k2750V'MEo)]d7?f9";+'.3!5WtM`NPG\;lK0C?#p45AhG,9bmjW78-SdMGf+Q6t)@sR<L\F2hfF=XL6Za>f&"^=#u&CJUb=,mB-)9HOQrNY^-p+%g$c#&LWg(,F6n^g=mfY3jU?,+07mn<g^jV"HP8@,Qs*PQY*1W$JUB!Cj.VLU5C)4@g,gT`[-s/en_t,\V>?b&TL,]#q1s!_Vo]hV""*(7D:DUMigs?F3$U#MIOGIs'6!#(2jt\(]1eCAl1r@,R@8/A>dajO>_i)SS:&.;XZ6F^e6YNE+M[XS4QF'[5Fe'B!@7Ra&Bd$O@$214+O'A,=$4--Yg;HF5FH:>pT]f1DVlC-Lgp[0e$)hW>eAbf\ARU%.$[U>m:7/2I1fGcF$'Hl,lPV.OK/23$<cD/.%uHJ9M>ip'"sDJft3IAQbFdbtNt3ddgu_5Jfr_8N:ZYmWW4#W_lNB$\eds%$m-d2f*u/C*/=oq4P5(*4NTtF+IiO/L%Hg%31Zs4L!c8JJnEH^]_sf<pJX`V48"<q8:+udg%hk8:$V,,Z(LU5.N)i6Ke2)h%@Yg&2>&IkMG@OOPtpq1>K]ER(263=*uc[T>PKY00U:Y?XIR]?_s$ApLiUm_:,lo%o;(I4s!,o;7p67Qh`NAe9Nr;2Vbh(+jQ6IFok;pK:or\rnG`B+h%A#];sAlLf[(Cb*d<q<c-1ASM/d-'A+;VZ/0cnX)\\pjBSOC<6jPG?<B/6!YPR&eE([>HaAH"m:Z1F0"DD/RlI16[DQk8r$5b,*;l(EV8!OGli5\lXQOMkKCO8ciO:kn+&cQEF84A?/iB'=I6G[?KA%rJ6G:ZO]41)"=\_;AV@,$)U:ai=gBFdf96?PphI\jrYd(_K""[FIrRnVMiHMMOm8>8QD)pE7$kGnEe>^dUcn,RaZ@JaE&(hcOD#@AU!^VM8l((D_?T&.[(u<iB12.ZhXXT18$7@NkKc8g?4S`[B-L?20\$Nr1I'Fg`l'+q0%)2-W@b+InGRWR[R./IQ7pe4@RVrB_'7n"g*L^X`/Bl@i.6R#mOW9c5fp`*dR7*h6\lh!LYs+.$nV/C=VkHR_W'1MJb!G_Mn50D&:OnJkftilF/Ajc.*;0nKQ/535.uqSE<*'c75pG%0DDUj`97SJ]SSGO"S-Efo$YPYg]g\S6%m#EMTjq`a_M&eh!c7;Kes;j@Fc[>R]<OqP>aom;R[8X`IXiD#Y&?d5jg^g@X]:DIRfefKK6!h8j3qat`/#k9HKQ@^1G'D=bDQk4A,-4L0gj'2CX.TOrVs%+n7#BRGaJQ/Y2E/=Z6+3B1YKV&BLh[dI->6%1Sr^VDC1Xbcn?sb:A8$5\@HD0mj@3h=uo7"Hb\Ubr4fHT@801*G3^2QUa^>Znn4+)K8ZeRqiMe.Ga?imh.;ACL:CV:Na_U':N5K&YALA?g$7-TU/R8Z[Bl^=M*?^-b-\57J%2l[_$)3!5Z`r.nj,*S&K3scWJFcjV`e8eO5A5L-WO3D7c3Lh??u]\FBUZYV0-MFf'09M"]oD\!uJd\Hi)od9k!Q6ISP^[~>endstream
+endobj
+32 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1616
+>>
+stream
+Gb!;cmr-r=&H2%3i]aqBb`NT.8].b5l]7`,$`pJB:BcKB7&MR]b,*/_m9a4^P\hjHljP;"%0;u$,k%>mhL!9sTKn(Icaj5RFULDrB>?KCGJF=nY^Hi([]<1S_?ulm$4%Fcb6fBNPNQ>W<sC(;N08dY"lrZYG`bY?(h"_#?kr#LY@:lL<K'RB3Q>VAIdD2Z:FI&N:,9pOPaiC:$4bf#f$:!-G.m;BC=",?2Xh'5`tfQsn!n:g(Nd?="P]!AI2jG,!X^B5?sLo#%bc2M\i1S/p:YU4ZU@b=bpjjHW$hn6kI_E4R%Z]TG`@U%nLZ)uGYo'po+H:>1*M@1\c0B[D%IPT-7K(-K`k:E;:+eojQ,gm\!8u)+KL;LF"3i84QE5HR5d?FiU,q'lI5$#\2#'SGX6Ai8uTAnNLSk'Y_c1DP?<4G^k%iV0&VTT?r0[0>PhI[(PE!`C)%-qSF6)Ss"\l%f?97(RmE4E-j>^&Z:Zkp$/lmmm"d'Z+sIH(0e_l..#3.lDuP?O;G&9$ddgg(M.A5)j;H'.QGJ=IOhsVkL+Q:UD';md>E,be6r'fRE(5YA@6$QaAYpZ#Q[KJR&IJ1iOaC9!aYkIQ;IhmOm!b_4I>a<&@2kd,rCk'jWThAUGQkKTkcURE$Tk^$?/Ok:Y0j8Be%qaL_Z`S@][1%.e_O[CCDH3`@/.=B\spZ>K2[<GlG(#UM%LZ5d8"2PaDsTR)3(%j/RX5MSQ4%W=9qB=\4;;jTT9+Dk]Lg62BG.'n?!([;mb8JI]0qIGe^E/g<Z6oDf<u\miUAD[7jjH_0N)?])X1KGdj1[CYt+T%LPC#[d-"dS8VhSqcXGB[@T\l])$ioi8Zih+rT/U<7IJk>aEd@_?-8lVmFG6<-g7OYoH6Ul%5/?"X0`N+rTL@Y/pb.irTlFeLY5lIMjrT^;nXlP(,hhj7$=._80&lpRBhj[@$gf/-1eGA;$;[X=DlZ!6[`e37MY5H&sqc:Do@H#3F2tNMZ_p5Y"+Uj"/&R)/&oH]/Y;J)*-6@Xi#eF6c:#&/LF[$'Ha,-l-H!B/I*hB!cQTFW\<(r`'jdn[5PGHq`r-Of@IE;"4g6I6S;Ff4&op5'SpK^M^hnq;uio;%T]o5+Jq=UjClWDr@u"2d3)4V)27tB6j/j`.&L;0GImDtQ9"Uf#h%[m\#Td1Z,YN]$_No@JMhn;YgAHldKi"/e)jh"UTLQP<GF$@C>P3='u<%4X*!pc6leMK^_#c5f"e>_ArZepXI!<:q.LjZ->t%LAfo'AbP!YCh^<.^o5?&B%%aj)TULY8>%I9<W]=K&j5EIQ:=YPm;d$Sd&ST_0&oWYNYBoBM6eM'a")[<6H@S<-a^\>GL:GY[kYOY0>Gn.'qC5`''8>F:\rA"1cTA3mE&<QY-4mrkTGqGYH$?=AS=VZrX:R1O-qg/n5g"&P.q-*RI0Yhk,g.(eik.k$gXjGL%EBs!9/\LQ^g2<1.'u9WS3!+Xh>XU]_"_kn:bHj*hW,"?rcdAJMG'Jt@W?@kE!ZjR,[Q2=$Rps20ZkG/$DVCma134F.Co\#]Js_F<>l4.gOVqk?Oc\Xd)*PIJI2<t'hoZ%^;H$Xprr?<^O\ULgXk/-rf8i:<aPm5C+PM~>endstream
+endobj
+33 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1384
+>>
+stream
+Gau0BgMYb8&:N/3S2]1'[,pjR^D*X\(ClTd8X2IW#hJ'5R=\[!HVn$tIBf#Q8V%H+JI;Li/U-BJ3AY;<,!lDm^"5F:gB,,p9#qj-(,?UR(2r_h1&F!FZA>ioJr%lD-3Ze^O#*0b9HukQ,>gj?JZR!^>\#i-.:akR%&&)(RgtHU:$5!?gmfl,?=k)+f-hp8=<r/3UPr[pV+$>3O&K\U[d@K!c])rPo/YYVm8\prnB#[jGKLBW%#]V>GS*^-3AA^!OifZ>5LHe.b42.fL;q'>S\65Lasa53ZF#KuLb+IboH%Vc:DmhF,2]WWM%phlaQ'?i>`'fOdsR&G?7f;18@]\88>RkXLa#WQ."$c:0g>S#dgnH0.Zp'#PbL[6`1iDd])AhM?aC9LYHs#&Q0V.5>_l(r&p=4aiHB01QqpP2891F@C>^[=93c1DkXHFZCT(R%Fp-!mX`E:f%\jPid6uY`TTO"D3MbF2F*3L=)JlN'BFeY[QY`b@/*//n774$<f;"`(6LJ78$QMY[ZDb(A8h2I,6"V;4e.ki2&g!!>Q8nhfNiN.km^ic7P[eR(\`R>#;K?MOYf^HeB\<7TSKl%)1.pIsj2Q/lHsW/4"^)Y/ou\\<>2a!HglmQrR+#-SM)\6`hpOTrSlG`f,T#9EWHkcrHZaA$j[8$D[9.2h7@BsW/>`Pu4NG(MnVT"1Q>a:.F'P?[la*]o;j(;8$4Y\b$X82Je+ibJIsbU$@3N0F_b7@hFYL2UJB!Xb?PqAe(N.=@EI!.)r^`W^8=ibO2r85uq$sE99Bo9gCT%sca0mA_65E$XYYI2s]jYU>eJRKlVimlH7EZ0T(3KDKWS7mZL5cNtAGlY2A^-E8B\>-Y5FHrSq-/FEAuNg$6OK.+Z;r"':#+O^]]DX+:UeCUY/g'RMJtRQ#^dQmP@[)l<,4j^8p4C(5M72(0'1*u6K8"l__'K_0cCe\@'FC0h@2<QAa<="H*nj:(s2DdfkV'.g"HQa!\Z,Y]hsgQ.i%ENI:0VE[bi=!m[5n[I9TYE#gUDTo>1)NInlCaBYsl<&7!H1(eHgLpO2nJS#(Jno/&C!$Q7(a?ED8W(>P)g\"13<]@V#NnM3d#m-atd+o#nMc>_#K$!^`Lg=`06C)C&;Fr]4BREa%G/f7V^U\`o.\Es,F/q!+Lj`pG(Z/h5CU%P4=SlI<VCa.LJ_M$p:?knXhkRRL]ic2Yp]nt[(7eWaJg7f&Y%-G9:1p$tRqRm1CWcgS9<;>=ST%raY8s:K$H1JULq*jLA9<-SN-ab_lhg%;NDosmaO2tbB/+4-m\DVi.*Cb((C@AslRCUq=lX@Af)WfPXXIS5gcS!F>g_3JI'qt>IYdIh6*Pm73,ElgINr/>Y\X$It+(go=#;A;A_Z~>endstream
+endobj
+34 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1372
+>>
+stream
+Gat=*?#SIU'Rf_Z\8P*!R1h$,P(o\rf@36AFA!P8/O7.o[)\E,<.6)qIf2N'[O!K5P/2YWl@,7EGn7*7+b9c8qlDWimn<FuJH6EdXoVHh@<hmGQF!2>KQE=(&eL`c:3/\j8M[N>R=PJJS=htnElcB3OZ[-8@Y>,J_$X;ZS[F:\P\o7['n'BsnRjf.hQal3#YGsX:_83kRM/e<3:W:R\#uk4^>ba%Hk'Mo$!b;=^l=[Q5&jra;cqnmnnlT584XUc'GEOQkbJaEbM(1BBPQi<Z&"]7P*UVR=saAKQB@>JBu^*#@MpJ$I2)i8P*^ueX8l.kPVUBbX@p9iL'&biOITdM1I*sqGnU-%-@p*-B4eUXBo,rS,nr1H.7#7Tl2I6*le0hTkA7VI72M2P*+]s';!I#")t6U1hGT>-_JOQq!uGoS_Ilk152=km&Sdo1Jh]rMB%b@8UL"4a!@c0)R_kSV?7%`sZp'^:kC^o0ES9ef8[G3DG!RCA9T70Sonh_0ai#(q+,NoOSJW`X:L"TtGo:sW>5Eir*Ns-5%*3o/&He1BmD2p4X+biu=Q;5,=]XOQo;BVuabkEo"p*+1)'%IBTVQ8mI,rlX1LJc-J_S]hFs"&T\d8_>nTGr^37!"l@"dYmmQifcJ9rgH$IV:<?>:WLGhr_)JuN#j]Kje10d'%H76W?LVV#]JK+<ccGqWR!l3B;4Ht0^IA!>Y,5K/&QJsRIIYH+=JKLYT]U]E,kF-$h`BSW9r-WY3+]pN38NAuj;CMA$`elGBK-:j6DKu:<.ekPIa[*HDlX:K!\Uo?a,,*WG"D<p8JQhR.4">^3U4'@!ZN=oD3hgR.``1`5S`*js"-(aO?jgdO++6RU]O"@1?Hf(=F]]sFo@iLt\?Kfab,JC1-#VY-06p.2GHc>@ZcDBX3V["*(SXRj-s86@.^\;!_<c\dX4F1sE2_%';N4/ggg^A)XL<9bEO,,sf[.9L:+2UdGp:_?k8/VeA9.,G\$=9e&(lO>Wm=[BL5B3W+NH;$Xgi6>`hr%cjXS9KF].`<pef--0MlTV/mgmjj3gEuSZ'LFa1e58GJI,LJ)0BtSWbj"4Kp-]7TJmt,/\cd[F/1a/5P*TTDGRDuhh^%9#pt)INIcgG;"[:Y^_J]7Y(USeWHlC0G<CHY`rg!-5mPrK0+PBtAZM;QbW7%&g>]Q3R,Bh/C"9QW>\.J2R$7Ru]=)QH7q6<`.R.GVmj7-Q%!Tb[="&cXh(;%`5?2\@03-Da$k:>BFViZC)7UYW'Q5]n'.%u=)+TfP:;!;09XlYIVOWW>3SU%/;*Ap01Sl<7EOdma&WO<URYh]8@S_T833YOL3at>Zq_6l]/Nf&[eYn&?@COm,@(^5\c!^5um_0I(~>endstream
+endobj
+xref
+0 35
+0000000000 65535 f 
+0000000061 00000 n 
+0000000144 00000 n 
+0000000251 00000 n 
+0000000363 00000 n 
+0000000568 00000 n 
+0000000683 00000 n 
+0000000888 00000 n 
+0000001093 00000 n 
+0000001298 00000 n 
+0000001375 00000 n 
+0000001481 00000 n 
+0000001687 00000 n 
+0000001893 00000 n 
+0000002099 00000 n 
+0000002305 00000 n 
+0000002511 00000 n 
+0000002717 00000 n 
+0000002837 00000 n 
+0000003043 00000 n 
+0000003249 00000 n 
+0000003319 00000 n 
+0000003657 00000 n 
+0000003795 00000 n 
+0000004442 00000 n 
+0000006024 00000 n 
+0000006760 00000 n 
+0000008158 00000 n 
+0000009424 00000 n 
+0000010895 00000 n 
+0000012513 00000 n 
+0000014369 00000 n 
+0000016143 00000 n 
+0000017851 00000 n 
+0000019327 00000 n 
+trailer
+<<
+/ID 
+[<9aaabbdf9058731a34c6cbd44e3301c7><9aaabbdf9058731a34c6cbd44e3301c7>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 21 0 R
+/Root 20 0 R
+/Size 35
+>>
+startxref
+20791
+%%EOF

--- a/docs/transform_data_ManuelUtilisateur.pdf
+++ b/docs/transform_data_ManuelUtilisateur.pdf
@@ -1,0 +1,308 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 5 0 R /F4 9 0 R /F5 10 0 R /F6 17 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 23 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 24 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 25 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 26 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/BaseFont /Symbol /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+10 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
+11 0 obj
+<<
+/Contents 27 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/Contents 28 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+13 0 obj
+<<
+/Contents 29 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+14 0 obj
+<<
+/Contents 30 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+15 0 obj
+<<
+/Contents 31 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+16 0 obj
+<<
+/Contents 32 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+17 0 obj
+<<
+/BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding /Name /F6 /Subtype /Type1 /Type /Font
+>>
+endobj
+18 0 obj
+<<
+/Contents 33 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+19 0 obj
+<<
+/Contents 34 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 22 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+20 0 obj
+<<
+/PageMode /UseNone /Pages 22 0 R /Type /Catalog
+>>
+endobj
+21 0 obj
+<<
+/Author (Robert Seebauer) /CreationDate (D:20260513201340+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260513201340+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (Preparer les donnees Jira pour les metriques et rapports) /Title (transform_data Manuel d'utilisation) /Trapped /False
+>>
+endobj
+22 0 obj
+<<
+/Count 12 /Kids [ 4 0 R 6 0 R 7 0 R 8 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 
+  18 0 R 19 0 R ] /Type /Pages
+>>
+endobj
+23 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 556
+>>
+stream
+GarnSbDP%.']&(*cE?P"DKPR&G+^Dq/^1S6[`(t*N(Y]LZ;#h`fM:Rk[Kn.gkWC/GKETWuV?LifX?SFAU"Y&,),su4YnAEMm$0F?Ul8pQ6.;tfb$O-HDPJN>X[=d9+iJnoYe(Lc:AS?`<cW9j>'S=P'b*1Djoqnm,U8:5_\poQHSJ`'d'GSMSupgLBE&AM9^HnPQ'PP<LoSGkU"$X1Ff#&AXbZ`TWaD]BcH(j)_o/L@gu"'J28u3iN"$J#>St6,Gt\HZhi1!EB_m$g\pVd"NtNlo%7\8%h/lg\e[0gi_0E9B#8gKPQ(%sG901WM'c^,4D3o<94mnb:j4K@7ZqWo%:1NRO#*et/m)m\i1A)aZDk@29r"^0oOefAn*Ag>,"'QQ181A7[Ad<^ujGS(A8`:<.T;fL[?;>-p3i_Ln+cqXPK-c^\0$F@nAf0\L=!^SdZ,43mT#RD0l.Yf9SbB&LdUBc%^A,/1B9?lK7]#&qGq\8'Ee!?=nn`"k4`ZlDUs2hEg0:]KQqH7X)3Q2_<rrol,VBE66(?u*Dd)ZR+T;A0`6Qj~>endstream
+endobj
+24 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1544
+>>
+stream
+Gb!TX?#SIU'Sc)T/)In6"jHL0Upulp90^e?>FWUF.kkp#mAeNg6W-:$r]o/9SLK[/\_,mcL6BV#q=6O.LZaa-'GRWq/h5f23IZ:n^c:I,0M*PP1VB5RDC:*OSk0%$V-lWBUaOLHf97*e3MT!k>U)$BiAsmKN3Jg,G_ai@8_5\Pl2%5%ht>0SIf)6T^K&+C3"_$hjI?l5293AHAb<D@X2\4j/o@t_:@XgU>?>9ZdDhn3JrN2t5K!CTk0HuP#9?F5Lh'cImkGN]m2A^4gGD)8ZmF/]<#C]j)Tk@ON#R$i1\&T91^m6n=WEC>F%M="3I";P<)RjK]shb^IQ2qFN+iHiQ..Yh:'5P7nTn)_"X"4NGt')0A:bK4K\X<mEAP.sgePR]bI<Hff-FiWa.aK\g4<ppBr<aiLimc3$Xe_4\c&RN=Ls%*`km!;%d%a/nG'@0So)MDhpDOFN:)&]QIT;ni]GD?QHM7M,3.$Wjftrj6+S]:]#WnUgj:jC>,Fm9%bgC+4Yjn[Vb!M[4@,_^WKH/N]l5,i(CmpV_nUTXQQa=N:/=]VNE"-lhE11DgEOF%'Qo5?/GCdnR+TXT`%mVjXYn.:KsLS1A3VCHT#0Y&A5$hf^p5Puh)#V'O^r'ZQ#5Qg..<N`J&K'qmkmd8U2tA[aMu-WGi:.<^%3Wm2SN=@>?,PP'g'B[eOWaQGZ?:Y(![%803fO2)\a`\3-uH<,HWF$_oj]I0?2b9GJ@YPn@%h0&=;Mi/H;5ZP<F%nj!jN1-'\`fh5[E3'Nq\WYq"K]K=p7oS#d[q!tmDFeS*34pG?[>APi19\+.7(O#4Ts$ocSCMqImb84$>62(0bS4aGZSDQ#POq5*!2G:qUoE-<W"m-J6NGZFl)dDe'Ke4kqFDN<+Bm"A2uNsm<PAf!lVSR:'(_qNkiV]t6@+"puNGk:IYTO?GKKc(\[kMeVJRuapnQ9p<Vh-q=C?+>g3_tI[(>dr;STK'*CH<%%Nh\@YUZRROnj'se\Cq2Rh1jhD=JXNVV.1*K\ZLhh$a)ul%2hLPCSDfJl*hH'peu_RkZ7VB[$S2r=6sDH&g8]eb`I3X`#l]J;*+l!H'k)>#6L3c&jT>6UL;DZ21\TjR_K]Z4o+X<uP2J;VB'9b-&<*M7E:rM8EGDL\%nN[U@-/CP#brV3LrNFn<N_?1?,4n./f!:CdsC0Y6;tq(/(9uA/Ji8l?4J$&1&4)/:'KVAHkLQ54N@#laYdLo]4r"`Z$op0%-$:FK.egf.tMd7QP7`Bdh<fI?J%52NV7SO4@PZZ%*b[n'=]N]i0Hm$Blcn&@3\-5Sds%5[s)5FDB2uqM_^3f%^%4@h!+H@M,ApPc.Q.(\9Hp+Ip2Y&7QfRCARZ$]Vg'lf)F*7LN?Y2GW%T\[[`dq/^6%b^2biUVgSPet^TsK<E,(2.i^jaZm]6ngi7h]1IR_PH8U%!14fjj'bT&f*XflRJ]1N;6%W)[P\+?j1_0&t0B[ccp5j4aaOhmfI^'EejBUq;con;d(Edn.sYH(Kt^ZsIR[RJ>t*ak;*f+UjW!@d-DDu~>endstream
+endobj
+25 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 651
+>>
+stream
+Gb!#X9lJKG&A@sB]N\%*Cj0L+\KHuI0-CklHY&@_E95`sg(s2HOmP%u8_"1]<4:A@=79YUbUu1JJu3[u"[;"W]HRn300rcTjIborcZY^!a$p:>er#]E(frUdS#h0o-RkSX%ON%/c<)J-jGAsBb):'[AqZ"B$NIn7(n\/QpLb9Fb<f?DG\/,,A)pjapShi;Z;'*.FjV"-/F^2`L0.r62Y:!TF[]ZFbo>_fa=g$F,=67Ld)>c0@or?@"BqUGhkpAY.s18Y"ULlUA-c[)kXV+P5(5%-#l@H;OVW9qJgCs$6><LfV"LS:7&XT!VhpptE)o%\IRc]DfB]Nk#G?[QhFNVXN+*Ail,17S2q]t@Ac(!T%'mk\6fbN+B"Mm7P=NVa:(?-0>9Df:f$'5N@`Ylpc7mIE`T<A2;YVIqc6;[a?D?U%c@0q1C@o(2I5&=P>:dhZ.BD"n.ON@q'GKoh+lV0Pea(t8/3:G56lo<n:I:Dpp*;NX+LDN[+go&lkWO)VXQtZt`SD)p<Q)JN]#@rCr#&R'*u"W5Q7k_HmW?6$$`DNjM!?(A*4fn6<+Qea[OP2O[4'f%UIa^WQa9U<d:mHOU;1_hF:=o.Cb%62mXm:bo9SJHV<KTr&0-3$f6,hj7?ul3[rG\caF44*.8et~>endstream
+endobj
+26 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1379
+>>
+stream
+GasIggMYb*&:O:SS2\(!RS-9&XY1&uHJ'':@+0GZ!Yh^mG1`'.R?uLlf.SQ*M<m&N%+kS6Et7B'R>CnKLD[el%et*thd6bI"IgurA.kAI]\4q1$RU`VP8.1D;iqi'nN4j#G7+M5;K,\+Z9VH%/1IkEWF2G7!g^'=^)-r"W5c?;Q,gB9nRHc_IpsR_-S3N+"D*`M/rKk%%P)I_ESK>n*uj;Venb2c9V<0G13hViVnDHB1Mf6bo/oL6"dF;XUe'Ql7&PGM0<Hf8^%J_D9NEH8/$M]J49<X2Ulm*o0gB5s7`FrY.qVmT.9Vpo&kU2CREKurqFBoYEfNse+c78@aCW3JDZic'rlr=8-QoNn?=mH:6^B(#&ug7\C[khQZe-r!ZW9hfMPOXJ&1-W0kGlctF0%m';'@[./K3Oc.tO1o,j3c:@35ak.f;#JdEN3TjB4?MEsA'&#g(4G04]g^=,8D:NqVLq6TiFuGE9ZikKsnH9:[DfY&?X"BF(_,IAaFq1s8):_VnC(L:8a<m1Bcj&6Il1VDj7NSY!_D*QC+cX"++ZqIG4+(JfME]d:1,c;QZ2H<pP@hViYN:0Vl<%-/Y>6!6MnmnBE0oYD^gJhjA)jp7[RA2ON`%+bVT0!ns\Et2cMA;)!`\DDITgM;T7bUD&0W7=r#GFGVNX$]VKEVG^;(%sqgl]&Aa4R0ZXUreSFW>jV`;EG]9+X.?;3C9L"Mn+e@P?.j[$"qI_gGU%k+BEnf\n/Xb!\\1e3/N"MM):]<GiCni,%F&FM5hP8YG:UccDiMZ?b<"mFI+_gg3Bo-<>0OV%<jjrGIe_s_X6X5^Me%_i<<2Zj4V"&7VV%MW<m)fPV4dpN1O:FYXT/>`+"7nIF*uk5#=mpgbA@@%>=mZ9)OFTNVMDiK#R<2Ja218/u(L;_TrraeFl#<KC,/$]n6[+O6HI+*?"nC4D0qlcguP!i2k.D+d%Vl&?HML#D#lX?KN\=<Q\:^;dV1ua=Lnj9N/$Nr7K9WlHRgNm\e#1<,as*qko$A*YnV'e8C:<\845[/fYq]Z!'AlMRV!_)r6WdLXmIeQ,O,IqJbSHon@/9osTo84*"3#:7JN^#A'f*QkXcHEtau,BSe*&s3f3eFu3jf7ruZ[jP[]A_2gb!T@<Wci77.[:B=boh(V!e=]2>MEnH0(lUI)+4_SS)/`EO,Vn+(bNqIf8]$Mq1[m.1S]7n&`"VWmL8dUf';<7jq)E@3C/6IY1-P(>1/h6F3G/XnS?fu(Fj/m$(G2dM/S#<8On/k[sIb^:O_u>?MPA)_->\#&Wq-^d_>fo,`A>>a$R?DPUHc#D.b0`X0SOV2,R%JtJRuc$kRYK3pd8?dp'%tYdpH@qlCor_HZ>(5o>UkNJs"[<T%0~>endstream
+endobj
+27 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1227
+>>
+stream
+GauHJ;300c&:X)OptdET)V]8%KU3@mE_%QQm';oEAYkS^Vi+F3loI%Dr;)W+Unj5QmY"?#;JGKcq7^cZC^Y3$LuDRI^oqN9q+X+FXLAau.BHn8`HlO=@%ranWkbFQ6rni7YKYsD(ChF]i2kjJJ\9-n/96_D0Mr/X:Y7j7%"T_)+YIEh(fqjYr,#WpTb,S6AQh]j;DPB^M04_fnAb.UcF8:?9JBSNn:u"G)JgJ5?lRji?p")olh=LG8s*`eQ.AV8W=C0H2T3FGjlrr>@HPa4<V!3mb>lM-=J!].9e_bpAYN$V4gLI:P,2WQ(+!M518U6WEa>,<69`^l-m8p,<bPM&oUcag]Qq&,HNCF0kq_E//b2T@8n@4FXhj\iC2q#@X&eYY$<aT<L_=k-rMn+-F0#S9WBt(PQ5\ZrQ4fOU4P`N^K*&.?K5$dXV7uda&2"HCBO6o1/E`bU!c3YX#`%'maQ>IL^f;Xr9aiQ,9L-\ZQa8ZYeh\9Nfd'AH"B.?[RDeqH7%WrY,J[7W[$/Db*]5)5!S]5QB@1q.7p7'P#QpZL^^sn!BC6uJU^f2!)]G'@pe-?SZ&XhS[)M.aiEbWne"-"sE"Ao)pEr`rQ]>hGHXf4Do*VE0$4%(u.%j>??6/S3e%/9JZ,b=sR7s9;1)kOX?sVU,*ZO-c1k\_^eI!7q]CsNKhp^c<<Z>e5p[n7dR#(YcPLR,BN_4*Pf@P8!=4Y>dh]VPBim(J<aeLSnVNtJ3N9EOpKCtdVK4W??mbHCM7Sb]mFKGlC4q=&/B$6\*kR<$n\esWcX:+)0"mdT'k2CS/o!8+K_^0<-.tJcLjh"`8g6U$Z./<hi=;P7jgX)s<P+&#j7t9U4Su2+r"N0)bE&;4jalM.$,I;0f@k,eD>@Z\T)h*<,h6jA)S"h+$6&gU>Y2tYeoiGA<Q,t2=,.rpX]_2:jU?j6K,c@O-,+TOt+cpWE1C]pNY5'.'P=)&?GNY[C0*=";0/tJi((.(3Q_.9j._,V]`r!*rh:L\&7qnpO/h5&K;L3`N9PgV._H6rOIm`Vbi])?,ALsm>//.X@807$k]Q66h"uk#dgcYMn'C<:f5$Z^2aPi.gJD"gWrJl8gh0^=eCu5bMg#8e!r&YR:3LoaQX@lP2DR'1Wj5q^.GIMUWjM`LH@j$j0B\WeDNJH#O0)g8BnG^odq<$djjnLgc[Ja!+V2&,Q>2XH`5;3US42YmTEL6mkC4X>g-R-oK~>endstream
+endobj
+28 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1397
+>>
+stream
+Gb!#Z>Ar7S'Roe[ptk!G%4>&L0&9IX[7,_DQdcs.+@*b8a,Vo\*0G'MIm9$X&p\Yi@G!qU5dkquQg[$!45u&-JVRmc!5GW)dq]FGYZcZP-F#VPX4?3Q_0@Gobe\skH(9K^VblS9M\Zm[*jIQE;Q*hTOfAO=B0>2o4^n;2&I]'._/@2sd4U4SoGbP07)=uk(+2Ek'7rY.'j*=qg0V7#h=]%U;Ho.0;dAP;;2t.bfrD36[T1pC_<M6*Vr%!gTM,tF\WH\(9k@V?FP>3Plg=$kPBdq_3LGtT,f#WW\X^P/pgcRJS0_Y\1LD>i/5LKpOg/"81'tZYkRA]'HUoIGB`aSI16)4@G:7G+B$oH;&EbUd<$]jV`Id26Q4Iag4tSrNDAW&GA](?DUeGd"TkM0dg+;FnV]eg]&.c>I!]\4U`p9Y7Y,F9-:T1Zad4C-87fu;fHkq7iM[nO!BQ2#.UYnmmG>+i9Pic*(*Uql_6,lli5W`7RC8eNgamH=(!dp%)KQ`qYS:,_`%OL)8l8?YWVWjIT/SSLuQ"M/7S'm.Ff6-J(reTt7='a>bk@=cUVJ@alePu=%X^BY]6*9\>\$t^D:m-'aPpAsX$)So<-QHqFl$sIs:J*_sKlOad9_@il7.suEa]'lK*[#c5_jopbAUWaL(_QM0Fj?X,K?>%onaYAg^:POM&>:+,Tm@!6iGFRKCMi14XA>uLA%TIdFbHK)[Pc`dC.^68<a02GY*R&7DDtO=S#[p_K%#IU/j1q"7`L5$d"QUArsORUH/It>U-'b)&eE&WpgJHNI@:>)Xs`*R'-^X^RBZmSs'PE4IYY3P1gT?\6AR-g*3:bOA4+=sl]\g>isD[^+bBH<)R1hb\:db-Q6?LV7r?=&&Z^.SEg]1mQmion30hUaht(lVQ%ulA&!K'ri>@;:@8.l%!ta@4%I@HV_#O"U-BAt0X3WHONTo/0\G5+%jnlAc03@1`ZGcg(7q[S;8lp.`bh0,+V7&eVd!![#^tDhq5JqU2X09Q\m7]sO2n8(36%??$\G9/I?bTYsKt@Z9joJ8G"Prbjd<n+2>7S,sL"V;M1EXA3#t"TO@O%`fE1ickEqsBSb#CMR40^gr4!IP,:ndj6pEVlb[-oKrhCi*e=b<WcG2R,Wm*8p#_6'cXf(60[`^W*iP0fdHiG3(QRafJqrLWd<U$`.aUUOG_coqH1rQi(0pp)auOWXeH3"t@i6jpBLoe<[h*VlE<2ppjGQ[A+.rSjon57X95l-k?gej7hCMRp-sVoRma-L1JK+SgC[ZTQC:83Vhr5.mQd^nPf"oma.1mdB\>%X)L"/I!kT,&DCO`6@\$H9[7.@:?.FDM,jPiD\.9"rGuqlMW62CC0=01;VC8/C2]/Ic.[!b%b3&V</#G$S;8]AFKt]~>endstream
+endobj
+29 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1552
+>>
+stream
+Gatm;D/\/e&H;*)ESoak$S,*h72\OF/h]SMCi'tuT*c".I*PhbPXA>?]3ddaP[ujmiiX[2=;$[=cU/cLgkA'!):8._[fF/qiPd)Hb$_aaapEjb'jN;&[kg?D<q$G%j#P@W+Q8Y%?uKW]16==;AL:%uWe.I\&<KgW-)Fu]f$@t`0S:jpc%mA!;@%dG-J/t>$A+CF0F![pP4=^OZA#iub.)S,gV6h4.l]\Ghj*H2J^m?\FebMu\hhZ?q&,LE6f^g(/d1-tnbn8=q`['3>245N:OEJPA<p:^$=79P85ZUKDeXt)O^T+B&]6(F=A3a5#qCKtP&nH.`-SV)&BZFgaXJeFOAbR'$dSgoi6U:mB&%pL,!m%_LDGc;Oc&:K2qGe;m)/152X[#-:*hD^6)fOKI6)-WdM\QESfpHXXt:WD/!tCf6<NRM+,q%:#V0.qUVitFWeY`GJ!mD&_`.As=\\Yo>BYPBZ@ku(AeD]^kW*'_=`FYhH^O9n#fohd`nRX^BG@OJ*B82]_h4/INCUUckRe_Ti4SWoGOSX;7GtAPG@41q*WEZV8/C0%d%FAJ[V.d>P_2cq3c+qAD%SAL4$IjomnR)'OW<6eOmaSdA>S?PMMtSf!_Kp`a:0/2P>?6e-sV,Rf=n_=*1>t[dnku_P:Xp2^0nQe&/Ibj$8/3VWsU"=%M,1/0IVP^GaMi7#1Za#6IZ;f)FP^0$4FV#(RIQ'ON1-SbV+<QYZ^mTpPX571lGoMk?Xl)\BeM$eU2Mn/`%<]h_1MOXn'!Uc$L,T*3pY4,0W4jH#L;6MpC_&c9$Z:1M(<;VSQTYfD28O0$2?8<I/I!*)(cjp4@5GmrLJX3bpc8i,1[ZUZ73SGDVgCbD\t8-jS&k1Ac/BTJQaWjJ:^Z%]>6p\K.M1Q4*Mj.ATRUX$I^U?=]>Vq?V't/Ed$t/7VJ1h()as;"+Wf8`MHcgT"s&R3#mBO^&ZB482q9(qnMn_kK$%QU)+R5V78?FQ(aS(U"d[*)-reKYl4Ne/d*F\d5FlCs\:erYpc4&384IJBgN7n[2Dp1]"Nj,lsGJ%)Jh3[n!hs"nuRjs0!X9&WVLa)1%>TK0u\UJ855GVr!4*j/omk\cGfX]nVU4I_iScq!m%4AF`i<jtCp;m(4)DDGs"l0ne\"s&qkrO5e=cT<@I'6-Ddm6:'FL62oj'E;.,PqJ`"_c7"'hWp(WdglIf2h-Gj+)*3abg,&(+-bhJnRIWlk.Amq17tV@OK+Of/o;R;=mUs&B'*D`sJ^Q[J?/RDcCcQlf6j@q&rP\!Fi140,E(jM/RldXf\L;p2=!ESp>#dqjZipRK)PT\_O6BuJN.^8g9<@+XhM)daRq=a+UMScZ[NDCP"mB]CY'1#ocpMioTob6C;ej/]2I16Rf@f7GTMM2fC?iOL1ql&Ka4mFQYC9qIEk!/Yc?*[F\Dn8Yrkn+R/[LTVEI4j2:rtBLs,85.Tm>1^\I?Mg/&$R9;O-)35NmECH._"`M]V`"Lnnjc41&<U(I]e<\ArdQU4OoaXo?fpW$!35ZpnQHBN1;/1T!CX%*\\Q1?Ogf~>endstream
+endobj
+30 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1786
+>>
+stream
+Gb!;dgMYb*&:O:Sba[E4k)pFX9Ad&>"YI%71j7a`'O5qM0[MDIPT'Ms"Y!T?CraXMM?Ob"Ckrd<L50DR%aBM*"m3SK*8pQ;r:Z]_j02bj'1BY,)W!%n%hlf(/k#hpMgtsC&GOEqR*DE,$8J;$U2^;kOb?4[KRaXM1Bn%lrHdH4F%ErL9&e,K"8=Mh2r@*@+QOdR3JWuC6:Jh$RDZ*aWj(g;jPO%=<\U/`+0'!.K@R?.Ff):@F]lA/jZP/%43I_Y+q0<9>`:7<>rR5[ggF-NHE`]k,c3j/7#HY<+B%bum)!l>`,6M#$+jIOI.:=#,\/Y!QinTIU%`])2@/j"6R3M,66K,R,3jWJ6OpRI-:JG1OH;/^<'UpKi$;`^fT0UJR!b;a9R>4JG#?1&+rQ:^c-N$9+D;+'+/_1Dk4e!DE"+T0f2Gu)B\"Y%fGIWEl%]K%g[)i0O5F7Q2Y?*Q0N8I4EHCcn[;7u^@+9OhhXb;icpEJk_H[tR2L#6sJ[!,qCP-#mAb0RHe0Cip64<%Kat!iM"H+.pmU4kg>,QQ_N<QDW.H%pV9VF64Cuf"=O'iB1'FQ%HZ6WsG>#^PZA3Ggd&4OHD0aPqq;*?"UOFo4kc<0:+.L5*7FH>;hA=1WXS+kn:WS.1"/UU`Lrj/*K/XsQrXtk425J]5^VDlYnARi*83p:l`$iC<lV)n_5\u^HYg*d$S#clBWBAB%CBkiWF?&#sCc74H^]lfN-%0lDRdhYn]Qas,eh].RN"m<b_-NOhZ((\HLXP'1qA22k`f$apr]raS#Ppn5Y&ZW,k*A!I)n*rgc@JrZMo+<9g(bu+I)BM%5BG+5E,j>q&Ba[I5IRON/#"4=kJ@PrtU,u&Y6&+pDW;#4I3(B,6V]J\J8g.[Sb9(#5mNLA\HW:gsFTucE:g@[Y//p\5ct]T[.a;^aWFP%D:\iI5Jg#bipehonj4=,M;!QM__>R;(IJ[G>,lH<2RdYeBTs)%FJe#icB\9M'#6o)dS,)UX0r.?h@HHHe<>KA`BoMM'%b"*oYWg1VSqH$q$D*L_iK/\^G9#s2]Z3s@HA*Uh8s;Y6R`)fqS=_Z#&f*Q@&(Lg([bkH&#'!fh0U@eCQLXCnL#*MiXj]X3EL9O7S-D0"AoA3Zr(I+HZ<OEWe>5&/AHNfRW(j8cI08>C;p<rnMM8m+[^ACoi'o_6CXpr(#0brHWYqYd0I]J"qj'"LBbTm%=@_g@%n2nI\f64bjmDX9jjY$a<MO@!O5E0*gYbumBZW0=gP]rokp2jDOLO7&le@i.pM^#O0^M(H5HUbQcm<]l9'#JqM&`*_jFJ0l7N((*Z];_O$-p-h`e"soB<ZjkcW:;oq(JfX!F2ZL7H<Z!YHABRs$RuGW%h)T$mHo.#s%>ha8L622\%q@o\C;3VFE@)CaWP)<2SFfQ0/F@G-/Ttb-_tk(QbXJD)-dUChg-r/Ng$ARoTUYP@^@dj&Rp10`ot,onM&/qWU)(FgBKGg03BCXA]2C./-urYYp0VXtS@pK'qS[=b_QJY8,i70*:.##;Z'-6i[fr*7O\q#.PYJEWF#aC%/MI,O)bs8r0TLh:*3tZ@H1['j<!sCg35<.Wo]FmS\)D@o.^??.km_0"P!IcZZKCHjP47<3_#pF50bFqnJ=(5p1YcE=f94C`9LiP[6L)'mfV=5#W)=&BA%G0*u"a<PFaP3>Tk:?2.\#rbt7N0>Q$u<G^B@QMK_N/=c2l1ifQs\/Q.BCZdW/_h6RQRI:*06dHR1,38,u&\C-(kInV>N(I3O8%hbW2Wg*,0_l[YA8<=~>endstream
+endobj
+31 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1689
+>>
+stream
+Gau0DD/\/e&H;*)ESlop2+LOY71J"%2I3b7h9Zu,>C_<j09-+I\0TTOs*c(>gJVKb8_YD=':F(=*08/'*eaUu$7pQ?28G+Rr,g57EEHHI'1BXq%K*r-I@_%:nPnR7\4B_b!V)dE"gaXT5X@+s19**#o9A_qQ&m]:'OtM^/t^EU?k.I<98Vro1@RM?jk!uX$m[3Wj;\lsKSk`+U4uTZFCQt.;h&%eVdVcE^NJ"6"j<+TPuVP+/)01m/?WFOe41P_'N,R[\/7`CV<``^gu,b$DW"/UY%Wt#8OZB7O>Q(0fVIctU\m#j,5YXSYdb;kQV7E],S<qqJFusH&Fpu2-5aoOOA(OjqVN?U_tuZ1c*dUD:8CL]J/ZjhPFNq.pK[qEB('?(BA9Gck`kUrUl6`NlJnd#8=ICXjQTHrKt[9dGQXiVcHG4I6t9Y^?sDY`*:2\@rX>_BADl)'4hNVg0jliRV#g#0+g4VPlq.N.[&&K"9d[X4'NdX`FgOuPFcCp21Pi8Q3s2+dZ<D^9VeX=a^+rW^MFj6c!@4KmQOHD9i4X`ID8DBD_$GZpeonPOCUE0"Z8W$Y1J3mr9Ro[d_iDrJ1bLbD1a/hh&t!ashllE9$9"FBZQXT&SG0^`Mj3@=j2>sq);)Pa5&`!K""4!c!])kT=K0?]Q#\X]&<@@FO!!/5+o-OuOheL7Ci\*-D:8nHikUL!#t`U9%BLM(9fK9t?:fVOO$V3c^eB*7Kq!\\Xj8JMA`rON2*/6,`>\m)h_./W^Nd%KJcqr=E;^/_-U9SU!<f)W.K+Z6U<FKNNZcHbs5BEXg\"Md2ti0aocCnie?1V&$sn%VBCNaFk4T(fTHVeiVd3r5E/2FCFQ(*HduB(5V9oN&4G!D#(t9%^n5?m?*VM,BeF0X2Y%?>rG<:YNa.kjPNHGa4mHrdLX@kBS!Y79@#s,ahpa&?*m1<eD)rXf1Y->pc`M=T+h)c[uIau(gmE2*0#89X<B:Mu(I9<=mLHf"lq?aWgjfVeE6?$r@V-G5B$J6&p6"mk`B\_Qa9'D?G/1b;n;gm3.rS&G/d1t6d5hu%Y:mXo>d)&sjMa"-o8qG8r1c^dpCn^T:gT!=d`O8pJd@K!U@#=3P][peFAA4Wi\3;7/8-3/-"1$c<XaftHaY2'#!Zc\0rSfa<P66C6J/p94>qeK4#>>&9]9LFb;C6T\W>I4`;;c:\j)?I#V;V[;E/Eu1:noSk/dXP\61.V^UC>'n!C![L#+g+6l&X9UY^P/'l.lBF-#!,W`>45_Q].bZ\-]RN8K^mp2l]e@85!b=<$tbDFfd)WGQ&(tqJi`-$T:h(d)rNY/6$:+d&6Oi/7#TGWS0UWV41KCXe;eK/"%024F`#dgol/r8nPij3NcodX.MHdoK1#ecdBe@%a.G<;RJ=[%]Rouo3h[*!SapZ:_$0\oWCn9K(o!=ZulcuC&-bqmGOc^kpQ!QV`M@,O-+m++!)7^kP@+NVsF"D-3Htm%^%MTF18Vq^R;,5ZIDaKhV.?ElMlS)=;%YIaDUUr,9>c)/q5.u-#e&,nmNNY'0=6T4>bbtP2df`W04C[]&UD8Z/:EhmJ602r2hJcQFc_*[mFc^qNLB.GSP%*\W(]eDR#7\kWc9CQK`(u)SNG//rHh".W97aMls9?2C9%9-",)p^+As"B`IY<6o_B])`[Fqg6J"KGnalj!>!21TE~>endstream
+endobj
+32 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1659
+>>
+stream
+Gb!#[D/\/e&H;*)ESoak29.Y4e1b^S\n:/f!Gc33;h9LbcRo=53$ac^s*c(:gJ[$t$nI&UJ7FMX]Aq`=4@_-!5_5cXZ3L)L$/]#E?lYJJ@$4&_hS?bbm!_EkigD?JE%./N5iO0;^hmZm:sb.67C@`Ka9YjM%Y>:i)$>YuIQ^>a3>BRg-$o((+TAoG>jo",OE2Udc9ZMHW)Ob&29^\/NF0/trbH(sJ].\>2bf&BXKK-B/*fp6D=\+#GHcH84c^T*4=?;33VDTQkgH>^_en_VBJ5L%VP4'Rab"OU=iLi[9/G-ha(#f/+&4PJ`AK#8-k0Dp+`j'L=FZ\I!i+ce8i!8a+=`_8`r@b;LQB3qRXG?-6#rMn#rQ7FPCa*dGZMZJm)/1=[P+-<2^t&TN%kcQID0QnX=9r-@u"/I>6M_NbS@d-lPc5m'm`uMJ0&\)d5aT*^2:^gWs\gnE:_LWAQQjiT10(bE&?6Q(R&BNWjDnl;-)`d8>#e.>Sh4KX;E<X(bDrKHIs,@(sEak``JDg4D,;4,(Eb''$)rO9TVpT!=R0XB^[Yq:%J4L#q:20`R+6DB!fps4]5U.bP>;)$+otR<9Bia!oiSWoZ*B:U`rEMYquE9Rqc3HBLPER3"n"3=n^_L%\\!#:`J`:S&Rhk`AAN-\6:'N?pYY^,W*$C5mXI//)5=!6Y3"\F<\6\r-`d#3nQKp/\5p=oDqVkc@50m$rg:7*afp+XJq:$O.Lus.I>e6$,Zj+%pafNe=^LpW6KLDGi:''ci$_`[L'D,&6?%oQ%9[]`hM3J0&%_UI[ZVC\Z^p6lQ2$iI<p#kC#-80cdJ&O_s0Q\rJm@GThS[5F]T_c]:AW'Y1pZ?*<^"k82V;5(+K"4N5==1`?PF*G6FrW5hA&R>[3r^kB-8SmHPdP/<7?aoC5/=mh_c>0?@I*#NC^Y3$/p'A:<QKV#?>tdYAKFQRVb?`K%jDF[!So-CiYtI:t>V$BkHP_3'jR#gFYH++[uX7(NWM(im[nK\8`>7&h!)D.B8S>m*RIJ5(^;-9-ZqgURURJWL0'f(oF0!s<?!mQ3g--V1./+m2(c#P/Y3s8(b`ZHHuXi;F_K2!-rF\97#?#mmR]r7p\$q-\"RWF4?=Eio,1<_$eW<0O"UcpCY;U_rr29P0#!%g8:2b5G:1q]kKnoFR6a38HD8[8Kt`HcD]Nls6W4h_r)\g*jqt5HQ6e>'SK.e>@l2R93WPd["4f^\58ZXK9=Ff7>m0mSm7p>1^d[gEnf`8do.k4[Q-_a$nCTlS6\FF_m/(itRB.Oq!9m-]FDfb7nN+G?e""j\n9;G2J8A!o?t[a48@h/t"n!FM_]7AT<jqUS(D>*h-5:V1.Gh@WV#0,b8j*XO5Q1'B%U4!F:4meTm(Do2@2/+aF_mr\W%W^n0M3$G@-#FD_/mbK:s,5-GA]WJNBDbs_h)a*XG5i>+BYK4#p4&F:>B6^G[gU_oonR,:oq?P!:"&<\K0#L`f8fuEh,0O<?h'@\j?#Mf5-%LY0AT3s>4nD<RmLPOti*#;.OBJij]LB*7aRlCi)-0N#[!jkd-o(,4VkkgoBQgeE+`n.``!4Y>P[stoh?QTK$KA`tMm6ePWD+tXpM,&_;&mksCClP<'>ArQfA$6[Sf2_\RIq$ro2LPIq90CGt"u_,p_>~>endstream
+endobj
+33 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1430
+>>
+stream
+Gau0B>Ar7S'Roe[pthMV1FH)p^'n;q%NR<4l+B._-lD4$AK[*n05["^5>ZBJ$&mRi1)R6X:o(h[3BS8f'(Fkll%*4)q"[&X(RQkk1R;HuNHb!9HGXnUnuN$/=j#2+/:NKsFudr@;"94(8Q?t<F!f&B5fstJ3/8e2?;H<."mY(%KN4L_3TA(3j8+R`UC\t.KKpgd9<qH'hW)IWWSPGDr_k>\`,(/mU^knJSHc8YjePsI^V]mio@NNn]`YU8?l9d6iJC>*0Pm1\=rHZ#p9Ld&P-bG:ZT8\+GqSCK$"h\bMDT'KCfp&;92pM.Bj!`$/Bs'R(uFq`>S9$RImocF?5?p[Od/N9NGfO+ptJ2T'hE+@<-aY#8"L&go/,5#YJX_2S&ou^Q)tr`Q(heLk7sHbgU?LC:,!W;7Z7%,/gfKp(DUfh\Yt\/_U:K,p>eI[NR<bckOpmk*649(5CeNME!gQu#Nl;0n@+-m/eIYS@O3$u_L#jba-H92PHcmZY(KUHjWq@1jEoep&;VSu&57&*PVqT1_=IqAW/i3UMGGS'93ck_)dH0_YjQ'UQ%S_#PkO=<jQ28l'kD!0-B*G0cBD6B/2:C$m;Nk@f7"Y0k^J-K5V>[bY<4sf8KsCW`q2E&3]FQ(;g+UBZ/^+O4g"a.P:erWW;Rm+%O1Njq_>^+k)<nl`d(F=FO2SMoMI(S_n7bMWOn01hVe*ZhnIh@(DS=R(eZRA$X(epHQd96iBqfOEcF5_f-SKOm'uN20Y+LMYTV\aO+s8P*?47P/Bc6/74l+ugm_]Zll[)PeU/\H%2kQ^kGTcqiIXKk%aI]h]Rr*\]j.\\S\aJ3@c(g-Sn0q>H?`$49;QhdITKQ:':dI!j3L&+jj;#Al3NN4U50hJ/j-@/em#-OL).Uhm?K$"K@K:^F$93ZfHk_5Nijbk$esd7BFT6/`d1&Y.Q!I:0d\sfde=TrZ:]qQg)BPn=g_)uLio@=HQ.lZP^NXp*gH9$r=+g80u:h^4X(YNCQ7lpm?ANiL)Rm4kCTPNg$mpEW&lhK/&=F>Z2QZT^O'Xm4%"^2Vo$jSN5)<@2fX(fb2kV"O<'eLi@T"<Hcutooj%b;AQ!.9f"_g$"3snBN]hLP@H`F-Y#A!XNNtCXo-VBn+Bm?[[qZr)0jMH-g?m;;OE30p+cTJ<@`&Wjh6U>P9$*opnKs/7[0mMT%"7?8=,YOfV=flBdIm'A#EQ>KJR.UhiuljiJ1ERjO0PQ/Gd;QPVOmK6c&7eBji=GA45jfiX(#M%HWEsejG_Maf%+M/d4=>"5n6U1/ZjUC)s8)*B02&Bf1#D]V#dK[3qa1[)en]SZ\>YkV/<,C81Noc8'@SU;B`L!&2+@T=.;Ado]Em@h0MH>V>"$H"bK,id?<%;@d]!XY;'49@GD_)^Wh%M9((AWYThhVdoM9>a6dJjaa['AK^S~>endstream
+endobj
+34 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1384
+>>
+stream
+Gat=*gMYb*&:O:SbZg6>bnV\m[O;K)gU_'[mO!qj(8,'sZ'U;8._I%kh\VMf>M?3]A7<7`3AY:XB+?;b&4$H+r@Vl95F:m:Jc]Mf>Qa)@_t!jm/8+]568Oqs!XRg@NAD^9RjDH#1BeBO1a6(eB93f6@9Ja[9F8rm"bX%.2/@a\'J42jnfF,apm=d[G:Y/<N5R/TO>B?MShX?uE9`BYG-+L;D'b^&q&DR+jfsEfM0H7g<]I)/)(]]7q'mKt!-t"G:)P,u>3UDR1cO'#is)cA(O6]25S@Bk$qQPcJo>@XqW-TP"\JSi%!&VCOY"du?oa'hb0r9#V:Zne2GB6Q9!]4&QLZR6^EFhS0-=hA=+Rk(Bq@^4C.Mf'$6&O7?3SreX4dGf=15aLb#h+G8olEHj)#a>NaU]V%5"=AiIV+`i3\#qQ*s^aK*1[GUVp;'nhd0_G`k0BEtAaQ6U4<X*lfsIXOkQh&?QIU^[`O:#@-mI/9hdBq(@IlPJFQH?Oe'a-@lj05Cd6%%8<O`"6]J*DOS9ZQ9V-ca%nO\#40+6-j>o)mEJe.WJAn@370]48Q*p+mt[g<P3'F`6#_hgGP>3;QFB-JKJ>^RCMb,H=\U42@kJ<4er>BK:_p\Fl\+j>PZCV=VEmK55WEE;GE3l>'!O]t,T6f-U-U38;BEr`';iR>DOA(@]V"2jp%5YqKTcoPMb64NHRUjBe7![S=uh43S`#.'Hmfl64BSN)4(s<3)"iZ`qP,'A7W[GJX0fh\]GGIcA_W"K!A!+?<X<95SMqAi\cQU5O\4!-)rV0=XF"!Z5%'IiL#9QOB6Ha,#[)^,SQpg?#,_"`:2lijVSX7:CGki;,(8N,,444h<k<!KnA@*"W"(Wcfr;p'moKZfQ?VP9XgLBp_n)\m=Y/?uiY)?r&5$@N_RVM_k3O4OU/ThBp"t6nYin4dg=3uj_^C4IAZ-e0g)HuBjKqg@(9B=+%#Vj<_TOtTI2:u%UGm-*rk(U>F#H=[&%muC2,O*PQN'K4TbQh85Jb%"YX0;!P\]Ti]r6(5E%<E?i"((gb4*YonG8?[1jWZYg9Bj[_jc;>P>7=.#1rE[WdeOA+;^m?5]06K#1cfo-aE-takJJlDf8F31bS4ZAp^JGdq^<h3*EgVkj,AiQ/9T/hf<Ij0%!j@]9*oLS6)@H1mPN_]s7N<[&p28''lp9(q4",f/TYVed>%p+,"[:ZMKuDY%sTq7SRCb/WMGdGhS\6.,5kjV3)T9G7U*fs5,F[_p^0(U7i_KD0L!UcG8NA:j<6T9q:TFC`LFfH,;(E@%p*(2eD6pPbi_*1-/35mS*/,7Tf(PF@7?)\#+Pk,2\ST7i]r?"[6D2#B^lM@@NjC-Z@?si36F%$Q*3N=#66B":PbjW;~>endstream
+endobj
+xref
+0 35
+0000000000 65535 f 
+0000000061 00000 n 
+0000000144 00000 n 
+0000000251 00000 n 
+0000000363 00000 n 
+0000000568 00000 n 
+0000000683 00000 n 
+0000000888 00000 n 
+0000001093 00000 n 
+0000001298 00000 n 
+0000001375 00000 n 
+0000001481 00000 n 
+0000001687 00000 n 
+0000001893 00000 n 
+0000002099 00000 n 
+0000002305 00000 n 
+0000002511 00000 n 
+0000002717 00000 n 
+0000002837 00000 n 
+0000003043 00000 n 
+0000003249 00000 n 
+0000003319 00000 n 
+0000003665 00000 n 
+0000003803 00000 n 
+0000004450 00000 n 
+0000006086 00000 n 
+0000006828 00000 n 
+0000008299 00000 n 
+0000009618 00000 n 
+0000011107 00000 n 
+0000012751 00000 n 
+0000014629 00000 n 
+0000016410 00000 n 
+0000018161 00000 n 
+0000019683 00000 n 
+trailer
+<<
+/ID 
+[<9a51e74e4cb31d36aca87e8f2c62ca20><9a51e74e4cb31d36aca87e8f2c62ca20>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 21 0 R
+/Root 20 0 R
+/Size 35
+>>
+startxref
+21159
+%%EOF

--- a/docs/transform_data_UserManual.pdf
+++ b/docs/transform_data_UserManual.pdf
@@ -162,7 +162,7 @@ endobj
 endobj
 21 0 obj
 <<
-/Author (Robert Seebauer) /CreationDate (D:20260507232243+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260507232243+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (Robert Seebauer) /CreationDate (D:20260513201340+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260513201340+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (Prepare Jira data for metrics and reports) /Title (transform_data User Manual) /Trapped /False
 >>
 endobj
@@ -174,10 +174,10 @@ endobj
 endobj
 23 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 540
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 536
 >>
 stream
-Garo>>AN"J&;B$7/'_WDfNF4%H4;]bcpH3mGq'NY.rS\DFs;:th_2E^F);MJ5j3T:c:A?M$!qB&!LFP0<t&-.)R(B;l4Z?\i^"-&APE:VUKMrj>a7b2MggfCBM!L8&.DJC0q`&6(P::2*t64_NfHCUkG2&(OE560jN9nHdeK#r0s@l!M_t[O=OZ6Vg1>EtceuUW?3aSHM7&AB3kUqSlGmKbh9TAqdX+s.;-f]V1QfRK<(u^3;&Ma&FF^WIJr2)Kqj7aTVuE%nYAsT0*Q</?d4fo+moI`_ftXm8.;B>HXN2m#o_DDUI4?,dD+U,>UDXEM4I*>rOnp(j^)tKS5'-7dDI5U8ZM5Yj0Lq;W13CkgD%,W9]Ha8KI6'IJgGr)8njj,N4T:$-c?MA<60bE*":?ELd9t'APm^6ZZ(6nhC578E3l_I%G.Kd7U3c%3f.$00C%>]AI=:YIS0+AY4gD?phNIV2Y"c'RJpuoB;m,Tc[S@&Ia';+3:s.fVQa%QW8;^rL;/aC*3+Et\2X;Hf4)lJfrW:($^eb~>endstream
+Garo>>AN"J&;B$7/'_WDfNF3:UXqb0#V@m8gXkG2[2YI?S]G.6pP\F`]gXUVU%?Mh,;D#3Gc=CB>ZTK`1"`/QK,lsOTCAOPpPLpKmh3]$b;Ot7C-9X)oo%TQ:F>o<ED.QJ:bq_\ME'fJ%cfLF^n?s6esYSI"EmR]',!=mi`XQo=#m4uRXnbG=a@At=e5LI=I;'OJ_-LGg4ZKD];a<Y\0"?;F&u01HW7aW?(@09O_#jXVXTmbS0Kpmi4P/=ZkC-7\_qPbTBbHPgcoC@BcUH!bV@>RfCO(o0<HToQ3E9XGnZK-?V8&59?)*YC<YhF*t#SAQ*qQ-pH+Ue2jA$(k2JV]^4'&BnON7[:8GR9=L"ZM&p/(IO>5HRSK77f+])A5BTe-5nViLE76U+6D)-#2$0gM%=>OY)A4\Vde#AqmU#2rsZ,*-)DGS$G)7o3XSI`9to5V6fIIZEh+.n=BJegZE'Vj5pPH1CM+8X6HS(kYol6B&6/gE7nr5`GcLE;lsV.\!kFfujZ!Fjm]K:>Wl.&amFh7pc~>endstream
 endobj
 24 0 obj
 <<
@@ -202,10 +202,10 @@ Gasan?#SIW&:E*5R(#+FbnDPk.kc[iU^9rkJ4o1e?31h"9Nu<Yd35JKrq?XqFs>[\mpNphpounB1V9H=
 endobj
 27 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1326
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1202
 >>
 stream
-GauHJ9on$e&A@sB]V@EA)3Q3:O\=([m35!IA9T'T@\DXO[*;"5'T.e"rUg>*b:CWFnHK7+"#dsbbe3[^L)^C)$J'^i(%Brt0E,Ki*:kJD+9M-npgZM`1*J4-;IgnT6nCqq_Ddg#X,.!Kas]hpRQtJJn3k9P(h"k'E#Qo4P<LZjf#OU4h8a(4+1DUN*=@OgP:5Q5.HcAAKO\=slCG6JZ?Fb_L%5SW)*YF]iN9DV.PELUK__qcE"kg\0bKA&j$9a:SarYd1T-_rq2m<B=\>Ft7#HqD&1MlO#'<.s1n`/c]E^[D`D](.R&/^iM*roS51b.hdZEJtM-qlk6'>=q2#N)]*7pMjHf,oU,YfX#W$!<[1)>`DZP#3\X3$^M6*,1kPjj>s`_tmJpPUm19eksRL;L0d>H%E<9KCrkmIZaj[)VDIaqf5=>Hc2TQYsb*l<uN6*MJ=(OpVal=V`fT*Olb:li8@NK-:XFf?2!G?*s)YDDfWJN@oZ?M^;-==H5/ZOH@SGVXJgLdKUqM>FkDVBi4*BI+:t.:b<CXgcaTPEuOmHh3Jt=b!2qlhV3h,;hDc"[(9+0H&_Q&^TQrhV&)&Nk]M*\+Qo03O"b&u6r-N>7W!=#rM-Vd]kLi&Mg9gj&]Ol7<B@7>/W@rtY0[?2KjPoMA&3GB:L3;6fmc`FpQ"S+'A,_F;)Y+0IuI.!nom$;JN(SlGGh7nm6E=aCHY;?fmN`<C>c,Z=6"%"C$Pl_<dSot<9NR>H'>;7ggW!<:#kM#!]ElE<lT;h5DQLM40/=RQAZ-&?^G(\ps@,+[;)/'98e,,/</1U&;Z493)gkV?9)rjC0*T#YFMW<Jro46`))!i`p-mth1/4,e_P)AB6e4^c[u;%DO_$>YUb9J6T=6kmo8^tJRr+&g:]TZ//J9'0H?5Men[J)(U'')jAu'ipO5*UTR5GB]_q7;)roOmkFn!h[]N2^9qVB36V*@;4NdW<S.`OoX0mEihn6*AAW)`XqZAQp6]Yrmi%k;oYC"IN&.K6.2;4WO3N[/$TD-[J[S^n"9BGhZXW-XC(JiEG41EHFC\Pmro@cOICKDCSb*RaI4M1kONWj7Nk>Cj7J9l$--qWHd$&IYU%EN4K;?;sJf7@bIIdD8:&OXWq8.e:XM0Qe7NG!Q:*.HNC%n]\]oVcdKj<JX_8LZ@N*$/42U?()d=:E*U\9R!jI8_TXDfVb`7A[G+fC]=T)s+0+.tZY#Ct?)'$Z!Yc522b$d0AE0:-r<3LQ.)o_Gb$T)mqhSr?!HV?PA/iO58pLQP1RJ)/<1-=%gL1+rC`1Hqo`_H`u8AkT?^2!gp"p-N=+0\+k(~>endstream
+GauHJgMZ%0&:N/3S4@3(1F,Ced_6E/[gfde2E)HL@\@*S``=9\%RmMOrVAjdjX@1>:4]&L+9=9eR<.LW%Kck<leZ=^r&hmMD[_S7Fq5pU_!D-;c@VsEY_Yr7J8c++0EPtG>f&&o$]:<K'%&[j9I/SZ<!X@M0k5/,pE,"40h9[fV'OpnAS<0pB_>RD%#U6FEK6E-6:JgI.l$Qhg\SX)j^4GL)Ug/7XGt+6D&ZcN@.o-(LXtG"O&1]>`l1S@Fm^49o?'h!=]N`XCl(\l)C?S),a<pPaV3'sCXWp*kS'\6i!6N3/4cL;$m(U/.&"4S=*e9tLCk`H=JS2+,pM&lgOL8&kCMI\%MPRG8Hh`-OHY?Oi`T=?2Rj6gJpjraX\m"]+rQ<$QN(9m!GI@)LU/Q@laX?F^VGN_ar+i`R_6qZWM+0`caNPY.([n;(gXn:L9_V/'THQ&+t6/!"5/8FJRNmZi=HE+pq"rresNOnYAe-9Dpas=Vk[?n4N-e7U20oefnSb&T!i'3-&#Q^H7lC`R3MZCSB7F>BQUL@^n'S_m3d<`(p%iUW#''DmlaGPrhrY_Q$1k#>]'DEZ9=I*Z#,FPn'5J)3&>]-),h(e20"H+FG0U.DR4(`J,BoM*bGje32<ehEgmh=AhrE_I^s*L3TgtqRbFOAJ*3l8D-UT.5U<-1M6r9<hjBWh]tD<%/oo]o+7m%uK"fQ:m8<)eVTVp%Su/dME`^rB=Pm#ZNCU=,DL>H!T;T7K2OI;4C?;Ja"K\LZ.<F6gF,Jb!j/heJ1<r\P^n6L.*#FW>YFX#,@TsjS/Y"GSJrm88+1g]8e_CmORML2F33o"G"8>B6:%#A1%FB)1.XjSt>pkUlguOBiIhROC.SFWbOb]Jmli^NdP<"upLL57ohB;/J>cs#+H(@_\S!qgoLto(R?/o1:o4Z@j\@8i=Pj`jg*14Id()l&>1:OjifNZIGJ^7XLY[/A@/Y7`1W/i?`Q!se=)7BZ>BG+5EP3f?mA:#Wkp)'JGA4WL%6VN3fD(e'"IM(3IL[V^IIASE!]4a0@dmm@W8guGumk5\Fb2b*\@G]>Vr8`k#f57LX^J17R(8]l\?<1iTXL5CF>nHr)C9rAg>^Mam=%=3/*c03*B&rfcfl%2(,s9RuZdtVT%.ruh_o&0HnE)hU''m84j`@h_lB\2G6&0LW6JP^\"bT%ZDH\aG!J5e$DGd^(~>endstream
 endobj
 28 0 obj
 <<
@@ -216,38 +216,38 @@ Gb!#ZgMYb*'R]XVbbJ)^>`tgpWVb3B2J@D.>V$4!-l@fLPtIcD;K]WZ^EDWrZ;-k-@NPpZ^6%?B_jPT.
 endobj
 29 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1751
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1614
 >>
 stream
-Gatm;D/\/e&H;*)E?F"GiC&QtW1YQc2Ta=?h:gDu0He0Hb-]D],$gA3Rt!YaP\d==ibg.Q=LO66cU6P>0k?@HNo+sen8\QE?=CVP(+[07;-:JbbJihk%,m?`ZiWX/Nq3l[pa-0soh7^W*+u4oGR6f=+Ars`Ef;]m(p&D@doeM$TSdnK`-]*5_T/g34L)];#g+#.^^3:E/I<t3R!U?j>8c2pZP6`]fbo0Xd_\)>44-0A`=4Ai#(n-^PVGQ\Ti4<Rq+c0GoU1tKA,Sq7d>DR^"fS(o7K=/,WT_,M*"*;D/&Zc),:p\\WYjk`36E\F/7Q:/CC0)>TqiNl$rG&ZR>#8R,k0u81VM[i?6R=HN'[n@:/HXcH?e&Wa4Z7$QeDABGZ$"_M$f2%eEu;A)Ni>'/Fj40_/XD0mr)W0@BksaQa+$#`pDVMY*;uGbhu)NEjVGL8%GjeNjo3pFq6Sd&i'Z]7H>X8T4J:@]\jbF4.$6c]7Imm2%jZ!]ete%NS2-l+ec90G&*pui&;;*-nE)YiB&D--k1BtZ`pk"7b/Wshkl%OFeWU<?tk?IAH<S^=]Q5:UnE\P/`dVXJ_E`T-2<I?M+t5<A?uWj(uNm`Z1ZOsr3gHqdLMLci4SGlhcU92";Rkh"tRY*KO074hK7%qnt9"s(@qMVQg"'U;a0_6b=YOI-?-pXTG.\+*09iScc;&9(d8FW:Eu&Xo#-"LDY!&.a$V,fr)2#`BU"gePchI[ZZI=Thae+V,&X1l[H>bmFWtl\22CM.#i;YZ$V)bWf2'1%dr'lQQ1h/&WuC68dIR,?JsVJD[uljV@3qk[2YMpO+!48:W'&7!Aj`1!"6joHo?2'Hh)=j%,_[FPit/-r``Wf/5@^P0">ZX7Tq]=*WhDN[X!:(n<8ZoV4Lq[eQ2BOO!qWHfCY>6X/pHK.Co'=&(q<+n'tDRsB[PTqjj%4Kf`/[-?F@Ynj^I!2YiSo#+,b5CIK.Q=CXuNIGL3oT>+WJA\sCUnfX(?oI\j,=Kms"`4U),bQG1o`j2:^BLO34.)WQ/!5pJ'Ekr;ie*&j1M)<-T`$9=`'p@02_E<`ek;*jdnc3WZ_]C3#0:\/'h:mLBJI=%u-O]?eU@I0dm9)lNVYl@5;:*p0c^Z@5L;O>'P[M@gd4q;+.TpupH=Ski#Xn6qHGaskh5WjX"dV.ZNW(6#()C6@u%rq`!X9^oL2rj</>-u^D/%43^B9Yoks/n]<7Ob:cdqYS9<jcUml<6[1\3Nd@(2;WN(5)X4`'-Jnf3!],Q2j8A9[M&mlbTYfe6[PtI2T1dB#02jTnYbL,gR*e6Z2i6SR-/$`sp:ARZ8![6$/^6;i:Pc0L(!p[0`cDn@Hs@,<HE-r+:]Bk-8>*jfmL;CjS^*n2F$c5r90I?RNPZB!gV"6_'2`SF6W?N<P:."dG#N1ejNhb)QUXoE(!CFE2rMrm/C=_ZRk2BA$'#>R7.t13V?[qo9%^:5Y60R:O?-<)ca^q>iGtVK&;,cHBdd1IHOZ'&hGJ'RD:D9'ZuXIW,U=Y$A_F3U">CQ&1t!Wb]49KOgRtKi`7>=(6#8)b7uB&7W!;9!=HD+ZNo>OZJ29,3j&G-o@jb)H'R"d60L;dX?tA9]i6e0`"!sKb:0s%1ID6J%[nu$KS[8nV``j32Q(^$";OpL<IlY;j7+!0DFlSc?8)N@4,mT/,N7>Y$.c#]/=]JedqKe#Jthg5'J/b]STaME#ro)g%>i-lZk(`]fTF9]+]?J/MuFr@.l7&L^6W~>endstream
+Gatm;m;CZ:'`IKu\3JeYAjqTAW1YQc2>*'*mFp+00He0HagB;\-=)e7S$sJ19"%\HEAnR4/6hl/*:eO_6O"FdpfVM9IU0aq3<i/bYl[T2KuI8@]pO28+C#OK.mSdM3%k;d:VsoM-Q4bu3(%8s94/K%UgsYi(h&FZ=:)%+PN\B!(&_a#GCD9"5J%Er_u`:l:gO\7S.Lq4P/(N7;f@A5.q?&<0812rS&&_b/\Db.(!RCogq_o`E&d>SMZQaLkh)"r^(jrl4gT0AX<6(=>4F/I!&7Yg";#(=U-6,-/Ng8@:skCI?kH.2<F?;iURW+,Lfbb;>!b5;-n3/I!N7P_R>#8R,k/im'7Dia?D2tWN5??4:/HXcH@4>[Vod!$Qc\3lGVUa?M&=5PlL!WJ)N`6P(3tYMi-;[ApU;iQYh2MAe(EDTA+jjj=%]N4B/!DH*1Z3P]j-GX%_)XEG(Q6jKT#qE&X`g`=b^n8)<\6V__dJ-pEWe>O\d"aX_AbkbT=Jk$)P>B4"IuH^QJ"T=TQeUh`C!eBt,t$Kq1([ZM"S'1+fl9'hr`S9@Ft3$b2"().Q[BTT'1.jV#4Wg.L<Mpl0<N:%7@WZO5A&hpraOo?r6g[VLQE%[;1q]PVHA=p`IW'<$Th/&`-S?@l;9[*F<pTN39Qdf:nbkko9r5)O`MQ(3Rri2XSC;BhV6*ZkHU%g.kHI-UO!7je.MS@^J=;4+8b^PV?\OV_XR=H8/lX'!2r*56pB*eXi15\Ycd_Z[!RnH?#t7QC%*^aYfN/NfN/e<:rV(mrTQX^uSD?LBIqhar7$0Q<FX-?,Tke=sKpb$A7d3.-5C]\3]GQUe`iE9+.N5.7)VIJW)Y2/=_54'Go./MCE:?-?jDm!8LiSLa#($_+k$O.O1ElBNDNn+F^@:97bZ`c\f)7::4$E9%kGTtJS\0+(C(i_a5.T.Usn5Zs*ac#]6ad`(o64lQV(pSjf8q5q6J>>^\d]XK>IZYh5jmqrGWeEpobP1*i;5aCKPgt8_G:8hSFisOn<nQts\'O'bo5^?InU!Z&U=46<mP8A"[nZl$/iUe7*^k[ZK=+2sl]:d,D3nT>G/p1"P;4K2<OL7pm.Wt&\BVSQZRUE^m;)W6=,IT-to&hb'?UX6:1cpUaB[R2p/*q,)G$\8]Ad+q&l>)hJE1JHd/qoYD:EF&0B8Oa8[XO$-B/ZFCqQVn1a,'a<3`"\57"5K0hgZ*C$)eI*\uYUQ:*,;fblkr/@quLq@=K]YmBI):c`k"ad7>s?Sa=doJ]\(T3$1aP57!-U-n't*JC:-AVL>Hpfn"[8:4R>UDD#lfr9-.gI%^;sSGgBg9H]UeYtJfW2Vss8B887amT[C:V6&R$,,,0J,rEbi\I9EVaNmC$I(P;'DoGdlh,1nmVO#M]3`iK5<Y!iVZ80f??Hk.`m^"Zl]^g_<Cq\9_UioF"fPdQ\.@Wl=>8<ULq<]RXoI#A;LX3PIB;>Fr/.KIsrtuQ10Wf"rY_VJnlF>TkDrKT?\.Zhfo<@P8STPfNp1%&k>P'QrS$R0Q\6%;j)eR1M<`;s5.eIEaD1D3<<p`.sDq.'ha:N86<[4,i>Aa(>^u0NB$Z#3C.qA=j0#p[4>Sg*5"mSRaA,~>endstream
 endobj
 30 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1831
->>
-stream
-Gatm<=\ftu'RnB33,bT-n[1OR/:F9$>Um<N:gY\P-K?@hB<1DCnF*RIR7SA"$27bZ'GN35q9F1"LB%Me`.-')J@AJPl]_CC0V&;SLr&]b5"nIr7Yi=SZO@CV&W%,cmZV\<MbsWp;M%btdfap8&P[KY&O@Zg"LNjXl]DuW+nK_/8pe)Ogn.o_rQY`O0h"r5.AW1PbRt93'#mt1b04X,rlg'20U]_aOW$E?WYNK'R/V^%CF:ft_r;Lf6J8diUMMH^WiLuB9s&8O(U5O1;$Mi_$r]E]du4ae3ET0lI>6b<pcoWi)9QEO!_lP1@MX;r?c>>u)JVe[+\<(jM-5GdJ#ACFjk6S9q]05r:,uo_!fnbP8AmE%"^I&$NW+mf@&;\UKI2KgP/=<U+0<7k$kmQW$OlR>\[Z"^R)="piCo/AWFhmgTK]Q\e8m@.n7-ihIK&8,i7GHYD8Ij.amJ%-$[?:a!J7ucg`(2f[o.j`6<dGAN^:HQ<I)90\ri8/Q*O&MX$VE#Kq,\e_Hb2,2oe`Rm]/>P;<8pnW#$S`'JQ`(5hd2*V(lF&%6E]=S>9Af`]-O-+HB#/'0mSZ4.q`oW)3gM,&l)#>:mM\k-0<+r^R)EC6=-S9!G?7<7S@a;u,R[:)ZSR:dnj>OqNSS$6,7_>qhk#([leH>N:cG?TuB,.V-:Kg_n!4hA'f!)iie?H=c0"%p0WD\?B*G+-dTamp)#":WU,ThN,7hV=qqK/a)EE"k\*%a;e/:3&h\UX\3(CK8]V>`#:"!qT]#AgYZfFHX>4&Vd/\Hhub6n7b<W#_Fd)ecGF>+lP],8leuN!rCbH&Eu`#38&G3-UGRu;"!2(uX#$9BQiYA+RZV_MW\<]N!QHA&=VS[t)Tm=r`IN;Wh(I::@G"#U-Z)B(%;HhIVlG$KKA-.V!AREh60HA?Tqo'#a*r"]9,]B04];j=j5Ys2YG[Q_nn`t=X9OL'%7h*$7G;V:E#ijKqchlCE+2nm[jQdO=nI<2M8Hm9R]AlX?#Aj<4NK<"Z2HdpnTOT\4$^`(^b\T0Suq/XGD*6ANhC3H[O>W*BBaAjd_0,!`fbndi@G&C)]MOXH[1"a+='<Ob1#>5-RgNF/V:kNZXo3/#^[Fr3YJ'2&g's)?[8i^SCq*'_eLX.m#(g@9*l^.B!UXC^J=nUDInjd]pt"hY\tXkhlQ"qGnm3qQC5GtN5,5-3ac9<oWot-OGL'8%9_tT6?%$e3W45DjD%rVcD1L@rTC^GXdlCh)K]&J]An?cl=N?DgO-d(ZFnq=GP^1"KpDtcr:Ko@U->(,3)%4LIU4q9cTRlEJJcDD%G$M\4]R+D9)B&aU(0^AE;cULpf)NHN4r\FLu>9T`B%$/ZacX&&(V'\<+Em44`q>`#u;C3=6l0VgLIj(iF/?A\nnFBLRk0/()gI3Zm\45OW/5JHT<(`X=g!n\l:'b\.qF_qdImKKm>dt&:AWKUfiapfNC<01M1b?/"p7k)qW<1d%DjAB,EfCpZs;$p=I`KP5n"Vl.0Q@,9Es[A6;9'r'K5N$PPgr&PT[n[+i1,%o@'rfPT^t"(EBjlIJ:+Pn(@;T?sEc]Trc%g-R5W[>/m1*9KSuQ9L^Q9`UZ7B2qe;`?kOk]q0(@#PQC,_"Lh7[Qg0)b$Qij)-hu4dCQ6TU[R*GBF`ISB)"UuVbt[/U4"J<D7ZnB0T!Pd:UV:0Pd5&?emMP$cB`Dom7PM.cD3']jc0::/IH'T#Yp6Y$?79u")X76;-K6]bhZ*$g`s>3Ji;mC'<$*\$oYBX=4@c'is40/45hh'J^&'8<<c(1ftUSb6kD/TDC#u!po<WAqA]J4d19@dUON83i`k+~>endstream
-endobj
-31 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1786
->>
-stream
-Gau0DgQ(#H&:O:SbZctkQK:i*<3ugl9t!T]+uf6J5epL/X]2#7MV='i^)0JJV6"MoRhQ6T+jK*WLSMa30q^d_L#5<*n8o/T>Vfb-k"B*F8=7/DkO[An).>7\A.!u__*e\7IsD0727#Ok@?e\eM'5J9_W+1<@"]hbJMXNX1^f.#U`hB;8XGbErj`ctgF=$g:5%UH'$^fK0o(#\(Z&k10.U+Qbd>u@GmXN#`kgQd2S+,=o?T+?KF%m/Uf'T90#rh6gc*sMQ+_9O;`R'u,r/2n8:a/aV&W#?nPo54@9XAG4sd3ZIXoBN8Q*M?i!Bun8JSJdk`p^@L_*5!@Ke#X18agg!BIgiF(TX^(+E*P6m\'/#u4AFjSiHdmq6QO?Y6o^-#HK&@hLM^^nNs)=bEFt>_Y:Z@ouhPme\NE;"2'dS&W?g?C6%8s4`1Y.S0ltBVTd53,Ocp0H-#s6m@JL,)5p\SIOGc.Vffs#/>?$_"4`;;ns$h+Y[8mg9_Ym)g>dWf8s2fGZd'%eDs'lZ/+4S[*>7M=&"g.X`h<N"6Ls5-Hj*ETF>m@Cru<YPo)A^d5[7R,0Eg&J@'a>dq?,TZP`D(0R-IHNLAt+WQEbdr]6#l`FQ<M6bU4$Y76^W[nsK%M[^qN<EZMH>=2s2\EXhf`^,VR_/8VlTSil!?5gUr3MS`H?f'-N;j&QJE0An"K8QbI,mP:o&kO8)P4O]-G,u:'3'H=idPc+!4`RH[BU\QZ/57H)A(^N'NoY:k_=*MRdE0<uo)3j!RS56npS[,N2f<^Wn@O(JJFb%*kZ(V>V*3&l%#6E,ftc9e@u$R<HpI1X3/'mbeooSVZg^nT@rM.oCuN9c+Y*UihT\8Kq=*lm!X1-;+n@:mS\XGP"%V-4\7Aj75Z)nNlaIfhKf/K-%-YO1NV8>fO5XfZH497jjgHOEAK^i-pKm`oT#0iaY8ZS_p$a_\)X7uu$BR87Lbfs+qjI/A/*fOUPq=[DY:T74J_UIV@q]Sga4Il&rAd\!Iq-1H6>h2TIVn#PE;'lJhs*`R"`_$1jea`.Z+_g_%-0&10_,VK``4O%l?WLqC1lJ)W9Wu#gBU\[E2XMtMV@B:KB#mJr"aa:g?1m*e]-8%K-PP\ZSJ`j&,k#QF<Ri)*tZ`#YeXV>b\cB;+Dc#&EXR>urTVkAA+Ipp<RK`.-K)L%/?6:$h%R,:<Vc#Ii>ME2`o-G;og]/?mS:E8:Ru`eOq19/BV;-TD-VF#i,U(TSsVkYh^?<_EF?Z,SLISa;lo\i8<-A@X&Jo%DJ0[[1@R[NRb5?5A5l"'01(Y5;#:mdVujL_J<0T\__]fc\;OJ,m\90ugEYuQW9>Ud57V`K]fFBlRHdQRH;CNb#`kA21'ld.kX0YuZk'A)Ql">!N>rJZ15N]<"`&MG6A=&i9D=sMpL:8laq/q@>;en]i0j*r02+8>gY1q%>N[m+c#&d(jB88To[CZTE-b\iEl$'<QA:aR8G*r<7]084@AWUU>l?rse1pnn?,TVbOso#\rdZQb./p_[l+oF$SQM:fqYfbVj;jd"<gP4..L-JF$1K(]>SuQ$B]#@Ha,c^U]]Zug6j]tSSql9Q1;",tb5aSL%.6je7g\W0l0nN[F8l3VRnU1@$,"quF@aGcP>h,fBiDgtos=8RP/ZdZF=Ba3.?2dg>s8anB(TOA$XFU=Ba:'_4q<3QS+;b_J_aML%"cB!Dk+r'TV+IK#8Bn#hLBG,^.4-s>V$Xbfb>?)N";OCDKLGd]A*.@.CS08r`_smibE+Yl_:tEB=V>/?%0u#0`)C=cdJi~>endstream
-endobj
-32 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 1754
 >>
 stream
-Gb!;cD/\/e&H;*)E?C_qk4g9\)MS]']5AY#@VNK'$8A\>SZn5)Q_NL$h[^tY>DaH5_hMVf!%/AX]-Er73toD[J],m?#5EWR?bIdO-nNt839%/i$U61TT4Wo?1ue`^ar+VJT^YN/E47V2(aQpGa"iFOa:QTP!K8-F#m$r4rF-NE;^c*[N+=#s5ko?.@6IUV5Z#B%V'%3UR-,0L29`a4[TthpraVe;K#Ie?CUJe%PjMFm!R$P.Hk?F?ic$%P-^7C/[DmF5S&R(NhDEN=hF5)=Qkb-,?=4*gb@n_IlGBsM:jmm_?i2;gPn`=2QTuj+>]:9rrMj`m&3N^MF$amJ-l5"diHN@6iVefn]/qu&OH:@B:d`5N.L>)3B,+[tY%F;<]A&M5V4?Zr,=Fk$T13Tq224ON1a#0Fi<&Le@@kA4bncPmn4Iu^K!Hn/RTd2i;H7:0.Bch1NK/.(Zm6fQ;+Y1**u$t[.Y%N8Z%+A>J-q73JE7R/b<+0>H)EQ,44&Ip.V3E(r_A+3.c%rT@WZI3f"an)m:p,ge>CZrDle[n4Nl"I[;i=0-bG%u<R^6`E"j9jL6\6dGj*]`#^nZn3e(JP-4gHQ9+EAfU_!Z*6KA+IZ9s/%&O6K%pW9&PSRWq!+<7[,IieSdXV,lu:rXB*"f8n%G@CtbKK-CD'e*tHe%"<R0')L3k@_\1H?.3I-Kq/K"QV[;l["Z_EU=F2URY1>Ck(>BHF.b;`PB/#q6FNMDq_YK:c]Vq%j*hC[L)<i?"BkHeaTO9R:?"p5tS;(9qC:3`WjEe9!9HqVdW:-b'RbbF<P_?d9,FgWY.P:bad2.U:B@;PBaeBAYHH<g2(lWn2#4]EFRa8A%f.<DSat-8u5]%pU8c/?7e,-;E=K]=>t,uh!4#'_7M&B31Qg[>5rET1?Nl83N)7`%qfWMY:P_LU<9dBUKOuRI:p6m@,m\R\#lpEn`dQNTW=\t"?rD4C;aLAW2SRZ=j#sQ@0)F]j2p?V<dHIREBK0kirpTL$_37oG\RT!\jd'lp'ZP;FBKd9m[l\leMD*/EW.W&)25ciSi+q)NuQ-%IR+R2,%iabFm9h@%Ph]ZO^aq?OK[1U[WgF0"dl7PUc<5)G,_MflI<u4lP7?1j(Vudq)@h0C*;ceDu2+RpA#hhD<('9<O7CeWAK2cIbJ;%hDj>+lZZL&LLq!qo]@=1ID4\0@Xh0DRmNpf*lA$q&p$<,O(C%[$@M48>kHVFe11>R4a?'P.DbL9@#3sNaRV&loDl)\HP7t[@2=FhqVZ\WXS:ZGYc0qWlS'Q:lTBbt^Lq?[?.8J&#7E4,<lXCP=-&\HLdE5$]mEF)fW0<3&Ft%f6SK8,LGWk83`_mdP^CCj"0d!9j(\q`P4dtS-fX=Ko?:dTn$oq#bKibO5FE\pRH.L8>^`4+=[>i!*b@1G6CaD?.-klts%Tn^7`7[)UBr*QWeE4)=8'a8l1C_'BWG32GEk+VWZUU\@j+WhLLt_Fr=F9g>D\D(pWctHPOu4^0IA,I+XL\;+;lLh$2rZR-(H0WK]V:%;nV#DA\@d2ZqZ3,&8@r=*eQTdIdo_-)n.V]6^[&'@E:MsVo<*PXa\V4b^.4+5QmubH)F`JEVdL.?!BJkmgOcP1T[9J*,RATN(p"n`8TrRcj&Nh13&a@n+;6UMpP[(0df0B2$u2^+`?Ea]/m<tTk-J/j-L4fC;OAL\8lWk:7'Zsls)3kj9_6kpWN%@gGU+qVR'^D2\o_TU#C3$25TjCFiM5`0@>H0,Q~>endstream
+Gatm;gMYb*&:O:SS@?!sbU"_'f!k:7Cl2O4#CS$tYVp'ne\t0YFn587;NabpZ'3-2!??o^iQU7@1ID?R$KceM-1H5<^Wm]6a#!l36t#iln"uk07YJ`C'Ia;(!=N?Jqo_@j`M`i,_C17T&gL(;_W*=:^^*RMK3$'"NgsO<eCgZDl0U7Y5J=;mSJM\H-UG[2'$^du0upZ>fP"DF=fojhF(lmH'APE:j.i\Z=hMQB(T&jf6-kRI+sIj?]7ud0[*n#X2:6/=CZFe.,#)a4JqP>E*$br<.L,>m/;a$`,uO-DG8<sW8L'OO-R97cLtl-?j?b$[:P]0aE<HnE,,Y(K4cn^h@T74(%T3oc+VcC;#+VJ?&DOGkf;#OEImtB]P&=4B@hLP_?re>`/C/$fM=]2&%!/],HiJV9M!7gr6Hdn7T?3g[qQ_kKB6'm=I=-$Uq>H!`f@Pe+U;HNDcI"cc_Ti/d7\'XTF5ST*8u"+=S%Mpp6=QKeo6QCBV5aacganTLKgMOA27'cK/6Bg'3CUWeT?Sfq22=Rs0-IZcjABij38$SOU2_AB6H[`4JTQG1!Q[/!#!RQjiOX*4=u]<Ia3PQqGJ88.Mqm]a?qu\cYQdKMT"pb<I^lBIqs2S#E1RlGT,@9\0u9>'TDcdOCL++_FlIr:E5Z&<C:qm#KY"SN+Sa`\<GR]H`E[,dFJW!'hc`in@"k$oYD1uTZ8HbRNFbh(pB8]cE\M+q?UOfnlebiBY7H?C>mSYP6*=8"?Kk]5"_)?Yf#(h7WiXbl'J!Jh;D[p/5hICpIm0_TM'=8XVUT6[9%/G#OL3VRg?"#PR0F'D$qMdu!0^e]TtZ%>`UHTZhLJ,$O(^2S:1.;U[X_-EeZ1j_/i*mR5S"6n,?BRtXrDHI#4#bM=_TbXRIVahhN&M&*>78[`JB1L%hP"1O94PWURe(W38GHq]=J#]`P.bD#;/#q`%u!2N]2*Gjbm0o*75pSOCoLRM)9H\T!q!UOiJ]lHQI$=Y$E6i6VBt]6VET"OJ^.(L\%9QG=qhL:;=Lflq6fY:"^'/DT5Qe,[iGZrMX7l<srs:I5N!)/tgKZT?>G"8KTt$hsr\WC1_4/L\4PZjg]2o=t.+rSZ/@,m#L.dr1iBWDcJ.=_S!a5Za7r#FlUr"a%_o\a'Y?U*c\AfqFQuf&=Q<rK*n_Z"=Ih`diW3M2M]Q3R;1ZoIp=m+X/:0A)KK%=\#92oeFltS/"QXK<H0tlk5;>#o0)idHFTjr6*JifnmrS*:K-Rkh8="#bR!0'LosJ;WTm2shG5g@F?j#^RucFa+o.$EIRa,<\F/+@N`AGrl[%#Ml\u2F_hF;+46dI$i\2.8Xu@eZ^P6ok_#6<?En+2<pF?8a/`B=R$S>"b-0L9ZgNMVTR+:;u2-(&QJNpGR<Sr=0=YpZ4L>[utVOC4p7'3q.f=+b(=A*KWhq2D?UdeZN4&9eY"Q*\\?nMoJa9.QAX)X<l+:L.Wda+X3HDYH4>n\HV@$L-8dsc$12F+Od@)#[5%>[=LXBU=c.P5[^gI@[@;%;ZqC/EFbV39@@eog_KakW3Ka^h<dD\J_aMdf40oD_h6`D1Rf:Ws=.G]jY=`>jR')9"/r5urop55-UVs&R,(;0iH55ek(q"r4,AB,oCi:",B(q^VU#]n?#l;Q?aNWR7eg1L&k:12E^9>UWn#b'F#i=ql7g,e0gi2g=/`%;m!s]?dqS4H/\[mq;QR]'#(?*qKTtc7?W(?h`!lX0*'7l/!od50YeX(OM#]!r~>endstream
+endobj
+31 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1624
+>>
+stream
+Gau0C>Ar7S'Roe[3,cJQiHQ#)%GQCkD2*3SHLou#'Wb"jl6ONKW2BRg_kA>[8o-"l3s9LFS]c4J*e*8c!t#`Er*>Ne:Zq5j,m2.q^&fX<K_[-C5+d7k&XMuUAjEj?9VarCQRC_C1C"UNUElZsKd9:s:D3n`&Z-EJDdi<`()(c1@U;ZKQ^7aPq)-m\.MsR/K]3t.kCh!B_n:YX_&HIZ.URX0RUG(O*<)q>LVJga9^rDNT4.^9'+XS(V2/YeNYBrgBM?JtGOFjqnmN)&A>Z?IJ0ZnF*(Z7^9_R#q[V2a+,H<8CJAnoAR:7)E-:02],1[^>[ZCq1;TW%@J>>f7'`TC#LNe6nghtpl,>'=_64&M,,\'1/h\GX0p3-.@[bE@h#,OF.$"FkhjlsZ$'M[OKeqjXLinEnW?bo)5YFDb1!aOlAXU"O64cE+s!#oeI(/iQ^0jlg>,n]@\WG[*kC_jI6E943UkMI&`J/-W89l65)C<.FH[Al?:C@Yj0Ys$$o9GXU*4k_#I;_<PGP\#^QC%prErik5XLuJ=E"u#8QZ1GW82>L;&hi?]oP\?n\"=`!Z:'e$:QQ0N[80Wb<F3_C%[(@s<LXSUS,\n'+?)qNlTpb>$=JdGZA(^_n-ZV8Qi89ZadE0=1h`n;BPA-l+Ip.<ti'oiMD\Is/c?1CnMlLG_GF7*O&0sh&2K3iU\fmINY9Dc7;i%fU.pm_5M_G;pp4e(a(-XjfA52"(]D9Jp+!)FtTR^_o,QG(($&m^s?F!c@kDY<4.#RJ'_ffOfY_N.-!Bo)3250R6%%]BC1O'uk^HDTJBh\+^R*a>]R%<h;j1TR9?KU*0I3MPi1.McCec`U<B-p<TX:&`D[_T\kEj.C:6LH&]0sn#Fj3-60i@[qOJ*V^D6LI/DiQB#Una.F.^@dUN$I\@Xb=uD<lU"h@*K[nK_oOLd)df_\Xm6;gV!W_kU;Ap3#M;55_Lc:"!G=\PjTaJ;gk79W%X#jN!ih6&`u@P8qIXSQ&MO)^qfF!b>os%cle;UB$>&Xo?u)]"fNGb;E+QoNe[KDdcIQ"Ci*%Jc]1+?O](+U9=o#)1fhaX1?d9L94sbQ3JEu%0/,.PMO/R3J7#(t-HJQTKD[%ga'&gbKReT&acGb>@+*XS]ND->*Rh@_:-*9GuBALo[p1</M)k,En$pCUWmu(#;)UuJ(3N>@4$fL(Dm,8fh76F#?@JA.;db?#38^cZIW[A9t'Ri(9g4Xk=$P5Ap:5t+*dGtd+-!lp_?Yr<AE0]$GlVO_!'F!R=PVmnq<6fZ'dTnHs?<eAW[U`S-na%<#n$%$S$'E,/jg5RZ/7*3Ba</n]*Vl:k.P)f2-[P7Y"%oD"h;\R2#O<@RqI+u'p['r&G=:$-Pc,<H%hH7Nr#gHV`(''jm;=HpT)^I8c?mTg&mB2n;./07k/[0acr$9]2\R:pTT_LNo/fX`rsP)Hd;DOOZMpOb3lY]8rCeOOE,k^?D@FMgSRaDqgZp2?$'InQdgYBjHTF6HX_,i;$5TMCDJ;3ac1W\HJnrM)emhp+N#":$FhrC9CkJH)!,PIg/^8H/CGb%05-MdR(/<Hr#),LUZF,CiVML)0ri80`?aO/8<st?`FUcZ;ZhC9/8XV:0%m;@RPl~>endstream
+endobj
+32 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1567
+>>
+stream
+Gb!#[?#SIU'Rf_Z30.rSF8QY>%DrCO>IPARYr(=/$4O"0-Yi;4;H/YRqgjuJbDC%J=>:3bS4($$p[I$\%VZ+S$5Pkt$M\UtDdG.PNo_0Q&rG^Sr4JPJSe7:Z6tRQH$78Z4nAu?RRop1-bpZ/_:6B&niG##/(h&jf3/dJ$=\R&%`OqH!+YQ4XEAq=>8&:iX&W1XCc3]aba0NS;4&`WS``7MjN&Oiin4.77IPZ+Zb%Fh*_X_tC36EJ2,*HqkS>\#eB7/+V$YMDXo:pMdbVU%P80Tk46'?n6Eec9S70iH&;$6Sj/Zq**7B40]&Q218C]/-g//TCo80qcF!_JYNC%r\uEkME`<pqt"188kW,q:0lPDffnGZNgMFuB.ZgNQ<b0;UcW$"Fm!FadL=e.dfH1e`YCc%X!K`B;,Cbne<%r+*HW@HnSn7:f]91hGO/`nT#SUMX:26_`oQP+nqA+:2VI@N[hN7u5e=OVf;e%+d]8dg$j?CT!D1V3lq1qJ#nam+%2S+Ggd6$dK"&m`?>5PaVq&=e@Sk`gY#&ApX33PS_ehIQ$7X2Z,;u'N,gJG.j[DZkf$&8Lh7&Ktm(K4,OG4F@>aWoo`WNYM6LlaINc>^rO`qDU<^i],(4EWGa?UXhOjJa;((r[;2d+?d[Bm%K*?I\o=d$OLAh2]Q_?8/lWknMn8D3.7<<Y-.?E?"RUPYPg;9B27g@SRuL_H)(shgnjM8Y;u<<WCl>$J:eK2_gssZXmW7@)4?(RA0@l-;)RoS4N8RtTBcQhE2Q]1M=N<HU46LFnlb`mBr@?&?+=>FH.Z1_&bBL?I8o.argU8^!S+q(6-Ksa>N8`5Gj!"QZSVjELS$e8_'c-$.3B_[.hs);B,,Wg;2-s*o^EDW_61uWcW,&cUq67X[l^JV=mJe%R?(Gr@7.[VGAfRuu[tDG%1t"dP^&=l0O&TXXElQNAb:Qg/9#OYuL6=W8pS9cJ%HM<,a7e*85ljDRFK[Z.HgBBVkFO`"EHcS[Lc"NHVOi8R+3\6Crm1%gOBqN>_.sQo2pSk?pA:B*UKR%D:'9ppaaN]u@b\CSEk*LUd#q!#QeBdFPL3'&$'Ga-bDuL-Nm1k0_1`uB@_\\O/KTd)MUSmT>foJ+nS%]md9PQDd=(l]`1DJUY`j=F50R`.OP*3PmB+:E33Y"4D:8q=%2pl^<e[lj0CN8`hjV(9mZ1um%p<hN9jgQEg(d:G\c[GZAi+bOZo3M9,_K+<,:Q:Y1oo9L9j>T@HqM1P-!sNb!\__D2!.@:Q@`F@YXkRSfjt>Jb"bV)+,[PRG?V[qjF,!d$$:@<Chu8Qn**_mV(XagE&e<5ZB*.^j6.)O6gELDF2YQ2%Nmbpmf5[e7h21L(C>m-G;YB=ju+',?m>ablmir=&gr$(o^@"Klj).6=+&C>mk4b(4[.SBj"*rcE;h':`u\1@?\qgfZ.]>-RV;G8e"RkK:Pi-9jMI-M2X0fa>Z?=4a6UltiU^#^I_k1(fe:o._?kF(k\YRY2f:E8Z^o?X3$]RS2b5`P>H8^(]]n^#1G8B."aZ0B.[r$hZt5F;rr.CbhO+6N1%#43~>endstream
 endobj
 33 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1400
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1299
 >>
 stream
-Gau1-?#SIU'Sc)T/)In6"3cVOGA`-dBsnF%d&\:7';/a/@uH75\g19's*gVOa*-e!acO>h%-s9Cms1PC%upo-q!b@Gi7Aiq^>e&PZT39I'$T4km;2?)_K[]]U]_?&bi9Zo4@KUhQtSl9Gf90OaH;c;'7$#ik):+H_\2)r9nnK.b$j._($g-*_T+8qHrRqE#o7/?TFc]D8M2^_E9aRTDJj:b\X$Q23lPHd/Da%UbOuBWIq/1NQuH]0,g0<,7C#.?;neT))*PC71tM,SAP$#mE=%pXAL,(><0YKo?*L.2l:[GF`UDk#Kj]1r(D$b.P:Xh1>T`$Y_"hl*4Q/EK_"'%uU[T9Z$N0_S6pDD-QRjZ8-p`VF(9HS:Z@1?aj5ahCAb+n_0b2>pc;Mpq<8EULmAQ%!*J=VPHmgUtItuJS=-gSmUj`,rF*CD;DL-?>2RcW0c!_nqqB(sk;+Lo:GD+bAiES`1f+T(eTFJ&gFWQmt;s8g5oD$L+79Pc?.,%=`L9s&PabIfr6Lk\H?l(dc5JsRr[/`p.ahj4B)QMa8K(FPtZ&ng%rBnjn=X_U8X`;sn[f/BIRY10-%[H:dV]+"BA7fdp:>#(<nneC4j(\(6>(4j;8+d6Q(X^!C/u$1(Q6fCm$-ZF7#4TGgVs[^qc9%fW)/`7Gm@,+Mb/&AR[P1A&%(E.op'n2'pDjoVnJGJ%#><N",/=K62DmohdV75MVt;/A8_2Qa_I97P=3Do?==N-\'Whena10PbDleo2T=8G*%(^h%eY.4k'X((e<773=>[peE&h@\(dL4,XdsL_uP=''09A_gOa7Z?Wh7$g:M#!A+8=[";:6MCm$pQto8(/(L:f]bkhmc5g@1>M+Ji4Z-buN]qNRsPuQ5Def;iqI[epUD`DV:31.;!+<@C2Ada.qlN4B7AAPmi-a?[IES=bj0[507eGP-$5>j$LC:<R^hVmg":/af<LHoMcnKSF!Z:9/&-;1S3bKMAH_%p[F17K5V]/VQIsl*gH7+;V/a-2"E/*AX+Voa`bh;E5jTEQhLX7gX5lrMSbh<kGU5o5#g#qUW@gejM?)0]dB"?NN/F55&,^coStUaG5kr0^6p<p^%)dmJr-SMdVQh`3c(0>eWF>PXa:=XB/o.@V0W\"gD1fTX""@#W+bF8EHTBXa(Bk'CDEuRZ>C\WM<ab9hp==*X7,mcHM*PB'c,)kOp`ePB2IUBH4S!T13uYe^RGt^glid&Kp'=,\%Tf\^%44_39Ne'V2%;>31h*-mhfJE$nB9aVoE]?SQjPP]Aml5j(p7+?p$&K\':a>D91\3P1DflkJj[#X\[<+eB`)Nn$;FLf0VF6/P5hY*(^%q&N7"tpK$,C_+JX#/Z"`Xj'J4??6@qNBfO1^QqTNI`qa9"]Q\C+ndie7@T*~>endstream
+Gau0B?#LoG'Rf.GS@9aoiJp(YH)]5&e#(iaOtKa@,-@B'$b2V0M<tW.hcCjA5`5tPV*Z(W>^Z"NkM-Sh7#8YUB@R'uN:>:R#8\5:_%W,BoECjWKBE9q\O_ns9I)?RF0P-J.I:T<&Y\+pbG-7O>,G!SBni!2?>pBI(k3IrNWmS^Do@Nu?]OW\P@.ali5c%Z1EfR#_4i1k(pu?r<baQO[f'N*0/4I+:Ic1-V=%l8L='?FI0pInr$5Fb&h]>Q7o&kTH=c`qd`bh.Fd==b&]H%uRZrp792e\7CNP,n,+pSl[K=2Y9,*!>EF(mE/5EJrlXSbn$%_^8&:)-<Sq6!+P"4Im6koFVf7ABD4>'c;Ueu^ZBe3B.j(.acK5ZCS_=QTEX^ZQ((HG,K02T(VXk"9Q#f@]s:kn_d"l[5S[(s)GkDlof(:\<Z<9(,+(MIkog"bsb&u@gCKJ.mei-YpRh)R)EP]IjR.NPn4[Be*<8pUhE0V9tH5):U;Z7SI+@FGdRV]f/Lpe_;<N"PCZV\eM59kabrdgK;\P1>e3paO&TTWk\_HEhdY@o!l_1YcY+G,hOV0+6#jGpnHjFP9Y&l#8C5\2#GuE!#h^J\Cb6q*-=CClG.cSXbUO$dtKk>lZ'P,$=HNe:FqWM5![O2"(UX29r2AL'$tlBQoJl;uUaE-&ck`?8W29N&8GiWH^D?NW44A"C&OGc)$&h@5nk;#cb"JMYbCoA":u2,K/Q19_[5hUA.9!6J@Ee^eN)/6"2IK<dFiCBKD2L[rOC%3`MmC*4`u^e#Y[1<4Yl(+O2pp&q3n_^'01s"Dp89)QUZUdXA=CNI;^(Ara-2LuHpRMHjP6V-RZd=[W0:`9@Kr?@/2l1ukJ)Zd/<t2]5Y^Uo4%p^et#^c+jJ.Gb2*ciGqQ@'Dti+T$oPHe'qnoYKD+qWG=%YLT,YEbcUGh);/%N(WJDO=8>7'SYb2^DFU<?G2#8rI"&2r3LjVXDN`djchU)2E^*RS["j^ri!,_sN/cYa\VK?IZ;W:BOs\ML]I_[_gk8N];Csp&g:5`gPemo1QKfNXC`9\AXf<AYjn70Y^LUWNYZYPd/>.jbeUaC=A_2*bo]h-Lh3e#@1fm:EXDEqoB'X?=fD`#oq_p<d)10e)@7!TU#.E"5]uD'n-f3P3n!m,H;d-?jcj`-qDH;OI7=U(4>LW;@lS*n[Jc-O;m/F[/rEU@_32r^]MrE=@\[;#9>*A^ff&CO0hoT%Mi@qU7roZ'$Mq*0T*kO\32gpN@dWmrh1Y8ZHcu9hfY4(1+1rf>9#SnAtG689Q#0cN]@K~>endstream
 endobj
 34 0 obj
 <<
@@ -282,21 +282,21 @@ xref
 0000003319 00000 n 
 0000003641 00000 n 
 0000003779 00000 n 
-0000004410 00000 n 
-0000005997 00000 n 
-0000006723 00000 n 
-0000008099 00000 n 
-0000009517 00000 n 
-0000011073 00000 n 
-0000012916 00000 n 
-0000014839 00000 n 
-0000016717 00000 n 
-0000018563 00000 n 
-0000020055 00000 n 
+0000004406 00000 n 
+0000005993 00000 n 
+0000006719 00000 n 
+0000008095 00000 n 
+0000009389 00000 n 
+0000010945 00000 n 
+0000012651 00000 n 
+0000014497 00000 n 
+0000016213 00000 n 
+0000017872 00000 n 
+0000019263 00000 n 
 trailer
 <<
 /ID 
-[<55734f70d7aa10f5b6692cd1638bfbe3><55734f70d7aa10f5b6692cd1638bfbe3>]
+[<8b3cefe161fc40bcda84457c807c1fca><8b3cefe161fc40bcda84457c807c1fca>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 21 0 R
@@ -304,5 +304,5 @@ trailer
 /Size 35
 >>
 startxref
-21492
+20700
 %%EOF


### PR DESCRIPTION
## Summary

- Kapitel 4b ''Flow-Antipattern-Muster'' (DE) und ''Flow Anti-Pattern Modes'' (EN) im Handbuch ergaenzt
- Parameter-Tabelle in Kap. 4 um `--mean-cycle-days`, `--std-cycle-days`, `--pattern`, `--pi-duration-weeks` erweitert
- Muster-Tabelle mit allen 5 Mustern (none, triangle, flat_triangle, cluster, batch): Scatterplot-Erscheinung + Erklaerung
- CT-Steuerung und PI-Konfiguration erklaert
- Beispiel-CLI-Aufrufe fuer triangle, cluster und batch
- PDFs (DE + EN) neu generiert

Generated with [Claude Code](https://claude.com/claude-code)