### PR TITLE
feat(template): gemeinsames Projekt-Template für alle GUI-Module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Das Format orientiert sich an [Keep a Changelog](https://keepachangelog.com/de/1
 
 ---
 
+## [0.11.0] – 2026-05-16
+
+### Added
+- Gemeinsames **Projekt-Template** für alle GUI-Module (`build_reports`,
+  `transform_data`, `testdata_generator`, `helper`). Eine einzige JSON-Datei
+  hält je einen Abschnitt pro Modul, sodass die Pipeline-Konfiguration
+  (Workflow, Pfade, Projekt, Zeitraum) einmal gespeichert und in jedem
+  Modul-GUI über das Menü **Templates → Speichern/Laden** wiederverwendet
+  werden kann. Beim Speichern aus einem Modul bleiben die Abschnitte der
+  anderen Module erhalten.
+- Schema v5 (`project_template.py`). Ältere `build_reports`-Templates
+  (Schema v4, flache Struktur) werden weiterhin gelesen und transparent als
+  `build_reports`-Abschnitt interpretiert.
+
+---
+
 ## [0.9.9] – 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # situation-report
 
-**Version 0.9.10** ![Coverage](docs/coverage.svg)
+**Version 0.11.0** ![Coverage](docs/coverage.svg)
 
 Toolsuite for querying Jira issue data and processing it into flow metrics and reports.
 

--- a/build_reports/gui.py
+++ b/build_reports/gui.py
@@ -35,6 +35,8 @@ try:
 except ImportError:
     _VERSION = "?"
 
+import project_template
+
 from openpyxl import load_workbook
 from tkcalendar import Calendar
 
@@ -1681,8 +1683,11 @@ class BuildReportsApp(tk.Tk):
                 metrics={mid: var.get() for mid, var in self._metric_vars.items()},
                 language=self._lang_var.get(),
             )
