### PR TITLE
docs(modules): Manual-Download-Links fuer alle 6 Module (5 Sprachen)

### DIFF
--- a/docs/modules/build_reports.en.md
+++ b/docs/modules/build_reports.en.md
@@ -9,8 +9,11 @@ Calculates flow metrics from the XLSX files produced by `transform_data` and pre
 | Status | available |
 | GUI entry point | `build_reports_gui.pyw` |
 | CLI entry point | `python -m build_reports` |
-| User Manual (DE) | [build_reports_Benutzerhandbuch.pdf](../build_reports_Benutzerhandbuch.pdf) |
+| Benutzerhandbuch (DE) | [build_reports_Benutzerhandbuch.pdf](../build_reports_Benutzerhandbuch.pdf) |
 | User Manual (EN) | [build_reports_UserManual.pdf](../build_reports_UserManual.pdf) |
+| Manual de Utilizator (RO) | [build_reports_ManualUtilizator.pdf](../build_reports_ManualUtilizator.pdf) |
+| Manual do Utilizador (PT) | [build_reports_ManualUtilizador.pdf](../build_reports_ManualUtilizador.pdf) |
+| Manuel d'utilisation (FR) | [build_reports_ManuelUtilisateur.pdf](../build_reports_ManuelUtilisateur.pdf) |
 
 ## Metrics
 

--- a/docs/modules/build_reports.md
+++ b/docs/modules/build_reports.md
@@ -11,6 +11,9 @@ Berechnet Flow-Metriken aus den von `transform_data` erzeugten XLSX-Dateien und 
 | Einstiegspunkt CLI | `python -m build_reports` |
 | Benutzerhandbuch (DE) | [build_reports_Benutzerhandbuch.pdf](../build_reports_Benutzerhandbuch.pdf) |
 | User Manual (EN) | [build_reports_UserManual.pdf](../build_reports_UserManual.pdf) |
+| Manual de Utilizator (RO) | [build_reports_ManualUtilizator.pdf](../build_reports_ManualUtilizator.pdf) |
+| Manual do Utilizador (PT) | [build_reports_ManualUtilizador.pdf](../build_reports_ManualUtilizador.pdf) |
+| Manuel d'utilisation (FR) | [build_reports_ManuelUtilisateur.pdf](../build_reports_ManuelUtilisateur.pdf) |
 
 ## Metriken
 

--- a/docs/modules/get_data.en.md
+++ b/docs/modules/get_data.en.md
@@ -4,6 +4,16 @@ Retrieve data from Jira via REST API.
 
 **Status:** planned
 