-            Path(path).write_text(
-                json.dumps(tpl, indent=2, ensure_ascii=False), encoding="utf-8"
+            project_template.save_template(
+                Path(path),
+                project_template.MODULE_BUILD_REPORTS,
+                tpl,
+                language=self._lang_var.get(),
             )
             self._log(self._tr("log_tpl_saved").format(Path(path).name))
         except Exception as exc:
@@ -1705,8 +1710,16 @@ class BuildReportsApp(tk.Tk):
         if not path:
             return
         try:
-            raw = json.loads(Path(path).read_text(encoding="utf-8"))
-            state = _parse_template_dict(raw)
+            envelope = project_template.load_template(Path(path))
+            section = project_template.get_section(
+                envelope, project_template.MODULE_BUILD_REPORTS
+            )
+            if not section:
+                raise ValueError(
+                    "Template contains no build_reports section."
+                )
+            section.setdefault("language", envelope.get("language", LANG_DE))
+            state = _parse_template_dict(section)
         except Exception as exc:
             self._log(self._tr("log_tpl_error").format(exc))
             messagebox.showerror(self._tr("menu_template"), str(exc))

--- a/docs/modules/index.en.md
+++ b/docs/modules/index.en.md
@@ -9,3 +9,12 @@
 | [testdata_generator](testdata_generator.md) | Generate synthetic test data | available (Alpha) |
 | [get_data](get_data.md) | Retrieve data from Jira via REST API | planned |
 | [simulate](simulate.md) | Simulations and prediction models | planned |
+
+## Shared project template
+
+`transform_data`, `build_reports`, `testdata_generator` and `helper` share a
+common project template: a single JSON file with one section per module. Via
+the **Templates → Save / Load** menu the pipeline configuration (workflow,
+paths, project key, date range) can be saved once and reloaded in every module
+GUI. Saving from one module preserves the other modules' sections. Older
+`build_reports` templates (schema v4) are still read.

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -9,3 +9,13 @@
 | [testdata_generator](testdata_generator.md) | Generierung synthetischer Testdaten | verfügbar (Alpha) |
 | [get_data](get_data.md) | Datenabruf aus Jira via REST API | geplant |
 | [simulate](simulate.md) | Simulationen und Vorhersagemodelle | geplant |
+
+## Gemeinsames Projekt-Template
+
+`transform_data`, `build_reports`, `testdata_generator` und `helper` teilen sich
+ein gemeinsames Projekt-Template: eine einzige JSON-Datei mit je einem Abschnitt
+pro Modul. Über das Menü **Templates → Speichern / Laden** kann die
+Pipeline-Konfiguration (Workflow, Pfade, Projekt-Key, Zeitraum) einmal
+gespeichert und in jedem Modul-GUI wieder geladen werden. Beim Speichern aus
+einem Modul bleiben die Abschnitte der übrigen Module erhalten. Ältere
+`build_reports`-Templates (Schema v4) werden weiterhin gelesen.

--- a/helper/gui.py
+++ b/helper/gui.py
@@ -29,6 +29,8 @@ try:
 except ImportError:
     _VERSION = "?"
 
+import project_template
+
 from .cli import run_merge
 
 LANG_DE = "de"
@@ -79,6 +81,15 @@ _T: dict[str, dict[str, str]] = {
         "title":           f"helper – JSON Merger  {_VERSION}",
         "menu_help":       "Hilfe",
         "menu_manual":     "Manual",
+        "menu_template":   "Templates",
+        "menu_tpl_save":   "Speichern…",
+        "menu_tpl_load":   "Laden…",
+        "dlg_tpl_save":    "Template speichern",
+        "dlg_tpl_load":    "Template laden",
+        "log_tpl_saved":   "Template gespeichert: {}",
+        "log_tpl_loaded":  "Template geladen: {}",
+        "log_tpl_error":   "Fehler beim Template: {}",
+        "log_tpl_missing": "Hinweis: Datei aus Template nicht gefunden: {}",
         "tip_language":    "Sprache wechseln",
         "lbl_inputs":      "Eingabedateien",
         "btn_add":         "Hinzufügen…",
@@ -100,6 +111,15 @@ _T: dict[str, dict[str, str]] = {
         "title":           f"helper – JSON Merger  {_VERSION}",
         "menu_help":       "Help",
         "menu_manual":     "Manual",
+        "menu_template":   "Templates",
+        "menu_tpl_save":   "Save…",
+        "menu_tpl_load":   "Load…",
+        "dlg_tpl_save":    "Save Template",
+        "dlg_tpl_load":    "Load Template",
+        "log_tpl_saved":   "Template saved: {}",
+        "log_tpl_loaded":  "Template loaded: {}",
+        "log_tpl_error":   "Template error: {}",
+        "log_tpl_missing": "Note: file from template not found: {}",
         "tip_language":    "Change language",
         "lbl_inputs":      "Input files",
         "btn_add":         "Add…",
@@ -118,6 +138,24 @@ _T: dict[str, dict[str, str]] = {
         "dlg_output":      "Select output file",
     },
 }
+
+
+def _build_template_section(
+    inputs: list[str], output: str, dedup: bool
+) -> dict:
+    """Assemble the helper section for the shared project template."""
+    return {"inputs": list(inputs), "output": output, "dedup": bool(dedup)}
+
+
+def _parse_template_section(data: dict) -> dict:
+    """Normalise a helper template section; missing keys → sensible defaults."""
+    raw_inputs = data.get("inputs", [])
+    inputs = [str(p) for p in raw_inputs] if isinstance(raw_inputs, list) else []
+    return {
+        "inputs": inputs,
+        "output": str(data.get("output", "")),
+        "dedup": bool(data.get("dedup", True)),
+    }
 
 
 class _App:
@@ -146,6 +184,11 @@ class _App:
     def _build_menu(self) -> None:
         """Build (or rebuild) the top menu bar with Help → Manual."""
         menubar = tk.Menu(self._root)
+
+        tpl_menu = tk.Menu(menubar, tearoff=False)
+        menubar.add_cascade(label=self._t("menu_template"), menu=tpl_menu)
+        tpl_menu.add_command(label=self._t("menu_tpl_save"), command=self._save_template)
+        tpl_menu.add_command(label=self._t("menu_tpl_load"), command=self._load_template)
 
         help_menu = tk.Menu(menubar, tearoff=False)
         menubar.add_cascade(label=self._t("menu_help"), menu=help_menu)
@@ -337,6 +380,61 @@ class _App:
         )
         if path:
             self._var_output.set(path)
+
+    def _save_template(self) -> None:
+        """Write the current input list/output/dedup as this module's template section."""
+        path = filedialog.asksaveasfilename(
+            title=self._t("dlg_tpl_save"),
+            defaultextension=".json",
+            filetypes=[("JSON files", "*.json"), ("All files", "*.*")],
+        )
+        if not path:
+            return
+        try:
+            section = _build_template_section(
+                inputs=list(self._listbox.get(0, "end")),
+                output=self._var_output.get(),
+                dedup=self._var_dedup.get(),
+            )
+            project_template.save_template(
+                Path(path),
+                project_template.MODULE_HELPER,
+                section,
+                language=self._lang_var.get(),
+            )
+            self._log_msg(self._t("log_tpl_saved").format(Path(path).name))
+        except Exception as exc:
+            self._log_msg(self._t("log_tpl_error").format(exc))
+
+    def _load_template(self) -> None:
+        """Load this module's section from a project-template file into the UI."""
+        path = filedialog.askopenfilename(
+            title=self._t("dlg_tpl_load"),
+            filetypes=[("JSON files", "*.json"), ("All files", "*.*")],
+        )
+        if not path:
+            return
+        try:
+            envelope = project_template.load_template(Path(path))
+            section = _parse_template_section(
+                project_template.get_section(
+                    envelope, project_template.MODULE_HELPER
+                )
+            )
+        except Exception as exc:
+            self._log_msg(self._t("log_tpl_error").format(exc))
+            return
+
+        self._listbox.delete(0, "end")
+        for p in section["inputs"]:
+            self._listbox.insert("end", p)
+            if p and not Path(p).is_file():
+                self._log_msg(self._t("log_tpl_missing").format(p))
+        self._var_output.set(section["output"])
+        self._var_dedup.set(section["dedup"])
+
+        self._lang_var.set(envelope.get("language", self._lang_var.get()))
+        self._log_msg(self._t("log_tpl_loaded").format(Path(path).name))
 
     def _log_msg(self, msg: str) -> None:
         """Append a line to the log area (thread-safe via after())."""

--- a/project_template.py
+++ b/project_template.py
@@ -1,0 +1,165 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       16.05.2026
+# Geändert:       16.05.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Gemeinsames Projekt-Template für alle Module (build_reports, transform_data,
+#   testdata_generator, helper). Eine einzige JSON-Datei hält je einen Abschnitt
+#   pro Modul, sodass die Pipeline-Konfiguration (Workflow, Pfade, Projekt,
+#   Zeitraum) einmal gesetzt und in jedem Modul-GUI geladen werden kann.
+#
+#   Schema v5 kapselt die Modul-Abschnitte unter "modules". Ältere build_reports-
+#   Templates (Schema v4, flache Struktur ohne "modules") werden weiterhin
+#   gelesen und transparent als build_reports-Abschnitt interpretiert.
+#
+#   save_template ersetzt beim Speichern nur den eigenen Modul-Abschnitt und
+#   erhält alle anderen Abschnitte einer bestehenden Datei.
+# =============================================================================
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 5
+APP_NAME = "situation_report"
+
+#: Modulnamen, die einen Abschnitt im Projekt-Template haben dürfen.
+MODULE_BUILD_REPORTS = "build_reports"
+MODULE_TRANSFORM_DATA = "transform_data"
+MODULE_TESTDATA_GENERATOR = "testdata_generator"
+MODULE_HELPER = "helper"
+
+DEFAULT_LANGUAGE = "de"
+
+
+def _normalise(data: Any) -> dict[str, Any]:
+    """
+    Bring a raw parsed JSON object into the v5 envelope shape.
+
+    A v5 file already has a ``modules`` mapping and is returned as-is (with
+    guaranteed keys). A legacy build_reports template (schema v4 or older: a
+    flat dict without ``modules``) is wrapped so its content becomes the
+    ``build_reports`` section. The language is lifted from the legacy flat
+    dict if present.
+
+    Args:
+        data: Raw object parsed from the template JSON file.
+
+    Returns:
+        Envelope dict with keys ``schema``, ``app``, ``language``, ``modules``.
+
+    Raises:
+        ValueError: If ``data`` is not a JSON object.
+    """
+    if not isinstance(data, dict):
+        raise ValueError("Template file does not contain a JSON object.")
+
+    if isinstance(data.get("modules"), dict):
+        modules = {
+            str(name): dict(section)
+            for name, section in data["modules"].items()
+            if isinstance(section, dict)
+        }
+        language = str(data.get("language", DEFAULT_LANGUAGE))
+        return {
+            "schema": int(data.get("schema", SCHEMA_VERSION)),
+            "app": str(data.get("app", APP_NAME)),
+            "language": language,
+            "modules": modules,
+        }
+
+    # Legacy v4 (or older) build_reports template: flat dict without "modules".
+    language = str(data.get("language", DEFAULT_LANGUAGE))
+    return {
+        "schema": SCHEMA_VERSION,
+        "app": APP_NAME,
+        "language": language,
+        "modules": {MODULE_BUILD_REPORTS: dict(data)},
+    }
+
+
+def load_template(path: Path) -> dict[str, Any]:
+    """
+    Read a project-template file and return it in the v5 envelope shape.
+
+    Legacy build_reports-only templates are transparently upgraded in memory
+    (the file on disk is left untouched until the next save).
+
+    Args:
+        path: Path to the JSON template file.
+
+    Returns:
+        Envelope dict: ``{"schema", "app", "language", "modules": {name: {...}}}``.
+
+    Raises:
+        ValueError: If the file is not a JSON object.
+        OSError / json.JSONDecodeError: On read or parse failure.
+    """
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    return _normalise(raw)
+
+
+def get_section(envelope: dict[str, Any], module_name: str) -> dict[str, Any]:
+    """
+    Return the section dict for ``module_name`` from a loaded envelope.
+
+    Args:
+        envelope:    Result of load_template().
+        module_name: One of the MODULE_* constants.
+
+    Returns:
+        The module's section dict, or an empty dict if the file has no section
+        for that module.
+    """
+    return dict(envelope.get("modules", {}).get(module_name, {}))
+
+
+def save_template(
+    path: Path,
+    module_name: str,
+    section: dict[str, Any],
+    language: str | None = None,
+) -> None:
+    """
+    Write ``section`` as the given module's part of the project template.
+
+    If the target file already exists it is read first (legacy v4 files are
+    upgraded), and only the named module's section is replaced — every other
+    module's section is preserved. If the file does not exist a new v5 template
+    containing just this module's section is created.
+
+    Args:
+        path:        Destination JSON file.
+        module_name: One of the MODULE_* constants — which section to write.
+        section:     JSON-serialisable dict for this module.
+        language:    Optional language code to store at the envelope level.
+                     If None, an existing language is kept (or the default).
+    """
+    target = Path(path)
+    if target.is_file():
+        try:
+            envelope = load_template(target)
+        except (ValueError, json.JSONDecodeError, OSError):
+            envelope = _normalise({})
+    else:
+        envelope = _normalise({})
+
+    envelope["modules"][module_name] = dict(section)
+    if language is not None:
+        envelope["language"] = language
+
+    payload = {
+        "schema": SCHEMA_VERSION,
+        "app": APP_NAME,
+        "language": envelope.get("language", DEFAULT_LANGUAGE),
+        "modules": envelope["modules"],
+    }
+    target.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+    )

--- a/testdata_generator/gui.py
+++ b/testdata_generator/gui.py
@@ -31,6 +31,8 @@ try:
 except ImportError:
     _VERSION = "?"
 
+import project_template
+
 from .cli import run_generate
 from .generator import (
     PATTERN_BATCH,
@@ -96,6 +98,15 @@ _T: dict[str, dict[str, str]] = {
         "title":              f"testdata_generator {_VERSION}",
         "menu_help":          "Hilfe",
         "menu_manual":        "Manual",
+        "menu_template":      "Templates",
+        "menu_tpl_save":      "Speichern…",
+        "menu_tpl_load":      "Laden…",
+        "dlg_tpl_save":       "Template speichern",
+        "dlg_tpl_load":       "Template laden",
+        "log_tpl_saved":      "Template gespeichert: {}",
+        "log_tpl_loaded":     "Template geladen: {}",
+        "log_tpl_error":      "Fehler beim Template: {}",
+        "log_tpl_missing":    "Hinweis: Datei aus Template nicht gefunden: {}",
         "tip_language":       "Sprache wechseln",
         "lbl_workflow":       "Workflow-Datei",
         "lbl_output":         "Ausgabedatei (JSON)",
@@ -142,6 +153,15 @@ _T: dict[str, dict[str, str]] = {
         "title":              f"testdata_generator {_VERSION}",
         "menu_help":          "Help",
         "menu_manual":        "Manual",
+        "menu_template":      "Templates",
+        "menu_tpl_save":      "Save…",
+        "menu_tpl_load":      "Load…",
+        "dlg_tpl_save":       "Save Template",
+        "dlg_tpl_load":       "Load Template",
+        "log_tpl_saved":      "Template saved: {}",
+        "log_tpl_loaded":     "Template loaded: {}",
+        "log_tpl_error":      "Template error: {}",
+        "log_tpl_missing":    "Note: file from template not found: {}",
         "tip_language":       "Change language",
         "lbl_workflow":       "Workflow File",
         "lbl_output":         "Output File (JSON)",
@@ -187,6 +207,23 @@ _T: dict[str, dict[str, str]] = {
 }
 
 
+_TEMPLATE_FIELDS = (
+    "workflow", "output", "project", "issues", "from_date", "to_date",
+    "issue_types", "completion", "todo", "backflow", "seed",
+    "mean_cycle", "std_cycle", "pattern", "pattern_strength", "pi_weeks",
+)
+
+
+def _build_template_section(values: dict[str, str]) -> dict:
+    """Assemble the testdata_generator section for the shared project template."""
+    return {key: str(values.get(key, "")) for key in _TEMPLATE_FIELDS}
+
+
+def _parse_template_section(data: dict) -> dict:
+    """Normalise a testdata_generator template section; missing keys → empty string."""
+    return {key: str(data.get(key, "")) for key in _TEMPLATE_FIELDS}
+
+
 class _App:
     """Main application window for testdata_generator GUI."""
 
@@ -225,6 +262,10 @@ class _App:
 
     def _build_menu(self) -> None:
         menubar = tk.Menu(self._root)
+        tpl_menu = tk.Menu(menubar, tearoff=False)
+        menubar.add_cascade(label=self._t("menu_template"), menu=tpl_menu)
+        tpl_menu.add_command(label=self._t("menu_tpl_save"), command=self._save_template)
+        tpl_menu.add_command(label=self._t("menu_tpl_load"), command=self._load_template)
         help_menu = tk.Menu(menubar, tearoff=False)
         menubar.add_cascade(label=self._t("menu_help"), menu=help_menu)
         help_menu.add_command(label=self._t("menu_manual"), command=self._open_manual)
@@ -478,6 +519,79 @@ class _App:
         )
         if path:
             self._var_output.set(path)
+
+    def _template_vars(self) -> dict[str, tk.StringVar]:
+        """Map project-template field names to their StringVars."""
+        return {
+            "workflow": self._var_workflow,
+            "output": self._var_output,
+            "project": self._var_project,
+            "issues": self._var_issues,
+            "from_date": self._var_from_date,
+            "to_date": self._var_to_date,
+            "issue_types": self._var_issue_types,
+            "completion": self._var_completion,
+            "todo": self._var_todo,
+            "backflow": self._var_backflow,
+            "seed": self._var_seed,
+            "mean_cycle": self._var_mean_cycle,
+            "std_cycle": self._var_std_cycle,
+            "pattern": self._var_pattern,
+            "pattern_strength": self._var_pattern_strength,
+            "pi_weeks": self._var_pi_weeks,
+        }
+
+    def _save_template(self) -> None:
+        """Write the current parameters as this module's project-template section."""
+        path = filedialog.asksaveasfilename(
+            title=self._t("dlg_tpl_save"),
+            defaultextension=".json",
+            filetypes=[("JSON files", "*.json"), ("All files", "*.*")],
+        )
+        if not path:
+            return
+        try:
+            section = _build_template_section(
+                {k: v.get() for k, v in self._template_vars().items()}
+            )
+            project_template.save_template(
+                Path(path),
+                project_template.MODULE_TESTDATA_GENERATOR,
+                section,
+                language=self._lang_var.get(),
+            )
+            self._log_msg(self._t("log_tpl_saved").format(Path(path).name))
+        except Exception as exc:
+            self._log_msg(self._t("log_tpl_error").format(exc))
+
+    def _load_template(self) -> None:
+        """Load this module's section from a project-template file into the UI."""
+        path = filedialog.askopenfilename(
+            title=self._t("dlg_tpl_load"),
+            filetypes=[("JSON files", "*.json"), ("All files", "*.*")],
+        )
+        if not path:
+            return
+        try:
+            envelope = project_template.load_template(Path(path))
+            section = _parse_template_section(
+                project_template.get_section(
+                    envelope, project_template.MODULE_TESTDATA_GENERATOR
+                )
+            )
+        except Exception as exc:
+            self._log_msg(self._t("log_tpl_error").format(exc))
+            return
+
+        for key, var in self._template_vars().items():
+            var.set(section[key])
+        self._on_pattern_change()
+
+        if section["workflow"] and not Path(section["workflow"]).is_file():
+            self._log_msg(self._t("log_tpl_missing").format(section["workflow"]))
+
+        self._lang_var.set(envelope.get("language", self._lang_var.get()))
+        self._log_msg(self._t("log_tpl_loaded").format(Path(path).name))
 
     def _log_msg(self, msg: str) -> None:
         self._log_widget.configure(state="normal")

--- a/tests/build_reports/unit/test_gui_template.py
+++ b/tests/build_reports/unit/test_gui_template.py
@@ -1,0 +1,51 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       16.05.2026
+# Geändert:       16.05.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für die Integration von build_reports.gui mit dem gemeinsamen
+#   project_template (v5-Hülle). Prüft Round-Trip über save/load und das
+#   Lesen alter v4-Templates (flach, ohne "modules").
+# =============================================================================
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import project_template as pt
+from build_reports.gui import _build_template_dict, _parse_template_dict
+
+
+def test_v5_round_trip_via_project_template(tmp_path: Path):
+    f = tmp_path / "proj.json"
+    tpl = _build_template_dict(
+        issue_times="IT.xlsx", cfd="C.xlsx", from_date="", to_date="",
+        projects="", issuetypes="", terminology="SAFe", ct_method="A",
+        metrics={"cfd": True, "flow_time": False}, language="de",
+    )
+    pt.save_template(f, pt.MODULE_BUILD_REPORTS, tpl, language="de")
+
+    env = pt.load_template(f)
+    section = pt.get_section(env, pt.MODULE_BUILD_REPORTS)
+    state = _parse_template_dict(section)
+    assert state["issue_times"] == "IT.xlsx"
+    assert state["metrics"] == {"cfd": True, "flow_time": False}
+
+
+def test_legacy_v4_flat_file_still_loads(tmp_path: Path):
+    f = tmp_path / "legacy.json"
+    f.write_text(
+        json.dumps({"version": 4, "issue_times": "old.xlsx", "language": "en"}),
+        encoding="utf-8",
+    )
+    env = pt.load_template(f)
+    section = pt.get_section(env, pt.MODULE_BUILD_REPORTS)
+    section.setdefault("language", env["language"])
+    state = _parse_template_dict(section)
+    assert state["issue_times"] == "old.xlsx"
+    assert state["language"] == "en"

--- a/tests/helper/unit/test_gui_template.py
+++ b/tests/helper/unit/test_gui_template.py
@@ -1,0 +1,42 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       16.05.2026
+# Geändert:       16.05.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für die Projekt-Template-Abschnittsfunktionen von helper.gui
+#   (_build_template_section / _parse_template_section).
+# =============================================================================
+
+from __future__ import annotations
+
+from helper.gui import _build_template_section, _parse_template_section
+
+
+def test_build_section():
+    sec = _build_template_section(["a.json", "b.json"], "merged.json", False)
+    assert sec == {
+        "inputs": ["a.json", "b.json"],
+        "output": "merged.json",
+        "dedup": False,
+    }
+
+
+def test_parse_round_trip():
+    sec = _build_template_section(["x.json"], "out.json", True)
+    assert _parse_template_section(sec) == sec
+
+
+def test_parse_defaults():
+    assert _parse_template_section({}) == {
+        "inputs": [],
+        "output": "",
+        "dedup": True,
+    }
+
+
+def test_parse_non_list_inputs_coerced_to_empty():
+    assert _parse_template_section({"inputs": "not-a-list"})["inputs"] == []

--- a/tests/project_template/unit/test_project_template.py
+++ b/tests/project_template/unit/test_project_template.py
@@ -1,0 +1,107 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       16.05.2026
+# Geändert:       16.05.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für project_template: v5-Round-Trip, Legacy-v4-Erkennung
+#   (flaches build_reports-Template ohne "modules"), Abschnitt-Erhalt beim
+#   Speichern aus einem einzelnen Modul sowie Sprach-Handling.
+# =============================================================================
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import project_template as pt
+
+
+class TestNormalise:
+    def test_legacy_v4_wrapped_under_build_reports(self):
+        env = pt._normalise(
+            {"version": 4, "issue_times": "IT.xlsx", "language": "en"}
+        )
+        assert env["schema"] == pt.SCHEMA_VERSION
+        assert env["modules"][pt.MODULE_BUILD_REPORTS]["issue_times"] == "IT.xlsx"
+        assert env["language"] == "en"
+
+    def test_legacy_without_language_defaults(self):
+        env = pt._normalise({"version": 4, "issue_times": "X"})
+        assert env["language"] == pt.DEFAULT_LANGUAGE
+
+    def test_v5_envelope_passthrough(self):
+        env = pt._normalise(
+            {
+                "schema": 5,
+                "language": "fr",
+                "modules": {pt.MODULE_HELPER: {"output": "m.json"}},
+            }
+        )
+        assert env["language"] == "fr"
+        assert env["modules"][pt.MODULE_HELPER]["output"] == "m.json"
+
+    def test_non_dict_raises(self):
+        with pytest.raises(ValueError):
+            pt._normalise(["not", "a", "dict"])
+
+
+class TestRoundTrip:
+    def test_save_and_load_single_section(self, tmp_path: Path):
+        f = tmp_path / "proj.json"
+        pt.save_template(
+            f, pt.MODULE_TRANSFORM_DATA, {"prefix": "ART_A"}, language="de"
+        )
+        env = pt.load_template(f)
+        assert env["schema"] == 5
+        assert pt.get_section(env, pt.MODULE_TRANSFORM_DATA)["prefix"] == "ART_A"
+        assert env["language"] == "de"
+
+    def test_section_preserved_across_modules(self, tmp_path: Path):
+        f = tmp_path / "proj.json"
+        pt.save_template(f, pt.MODULE_BUILD_REPORTS, {"issue_times": "IT.xlsx"})
+        pt.save_template(f, pt.MODULE_TESTDATA_GENERATOR, {"project": "TEST"})
+
+        env = pt.load_template(f)
+        assert pt.get_section(env, pt.MODULE_BUILD_REPORTS)["issue_times"] == "IT.xlsx"
+        assert pt.get_section(env, pt.MODULE_TESTDATA_GENERATOR)["project"] == "TEST"
+
+    def test_resave_replaces_only_own_section(self, tmp_path: Path):
+        f = tmp_path / "proj.json"
+        pt.save_template(f, pt.MODULE_HELPER, {"output": "a.json"})
+        pt.save_template(f, pt.MODULE_BUILD_REPORTS, {"cfd": "C.xlsx"})
+        pt.save_template(f, pt.MODULE_HELPER, {"output": "b.json"})
+
+        env = pt.load_template(f)
+        assert pt.get_section(env, pt.MODULE_HELPER)["output"] == "b.json"
+        assert pt.get_section(env, pt.MODULE_BUILD_REPORTS)["cfd"] == "C.xlsx"
+
+    def test_save_onto_legacy_v4_file_upgrades_and_preserves(self, tmp_path: Path):
+        f = tmp_path / "legacy.json"
+        f.write_text(
+            json.dumps({"version": 4, "issue_times": "old.xlsx"}),
+            encoding="utf-8",
+        )
+        pt.save_template(f, pt.MODULE_HELPER, {"output": "m.json"})
+
+        on_disk = json.loads(f.read_text(encoding="utf-8"))
+        assert on_disk["schema"] == 5
+        assert on_disk["modules"][pt.MODULE_BUILD_REPORTS]["issue_times"] == "old.xlsx"
+        assert on_disk["modules"][pt.MODULE_HELPER]["output"] == "m.json"
+
+    def test_language_kept_when_not_passed(self, tmp_path: Path):
+        f = tmp_path / "proj.json"
+        pt.save_template(f, pt.MODULE_HELPER, {"output": "x"}, language="fr")
+        pt.save_template(f, pt.MODULE_BUILD_REPORTS, {"cfd": "y"})
+        assert pt.load_template(f)["language"] == "fr"
+
+    def test_get_section_missing_returns_empty(self, tmp_path: Path):
+        f = tmp_path / "proj.json"
+        pt.save_template(f, pt.MODULE_HELPER, {"output": "x"})
+        env = pt.load_template(f)
+        assert pt.get_section(env, pt.MODULE_TRANSFORM_DATA) == {}

--- a/tests/testdata_generator/unit/test_gui_template.py
+++ b/tests/testdata_generator/unit/test_gui_template.py
@@ -1,0 +1,43 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       16.05.2026
+# Geändert:       16.05.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für die Projekt-Template-Abschnittsfunktionen von
+#   testdata_generator.gui (_build_template_section / _parse_template_section).
+# =============================================================================
+
+from __future__ import annotations
+
+from testdata_generator.gui import (
+    _TEMPLATE_FIELDS,
+    _build_template_section,
+    _parse_template_section,
+)
+
+
+def test_build_section_has_all_fields_as_strings():
+    sec = _build_template_section({"issues": 100, "pattern_strength": 50})
+    assert set(sec) == set(_TEMPLATE_FIELDS)
+    assert sec["issues"] == "100"
+    assert sec["pattern_strength"] == "50"
+    assert sec["workflow"] == ""
+
+
+def test_parse_round_trip():
+    values = {k: f"v_{k}" for k in _TEMPLATE_FIELDS}
+    sec = _build_template_section(values)
+    assert _parse_template_section(sec) == sec
+
+
+def test_parse_missing_keys_default_to_empty():
+    parsed = _parse_template_section({})
+    assert all(parsed[k] == "" for k in _TEMPLATE_FIELDS)
+
+
+def test_pattern_strength_field_present():
+    assert "pattern_strength" in _TEMPLATE_FIELDS

--- a/tests/transform_data/unit/test_gui_template.py
+++ b/tests/transform_data/unit/test_gui_template.py
@@ -1,0 +1,40 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       16.05.2026
+# Geändert:       16.05.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für die Projekt-Template-Abschnittsfunktionen von
+#   transform_data.gui (_build_template_section / _parse_template_section).
+# =============================================================================
+
+from __future__ import annotations
+
+from transform_data.gui import _build_template_section, _parse_template_section
+
+
+def test_build_section_contains_all_fields():
+    sec = _build_template_section("a.json", "wf.txt", "/out", "ART_A")
+    assert sec == {
+        "json_file": "a.json",
+        "workflow_file": "wf.txt",
+        "output_dir": "/out",
+        "prefix": "ART_A",
+    }
+
+
+def test_parse_round_trip():
+    sec = _build_template_section("a.json", "wf.txt", "/out", "ART_A")
+    assert _parse_template_section(sec) == sec
+
+
+def test_parse_missing_keys_default_to_empty():
+    assert _parse_template_section({}) == {
+        "json_file": "",
+        "workflow_file": "",
+        "output_dir": "",
+        "prefix": "",
+    }

--- a/transform_data/gui.py
+++ b/transform_data/gui.py
@@ -29,6 +29,8 @@ try:
 except ImportError:
     _VERSION = "?"
 
+import project_template
+
 from .transform import run_transform
 
 # ---------------------------------------------------------------------------
@@ -55,6 +57,15 @@ _T: dict[str, dict[str, str]] = {
         "menu_lang_fr":     "Français",
         "menu_help":        "Hilfe",
         "menu_manual":      "Manual",
+        "menu_template":    "Templates",
+        "menu_tpl_save":    "Speichern…",
+        "menu_tpl_load":    "Laden…",
+        "dlg_tpl_save":     "Template speichern",
+        "dlg_tpl_load":     "Template laden",
+        "log_tpl_saved":    "Template gespeichert: {}",
+        "log_tpl_loaded":   "Template geladen: {}",
+        "log_tpl_error":    "Fehler beim Template: {}",
+        "log_tpl_missing":  "Hinweis: Datei aus Template nicht gefunden: {}",
         "lbl_json":         "JSON-Datei",
         "lbl_workflow":     "Workflow-Datei",
         "lbl_output_dir":   "Ausgabeordner",
@@ -84,6 +95,15 @@ _T: dict[str, dict[str, str]] = {
         "menu_lang_fr":     "Français",
         "menu_help":        "Help",
         "menu_manual":      "Manual",
+        "menu_template":    "Templates",
+        "menu_tpl_save":    "Save…",
+        "menu_tpl_load":    "Load…",
+        "dlg_tpl_save":     "Save Template",
+        "dlg_tpl_load":     "Load Template",
+        "log_tpl_saved":    "Template saved: {}",
+        "log_tpl_loaded":   "Template loaded: {}",
+        "log_tpl_error":    "Template error: {}",
+        "log_tpl_missing":  "Note: file from template not found: {}",
         "lbl_json":         "JSON File",
         "lbl_workflow":     "Workflow File",
         "lbl_output_dir":   "Output Folder",
@@ -113,6 +133,15 @@ _T: dict[str, dict[str, str]] = {
         "menu_lang_fr":     "Français",
         "menu_help":        "Ajutor",
         "menu_manual":      "Manual",
+        "menu_template":    "Şabloane",
+        "menu_tpl_save":    "Salvare…",
+        "menu_tpl_load":    "Încărcare…",
+        "dlg_tpl_save":     "Salvare şablon",
+        "dlg_tpl_load":     "Încărcare şablon",
+        "log_tpl_saved":    "Şablon salvat: {}",
+        "log_tpl_loaded":   "Şablon încărcat: {}",
+        "log_tpl_error":    "Eroare şablon: {}",
+        "log_tpl_missing":  "Notă: fişier din şablon negăsit: {}",
         "lbl_json":         "Fişier JSON",
         "lbl_workflow":     "Fişier Workflow",
         "lbl_output_dir":   "Folder de ieşire",
@@ -142,6 +171,15 @@ _T: dict[str, dict[str, str]] = {
         "menu_lang_fr":     "Français",
         "menu_help":        "Ajuda",
         "menu_manual":      "Manual",
+        "menu_template":    "Modelos",
+        "menu_tpl_save":    "Guardar…",
+        "menu_tpl_load":    "Carregar…",
+        "dlg_tpl_save":     "Guardar modelo",
+        "dlg_tpl_load":     "Carregar modelo",
+        "log_tpl_saved":    "Modelo guardado: {}",
+        "log_tpl_loaded":   "Modelo carregado: {}",
+        "log_tpl_error":    "Erro no modelo: {}",
+        "log_tpl_missing":  "Nota: ficheiro do modelo não encontrado: {}",
         "lbl_json":         "Ficheiro JSON",
         "lbl_workflow":     "Ficheiro Workflow",
         "lbl_output_dir":   "Pasta de saída",
@@ -171,6 +209,15 @@ _T: dict[str, dict[str, str]] = {
         "menu_lang_fr":     "Français",
         "menu_help":        "Aide",
         "menu_manual":      "Manuel",
+        "menu_template":    "Modèles",
+        "menu_tpl_save":    "Enregistrer…",
+        "menu_tpl_load":    "Charger…",
+        "dlg_tpl_save":     "Enregistrer le modèle",
+        "dlg_tpl_load":     "Charger le modèle",
+        "log_tpl_saved":    "Modèle enregistré : {}",
+        "log_tpl_loaded":   "Modèle chargé : {}",
+        "log_tpl_error":    "Erreur de modèle : {}",
+        "log_tpl_missing":  "Note : fichier du modèle introuvable : {}",
         "lbl_json":         "Fichier JSON",
         "lbl_workflow":     "Fichier Workflow",
         "lbl_output_dir":   "Dossier de sortie",
@@ -224,6 +271,28 @@ def _save_lang_pref(lang: str) -> None:
     prefs["lang"] = lang
     with open(_PREFS_PATH, "w") as f:
         json.dump(prefs, f, indent=2)
+
+
+def _build_template_section(
+    json_file: str, workflow_file: str, output_dir: str, prefix: str
+) -> dict:
+    """Assemble the transform_data section for the shared project template."""
+    return {
+        "json_file": json_file,
+        "workflow_file": workflow_file,
+        "output_dir": output_dir,
+        "prefix": prefix,
+    }
+
+
+def _parse_template_section(data: dict) -> dict:
+    """Normalise a transform_data template section; missing keys → empty string."""
+    return {
+        "json_file": str(data.get("json_file", "")),
+        "workflow_file": str(data.get("workflow_file", "")),
+        "output_dir": str(data.get("output_dir", "")),
+        "prefix": str(data.get("prefix", "")),
+    }
 
 
 class TransformApp(tk.Tk):
@@ -282,6 +351,11 @@ class TransformApp(tk.Tk):
     def _build_menubar(self) -> None:
         """Build (or rebuild) the top menu bar with Help → Manual."""
         menubar = tk.Menu(self)
+
+        tpl_menu = tk.Menu(menubar, tearoff=0)
+        menubar.add_cascade(label=self._tr("menu_template"), menu=tpl_menu)
+        tpl_menu.add_command(label=self._tr("menu_tpl_save"), command=self._save_template)
+        tpl_menu.add_command(label=self._tr("menu_tpl_load"), command=self._load_template)
 
         help_menu = tk.Menu(menubar, tearoff=0)
         menubar.add_cascade(label=self._tr("menu_help"), menu=help_menu)
@@ -458,6 +532,69 @@ class TransformApp(tk.Tk):
         path = filedialog.askdirectory(title=self._tr("dlg_output_dir"))
         if path:
             self._output_dir_var.set(path)
+
+    # -------------------------------------------------------------------------
+    # Project template
+    # -------------------------------------------------------------------------
+
+    def _save_template(self) -> None:
+        """Write the current paths/prefix as this module's project-template section."""
+        path = filedialog.asksaveasfilename(
+            title=self._tr("dlg_tpl_save"),
+            defaultextension=".json",
+            filetypes=[("JSON", "*.json"), ("*", "*.*")],
+        )
+        if not path:
+            return
+        try:
+            section = _build_template_section(
+                json_file=self._json_var.get(),
+                workflow_file=self._workflow_var.get(),
+                output_dir=self._output_dir_var.get(),
+                prefix=self._prefix_var.get(),
+            )
+            project_template.save_template(
+                Path(path),
+                project_template.MODULE_TRANSFORM_DATA,
+                section,
+                language=self._lang_var.get(),
+            )
+            self._log(self._tr("log_tpl_saved").format(Path(path).name))
+        except Exception as exc:
+            self._log(self._tr("log_tpl_error").format(exc))
+
+    def _load_template(self) -> None:
+        """Load this module's section from a project-template file into the UI."""
+        path = filedialog.askopenfilename(
+            title=self._tr("dlg_tpl_load"),
+            filetypes=[("JSON", "*.json"), ("*", "*.*")],
+        )
+        if not path:
+            return
+        try:
+            envelope = project_template.load_template(Path(path))
+            section = _parse_template_section(
+                project_template.get_section(
+                    envelope, project_template.MODULE_TRANSFORM_DATA
+                )
+            )
+        except Exception as exc:
+            self._log(self._tr("log_tpl_error").format(exc))
+            return
+
+        self._json_var.set(section["json_file"])
+        self._workflow_var.set(section["workflow_file"])
+        self._output_dir_var.set(section["output_dir"])
+        self._prefix_var.set(section["prefix"])
+        self._auto_prefix = section["prefix"]
+
+        for key in ("json_file", "workflow_file"):
+            p = section[key]
+            if p and not Path(p).is_file():
+                self._log(self._tr("log_tpl_missing").format(p))
+
+        self._lang_var.set(envelope.get("language", self._lang_var.get()))
+        self._log(self._tr("log_tpl_loaded").format(Path(path).name))
 
     # -------------------------------------------------------------------------
     # Run

--- a/version.py
+++ b/version.py
@@ -3,7 +3,7 @@
 # Repository:     https://github.com/Jaegerfeld/situation-report
 # KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
 # Erstellt:       25.04.2026
-# Geändert:       13.05.2026
+# Geändert:       16.05.2026
 # Lizenz:         BSD-3-Clause (siehe LICENSE)
 #
 # Fachliche Funktion:
@@ -15,4 +15,4 @@
 #     PATCH: Bugfixes
 # =============================================================================
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"


### PR DESCRIPTION
## Summary
- Neues geteiltes Root-Modul `project_template.py` (Schema v5): eine JSON-Datei mit je einem Abschnitt pro Modul (build_reports, transform_data, testdata_generator, helper).
- Jedes Modul-GUI bekommt ein Menü **Templates → Speichern/Laden**. Speichern aus einem Modul erhält die Abschnitte der anderen Module.
- Abwärtskompatibel: ältere `build_reports`-Templates (Schema v4, flach) werden weiterhin gelesen und transparent als build_reports-Abschnitt interpretiert.
- Version 0.10.0 → 0.11.0 (MINOR). CHANGELOG, README, docs/modules/index (DE+EN) aktualisiert.

## Test plan
- [x] `pytest` voll grün (748 passed) inkl. neuer Tests: project_template Round-Trip, Legacy-v4-Lesen, Abschnitt-Erhalt; pro GUI build/parse-Tests
- [ ] Manuell: testdata_generator-GUI → Felder setzen → Template speichern → Felder ändern → laden → Werte zurück
- [ ] Manuell: dieselbe Datei in build_reports laden → build_reports-Abschnitt erhalten
- [ ] Manuell: alte v4-Datei aus `local test data/` in build_reports laden → funktioniert weiter

🤖 Generated with [Claude Code](https://claude.com/claude-code)