+## Manuals
+
+| Language | Download |
+|----------|----------|
+| Deutsch (DE) | [Benutzerhandbuch](../get_data_Benutzerhandbuch.pdf) |
+| English (EN) | [User Manual](../get_data_UserManual.pdf) |
+| Română (RO) | [Manual de Utilizator](../get_data_ManualUtilizator.pdf) |
+| Português (PT) | [Manual do Utilizador](../get_data_ManualUtilizador.pdf) |
+| Français (FR) | [Manuel d'utilisation](../get_data_ManuelUtilisateur.pdf) |
+
 ---
 
 ## Workaround (until the module is available)

--- a/docs/modules/get_data.md
+++ b/docs/modules/get_data.md
@@ -4,6 +4,16 @@ Datenabruf aus Jira via REST API.
 
 **Status:** geplant
 
+## Handbücher
+
+| Sprache | Download |
+|---------|----------|
+| Deutsch (DE) | [Benutzerhandbuch](../get_data_Benutzerhandbuch.pdf) |
+| English (EN) | [User Manual](../get_data_UserManual.pdf) |
+| Română (RO) | [Manual de Utilizator](../get_data_ManualUtilizator.pdf) |
+| Português (PT) | [Manual do Utilizador](../get_data_ManualUtilizador.pdf) |
+| Français (FR) | [Manuel d'utilisation](../get_data_ManuelUtilisateur.pdf) |
+
 ---
 
 ## Workaround (bis zur Verfügbarkeit)

--- a/docs/modules/helper.en.md
+++ b/docs/modules/helper.en.md
@@ -13,6 +13,16 @@ Or via the start script in the portable package:
 - **macOS:** `Helper.command`
 - **Linux:** `Helper.sh`
 
+## Manuals
+
+| Language | Download |
+|----------|----------|
+| Deutsch (DE) | [Benutzerhandbuch](../helper_Benutzerhandbuch.pdf) |
+| English (EN) | [User Manual](../helper_UserManual.pdf) |
+| Română (RO) | [Manual de Utilizator](../helper_ManualUtilizator.pdf) |
+| Português (PT) | [Manual do Utilizador](../helper_ManualUtilizador.pdf) |
+| Français (FR) | [Manuel d'utilisation](../helper_ManuelUtilisateur.pdf) |
+
 ---
 
 ## JSON Merger

--- a/docs/modules/helper.md
+++ b/docs/modules/helper.md
@@ -13,6 +13,16 @@ Oder über die Startdatei im portablen Paket:
 - **macOS:** `Helper.command`
 - **Linux:** `Helper.sh`
 
+## Handbücher
+
+| Sprache | Download |
+|---------|----------|
+| Deutsch (DE) | [Benutzerhandbuch](../helper_Benutzerhandbuch.pdf) |
+| English (EN) | [User Manual](../helper_UserManual.pdf) |
+| Română (RO) | [Manual de Utilizator](../helper_ManualUtilizator.pdf) |
+| Português (PT) | [Manual do Utilizador](../helper_ManualUtilizador.pdf) |
+| Français (FR) | [Manuel d'utilisation](../helper_ManuelUtilisateur.pdf) |
+
 ---
 
 ## JSON Merger

--- a/docs/modules/launcher.en.md
+++ b/docs/modules/launcher.en.md
@@ -12,6 +12,16 @@ Or via the start script in the portable package:
 - **macOS:** `SituationReport.command`
 - **Linux:** `SituationReport.sh`
 
+## Manuals
+
+| Language | Download |
+|----------|----------|
+| Deutsch (DE) | [Benutzerhandbuch](../launcher_Benutzerhandbuch.pdf) |
+| English (EN) | [User Manual](../launcher_UserManual.pdf) |
+| Română (RO) | [Manual de Utilizator](../launcher_ManualUtilizator.pdf) |
+| Português (PT) | [Manual do Utilizador](../launcher_ManualUtilizador.pdf) |
+| Français (FR) | [Manuel d'utilisation](../launcher_ManuelUtilisateur.pdf) |
+
 ## Interface
 
 ![Launcher GUI screenshot](../assets/Launcher-GUI.png)

--- a/docs/modules/launcher.md
+++ b/docs/modules/launcher.md
@@ -12,6 +12,16 @@ Oder über die Startdatei im portablen Paket:
 - **macOS:** `SituationReport.command`
 - **Linux:** `SituationReport.sh`
 
+## Handbücher
+
+| Sprache | Download |
+|---------|----------|
+| Deutsch (DE) | [Benutzerhandbuch](../launcher_Benutzerhandbuch.pdf) |
+| English (EN) | [User Manual](../launcher_UserManual.pdf) |
+| Română (RO) | [Manual de Utilizator](../launcher_ManualUtilizator.pdf) |
+| Português (PT) | [Manual do Utilizador](../launcher_ManualUtilizador.pdf) |
+| Français (FR) | [Manuel d'utilisation](../launcher_ManuelUtilisateur.pdf) |
+
 ## Oberfläche
 
 ![Screenshot der Launcher-GUI](../assets/Launcher-GUI.png)

--- a/docs/modules/testdata_generator.en.md
+++ b/docs/modules/testdata_generator.en.md
@@ -6,6 +6,16 @@ suitable for development, testing, and demonstrations without real Jira data.
 
 **Status:** available (Alpha)
 
+## Manuals
+
+| Language | Download |
+|----------|----------|
+| Deutsch (DE) | [Benutzerhandbuch](../testdata_generator_Benutzerhandbuch.pdf) |
+| English (EN) | [User Manual](../testdata_generator_UserManual.pdf) |
+| Română (RO) | [Manual de Utilizator](../testdata_generator_ManualUtilizator.pdf) |
+| Português (PT) | [Manual do Utilizador](../testdata_generator_ManualUtilizador.pdf) |
+| Français (FR) | [Manuel d'utilisation](../testdata_generator_ManuelUtilisateur.pdf) |
+
 ---
 
 ## Interface

--- a/docs/modules/testdata_generator.md
+++ b/docs/modules/testdata_generator.md
@@ -6,6 +6,16 @@ eignen sich für Entwicklung, Tests und Demonstrationen ohne echte Jira-Daten.
 
 **Status:** verfügbar (Alpha)
 
+## Handbücher
+
+| Sprache | Download |
+|---------|----------|
+| Deutsch (DE) | [Benutzerhandbuch](../testdata_generator_Benutzerhandbuch.pdf) |
+| English (EN) | [User Manual](../testdata_generator_UserManual.pdf) |
+| Română (RO) | [Manual de Utilizator](../testdata_generator_ManualUtilizator.pdf) |
+| Português (PT) | [Manual do Utilizador](../testdata_generator_ManualUtilizador.pdf) |
+| Français (FR) | [Manuel d'utilisation](../testdata_generator_ManuelUtilisateur.pdf) |
+
 ---
 
 ## Oberfläche

--- a/docs/modules/transform_data.en.md
+++ b/docs/modules/transform_data.en.md
@@ -3,3 +3,13 @@
 Transforms raw Jira data (issue export) into stage-time metrics (IssueTimes.xlsx, CFD.xlsx, Transitions.xlsx).
 
 **Status:** available
+
+## Manuals
+
+| Language | Download |
+|----------|----------|
+| Deutsch (DE) | [Benutzerhandbuch](../transform_data_Benutzerhandbuch.pdf) |
+| English (EN) | [User Manual](../transform_data_UserManual.pdf) |
+| Română (RO) | [Manual de Utilizator](../transform_data_ManualUtilizator.pdf) |
+| Português (PT) | [Manual do Utilizador](../transform_data_ManualUtilizador.pdf) |
+| Français (FR) | [Manuel d'utilisation](../transform_data_ManuelUtilisateur.pdf) |

--- a/docs/modules/transform_data.md
+++ b/docs/modules/transform_data.md
@@ -3,3 +3,13 @@
 Transformiert Jira-Rohdaten (Issue-Export) in Stage-Time-Metriken (IssueTimes.xlsx, CFD.xlsx, Transitions.xlsx).
 
 **Status:** verfügbar
+
+## Handbücher
+
+| Sprache | Download |
+|---------|----------|
+| Deutsch (DE) | [Benutzerhandbuch](../transform_data_Benutzerhandbuch.pdf) |
+| English (EN) | [User Manual](../transform_data_UserManual.pdf) |
+| Română (RO) | [Manual de Utilizator](../transform_data_ManualUtilizator.pdf) |
+| Português (PT) | [Manual do Utilizador](../transform_data_ManualUtilizador.pdf) |
+| Français (FR) | [Manuel d'utilisation](../transform_data_ManuelUtilisateur.pdf) |


### PR DESCRIPTION
## Summary

- Alle 6 Modulseiten (DE + EN) erhalten eine Handbücher/Manuals-Tabelle
- Links zu allen 5 Sprachversionen: DE, EN, RO, PT, FR
- build_reports: RO/PT/FR zu bestehender Tabelle ergänzt
- Website bereits via mkdocs gh-deploy aktualisiert

🤖 Generated with [Claude Code](https://claude.com/claude-code)