### PR TITLE
feat(testdata_generator): Direkt-Report im Browser nach Generierung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Das Format orientiert sich an [Keep a Changelog](https://keepachangelog.com/de/1
 
 ---
 
+## [0.12.0] – 2026-05-17
+
+### Added
+- `testdata_generator`: Button **„Report erstellen"** in der GUI. Nach
+  erfolgreicher Generierung wird der Button aktiv; ein Klick führt
+  `transform_data` und `build_reports` in-process aus und öffnet einen
+  kombinierten Report (eine HTML-Seite, alle Metriken) im Browser. Der Report
+  deckt den **gesamten generierten Zeitraum** ab (kein Datumsfilter).
+- `build_reports.cli.render_combined_html(...)`: liefert alle Metriken als
+  einzelne, in sich geschlossene HTML-Seite (Wiederverwendung von
+  `_build_combined_html`, jetzt in `build_reports/export.py`).
+
+---
+
 ## [0.11.0] – 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # situation-report
 
-**Version 0.11.0** ![Coverage](docs/coverage.svg)
+**Version 0.12.0** ![Coverage](docs/coverage.svg)
 
 Toolsuite for querying Jira issue data and processing it into flow metrics and reports.
 

--- a/build_reports/cli.py
+++ b/build_reports/cli.py
@@ -23,14 +23,19 @@ from pathlib import Path
 
 import plotly.io as pio
 
-from .export import export_pdf, write_report_excel, write_zero_day_excel
+from .export import (
+    _build_combined_html,
+    export_pdf,
+    write_report_excel,
+    write_zero_day_excel,
+)
 from .filters import FilterConfig, apply_filters
 from .loader import load_report_data
 from .metrics import all_metrics, get_metric
 from .metrics.flow_load import FlowLoadMetric
 from .metrics.flow_time import CT_METHOD_A, CT_METHOD_B, FlowTimeMetric
 from .metrics.flow_velocity import FlowVelocityMetric
-from .terminology import GLOBAL, SAFE
+from .terminology import GLOBAL, SAFE, term
 
 
 def _parse_date(value: str) -> date:
@@ -191,6 +196,98 @@ def run_reports(
 
     if not output_pdf and not open_browser:
         log("No output specified — use --pdf or --browser to view results.")
+
+
+def render_combined_html(
+    issue_times: Path,
+    cfd: Path | None = None,
+    workflow: Path | None = None,
+    transitions: Path | None = None,
+    metrics: list[str] | None = None,
+    from_date: date | None = None,
+    to_date: date | None = None,
+    projects: list[str] | None = None,
+    issuetypes: list[str] | None = None,
+    excluded_statuses: list[str] | None = None,
+    excluded_resolutions: list[str] | None = None,
+    exclude_zero_day: bool = False,
+    zero_day_threshold_minutes: int = 5,
+    terminology: str = SAFE,
+    ct_method: str = CT_METHOD_A,
+    target_ct: int = 90,
+    pi_config: Path | None = None,
+    log: Callable[[str], None] = print,
+) -> str:
+    """
+    Run the build_reports pipeline and return all metrics as a single HTML page.
+
+    Same load → filter → compute → render path as run_reports(), but instead
+    of opening one browser tab per figure it returns one self-contained HTML
+    document (via export._build_combined_html), with an <h2> heading per
+    metric group. Pass from_date=None and to_date=None for the full data
+    range (otherwise the caller's date filter applies).
+
+    Args mirror run_reports(); see that function for details.
+
+    Returns:
+        Complete HTML document as a string. Empty string if no figures were
+        produced.
+    """
+    log(f"Loading data from {issue_times.name} ...")
+    data = load_report_data(issue_times, cfd, workflow, transitions)
+    log(f"  {len(data.issues)} issues, {len(data.cfd)} CFD days, "
+        f"{len(data.stages)} stages loaded.")
+
+    cfg = FilterConfig(
+        from_date=from_date,
+        to_date=to_date,
+        projects=projects or [],
+        issuetypes=issuetypes or [],
+        excluded_statuses=excluded_statuses or [],
+        excluded_resolutions=excluded_resolutions or [],
+        exclude_zero_day=exclude_zero_day,
+        zero_day_threshold_minutes=zero_day_threshold_minutes,
+    )
+    data = apply_filters(data, cfg)
+    log(f"  After filters: {len(data.issues)} issues, {len(data.cfd)} CFD days.")
+
+    if metrics:
+        plugins = []
+        for mid in metrics:
+            try:
+                plugins.append(get_metric(mid))
+            except KeyError:
+                log(f"WARNING: Unknown metric '{mid}' — skipped.")
+    else:
+        plugins = all_metrics()
+
+    for plugin in plugins:
+        if isinstance(plugin, FlowTimeMetric):
+            plugin.ct_method = ct_method
+            plugin.target_ct = target_ct
+        if isinstance(plugin, FlowLoadMetric):
+            plugin.target_ct = target_ct
+        if isinstance(plugin, FlowVelocityMetric):
+            plugin.pi_config_path = str(pi_config) if pi_config else ""
+
+    all_figures: list = []
+    section_breaks: dict[int, str] = {}
+    for plugin in plugins:
+        log(f"Computing {plugin.metric_id} ...")
+        result = plugin.run(data, terminology)
+        for w in result.warnings:
+            log(f"  WARNING: {w}")
+        figures = plugin.run_render(result, terminology)
+        if figures:
+            section_breaks[len(all_figures)] = term(plugin.metric_id, terminology)
+        log(f"  → {len(figures)} figure(s)")
+        all_figures.extend(figures)
+
+    if not all_figures:
+        log("No figures produced — nothing to render.")
+        return ""
+
+    return _build_combined_html(all_figures, section_breaks)
 
 
 def main() -> None:

--- a/build_reports/export.py
+++ b/build_reports/export.py
@@ -257,6 +257,57 @@ def write_report_excel(
     _save_wb(wb, path)
 
 
+def _build_combined_html(
+    figures: list,
+    section_breaks: "dict[int, str] | None" = None,
+) -> str:
+    """
+    Combine multiple plotly Figure objects into a single self-contained HTML string.
+
+    The first figure includes the full Plotly.js CDN bundle; subsequent figures
+    reuse the already-loaded library to keep file size reasonable.
+
+    An optional ``section_breaks`` dict maps figure index → heading text. When
+    a heading is present for index ``i``, an ``<h2>`` element is inserted before
+    that figure's div — useful for labelling metric groups in the browser view.
+
+    Args:
+        figures:        List of plotly Figure objects to embed.
+        section_breaks: Optional dict mapping figure index to a heading string.
+
+    Returns:
+        Complete HTML document as a string.
+    """
+    breaks = section_breaks or {}
+    parts = []
+    for i, fig in enumerate(figures):
+        if i in breaks:
+            parts.append(
+                f'<h2 class="metric-heading">{breaks[i]}</h2>'
+            )
+        parts.append(
+            fig.to_html(
+                include_plotlyjs="cdn" if i == 0 else False,
+                full_html=False,
+                config={"responsive": True},
+            )
+        )
+    body = "\n".join(parts)
+    return (
+        "<!DOCTYPE html><html><head>"
+        "<meta charset='utf-8'>"
+        "<style>"
+        "body{margin:16px;font-family:sans-serif;background:#fff;}"
+        "div.plotly-graph-div{margin-bottom:32px;}"
+        "h2.metric-heading{"
+        "font-size:1.5rem;font-weight:700;margin:32px 0 4px 0;"
+        "padding-bottom:4px;border-bottom:2px solid #d0d0d0;}"
+        "</style>"
+        "</head>"
+        f"<body>{body}</body></html>"
+    )
+
+
 def export_png(figure: Any, output_path: Path, width: int = 1400, height: int = 700) -> None:
     """
     Export a single plotly Figure as a PNG image.

--- a/build_reports/gui.py
+++ b/build_reports/gui.py
@@ -41,7 +41,7 @@ from openpyxl import load_workbook
 from tkcalendar import Calendar
 
 from .cli import run_reports
-from .export import write_zero_day_excel
+from .export import _build_combined_html, write_zero_day_excel
 from .metrics import all_metrics
 from .metrics.flow_load import FlowLoadMetric
 from .metrics.flow_time import CT_METHOD_A, CT_METHOD_B, FlowTimeMetric
@@ -813,57 +813,6 @@ def _split_csv(value: str) -> list[str]:
         List of non-empty strings.
     """
     return [item.strip() for item in value.split(",") if item.strip()]
-
-
-def _build_combined_html(
-    figures: list,
-    section_breaks: "dict[int, str] | None" = None,
-) -> str:
-    """
-    Combine multiple plotly Figure objects into a single self-contained HTML string.
-
-    The first figure includes the full Plotly.js CDN bundle; subsequent figures
-    reuse the already-loaded library to keep file size reasonable.
-
-    An optional ``section_breaks`` dict maps figure index → heading text. When
-    a heading is present for index ``i``, an ``<h2>`` element is inserted before
-    that figure's div — useful for labelling metric groups in the browser view.
-
-    Args:
-        figures:        List of plotly Figure objects to embed.
-        section_breaks: Optional dict mapping figure index to a heading string.
-
-    Returns:
-        Complete HTML document as a string.
-    """
-    breaks = section_breaks or {}
-    parts = []
-    for i, fig in enumerate(figures):
-        if i in breaks:
-            parts.append(
-                f'<h2 class="metric-heading">{breaks[i]}</h2>'
-            )
-        parts.append(
-            fig.to_html(
-                include_plotlyjs="cdn" if i == 0 else False,
-                full_html=False,
-                config={"responsive": True},
-            )
-        )
-    body = "\n".join(parts)
-    return (
-        "<!DOCTYPE html><html><head>"
-        "<meta charset='utf-8'>"
-        "<style>"
-        "body{margin:16px;font-family:sans-serif;background:#fff;}"
-        "div.plotly-graph-div{margin-bottom:32px;}"
-        "h2.metric-heading{"
-        "font-size:1.5rem;font-weight:700;margin:32px 0 4px 0;"
-        "padding-bottom:4px;border-bottom:2px solid #d0d0d0;}"
-        "</style>"
-        "</head>"
-        f"<body>{body}</body></html>"
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/docs/modules/testdata_generator.en.md
+++ b/docs/modules/testdata_generator.en.md
@@ -113,6 +113,13 @@ The generated JSON file contains Jira changelog histories with status transition
 along the defined workflow. `transform_data` processes them into
 `IssueTimes.xlsx`, `CFD.xlsx`, and `Transitions.xlsx`.
 
+### Direct report (GUI)
+
+After a successful generation the **"Create Report"** button becomes active in
+the GUI. Clicking it runs `transform_data` and `build_reports` directly and
+opens a combined report (a single HTML page with all metrics) in the browser.
+The report covers the **entire generated date range** — no date filter.
+
 ## Architecture
 
 ```

--- a/docs/modules/testdata_generator.md
+++ b/docs/modules/testdata_generator.md
@@ -113,6 +113,14 @@ Die generierte JSON-Datei enthält Jira-Changelog-Historien mit Status-Übergän
 entlang des definierten Workflows. `transform_data` verarbeitet sie zu
 `IssueTimes.xlsx`, `CFD.xlsx` und `Transitions.xlsx`.
 
+### Direkt-Report (GUI)
+
+Nach erfolgreicher Generierung wird in der GUI der Button **„Report erstellen"**
+aktiv. Ein Klick führt `transform_data` und `build_reports` direkt aus und
+öffnet einen kombinierten Report (eine HTML-Seite mit allen Metriken) im
+Browser. Der Report deckt den **gesamten generierten Zeitraum** ab — ohne
+Datumsfilter.
+
 ## Architektur
 
 ```

--- a/testdata_generator/gui.py
+++ b/testdata_generator/gui.py
@@ -128,6 +128,10 @@ _T: dict[str, dict[str, str]] = {
         "btn_browse_wf":      "Durchsuchen…",
         "btn_browse_out":     "Durchsuchen…",
         "btn_run":            "Generieren",
+        "btn_report":         "Report erstellen",
+        "log_report_started": "--- Report wird erstellt (transform + build_reports) ---",
+        "log_report_done":    "--- Report im Browser geöffnet ---",
+        "log_report_error":   "FEHLER beim Report: {}",
         "err_no_workflow":    "FEHLER: Keine Workflow-Datei ausgewählt.",
         "err_no_output":      "FEHLER: Keine Ausgabedatei angegeben.",
         "err_issues":         "FEHLER: Anzahl Issues muss eine positive Ganzzahl sein.",
@@ -183,6 +187,10 @@ _T: dict[str, dict[str, str]] = {
         "btn_browse_wf":      "Browse…",
         "btn_browse_out":     "Browse…",
         "btn_run":            "Generate",
+        "btn_report":         "Create Report",
+        "log_report_started": "--- Building report (transform + build_reports) ---",
+        "log_report_done":    "--- Report opened in browser ---",
+        "log_report_error":   "ERROR building report: {}",
         "err_no_workflow":    "ERROR: No workflow file selected.",
         "err_no_output":      "ERROR: No output file specified.",
         "err_issues":         "ERROR: Issue count must be a positive integer.",
@@ -214,6 +222,59 @@ _TEMPLATE_FIELDS = (
 )
 
 
+def _build_report_html_file(
+    json_path: Path,
+    workflow_path: Path,
+    log=print,
+) -> str:
+    """
+    Run transform_data + build_reports on a generated JSON file and write the
+    combined report to a temporary HTML file covering the full date range.
+
+    Imports transform_data/build_reports lazily so the testdata_generator GUI
+    starts without pulling those modules until a report is actually requested.
+
+    Args:
+        json_path:     Path to the generated Jira JSON file.
+        workflow_path: Workflow .txt file (same one used for generation).
+        log:           Progress callback.
+
+    Returns:
+        Path to the written temporary .html file, or "" if no figures were
+        produced.
+    """
+    import tempfile
+
+    from build_reports.cli import render_combined_html
+    from transform_data.transform import run_transform
+
+    out_dir = json_path.parent
+    prefix = json_path.stem
+
+    run_transform(
+        json_path, workflow_path,
+        output_dir=out_dir, prefix=prefix, log=log,
+    )
+
+    html = render_combined_html(
+        issue_times=out_dir / f"{prefix}_IssueTimes.xlsx",
+        cfd=out_dir / f"{prefix}_CFD.xlsx",
+        workflow=workflow_path,
+        transitions=out_dir / f"{prefix}_Transitions.xlsx",
+        from_date=None,
+        to_date=None,
+        log=log,
+    )
+    if not html:
+        return ""
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".html", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(html)
+        return f.name
+
+
 def _build_template_section(values: dict[str, str]) -> dict:
     """Assemble the testdata_generator section for the shared project template."""
     return {key: str(values.get(key, "")) for key in _TEMPLATE_FIELDS}
@@ -230,6 +291,7 @@ class _App:
     def __init__(self, root: tk.Tk) -> None:
         self._root = root
         self._running = False
+        self._last_report: dict[str, Path] | None = None
 
         self._var_workflow    = tk.StringVar()
         self._var_output      = tk.StringVar()
@@ -356,9 +418,16 @@ class _App:
             frame, 16, "lbl_pi_weeks", self._var_pi_weeks, 4, 26
         )
 
-        # ── Run + Progress ────────────────────────────────────────────────────
-        self._btn_run = ttk.Button(frame, text="Generate", command=self._run)
-        self._btn_run.grid(row=17, column=0, columnspan=3, pady=(10, 4))
+        # ── Run + Report + Progress ───────────────────────────────────────────
+        btn_frame = ttk.Frame(frame)
+        btn_frame.grid(row=17, column=0, columnspan=3, pady=(10, 4))
+        self._btn_run = ttk.Button(btn_frame, text="Generate", command=self._run)
+        self._btn_run.pack(side="left", padx=(0, 6))
+        self._btn_report = ttk.Button(
+            btn_frame, text="Create Report", command=self._make_report,
+            state="disabled",
+        )
+        self._btn_report.pack(side="left")
 
         self._progress = ttk.Progressbar(frame, mode="indeterminate")
         self._progress.grid(row=18, column=0, columnspan=3, sticky="ew")
@@ -434,6 +503,7 @@ class _App:
         for key, lbl in self._labels.items():
             lbl.configure(text=self._t(key))
         self._btn_run.configure(text=self._t("btn_run"))
+        self._btn_report.configure(text=self._t("btn_report"))
         self._log_frame.configure(text=self._t("lbl_log"))
         lang = self._lang_var.get()
         for rb, (val, lbl_de, lbl_en) in zip(self._pattern_rbs, _PATTERN_LABELS):
@@ -729,6 +799,8 @@ class _App:
 
         self._running = True
         self._btn_run.configure(state="disabled")
+        self._btn_report.configure(state="disabled")
+        self._last_report = None
         self._log_msg(self._t("log_started"))
 
         _progress_timer: list = []
@@ -760,7 +832,14 @@ class _App:
                     pattern_strength=pattern_strength,
                     log=self._log_msg,
                 )
+                self._last_report = {
+                    "json": Path(output_str),
+                    "workflow": Path(workflow_str),
+                }
                 self._root.after(0, lambda: self._log_msg(self._t("log_done")))
+                self._root.after(
+                    0, lambda: self._btn_report.configure(state="normal")
+                )
             except Exception as exc:
                 self._root.after(0, lambda: self._log_msg(self._t("log_error").format(exc)))
             finally:
@@ -775,6 +854,57 @@ class _App:
         self._btn_run.configure(state="normal")
         self._progress.stop()
         self._progress.grid_remove()
+
+    def _reset_after_report(self) -> None:
+        self._running = False
+        self._btn_run.configure(state="normal")
+        self._btn_report.configure(state="normal")
+        self._progress.stop()
+        self._progress.grid_remove()
+
+    def _make_report(self) -> None:
+        """Run transform_data + build_reports on the last generated file and
+        open a single combined HTML report covering the full date range."""
+        if self._running or self._last_report is None:
+            return
+        ctx = self._last_report
+
+        self._running = True
+        self._btn_run.configure(state="disabled")
+        self._btn_report.configure(state="disabled")
+        self._log_msg(self._t("log_report_started"))
+
+        _timer: list = []
+
+        def show_progress() -> None:
+            self._progress.grid()
+            self._progress.start(10)
+
+        _timer.append(self._root.after(3000, show_progress))
+
+        def _do() -> None:
+            try:
+                tmp_path = _build_report_html_file(
+                    ctx["json"], ctx["workflow"], log=self._log_msg
+                )
+                if not tmp_path:
+                    self._root.after(0, lambda: self._log_msg(
+                        self._t("log_report_error").format("no figures")))
+                    return
+
+                webbrowser.open(f"file:///{tmp_path.replace(chr(92), '/')}")
+                self._root.after(
+                    0, lambda: self._log_msg(self._t("log_report_done"))
+                )
+            except Exception as exc:
+                self._root.after(0, lambda: self._log_msg(
+                    self._t("log_report_error").format(exc)))
+            finally:
+                for t in _timer:
+                    self._root.after_cancel(t)
+                self._root.after(0, self._reset_after_report)
+
+        threading.Thread(target=_do, daemon=True).start()
 
 
 def main() -> None:

--- a/tests/build_reports/unit/test_render_combined_html.py
+++ b/tests/build_reports/unit/test_render_combined_html.py
@@ -1,0 +1,54 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       17.05.2026
+# Geändert:       17.05.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für build_reports.cli.render_combined_html: erzeugt aus den
+#   ART_A-Fixtures eine einzelne kombinierte HTML-Seite und liefert bei
+#   fehlenden Figures einen leeren String.
+# =============================================================================
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from build_reports.cli import render_combined_html
+
+_ART_A = Path(__file__).parents[2] / "testdata" / "ART_A"
+
+
+def _silent(_: str) -> None:
+    pass
+
+
+def test_returns_single_combined_html_page():
+    html = render_combined_html(
+        issue_times=_ART_A / "ART_A_IssueTimes.xlsx",
+        cfd=_ART_A / "ART_A_CFD.xlsx",
+        workflow=_ART_A / "workflow_ART_A.txt",
+        transitions=_ART_A / "ART_A_Transitions.xlsx",
+        from_date=None,
+        to_date=None,
+        log=_silent,
+    )
+    assert html.startswith("<!DOCTYPE html>")
+    assert "plotly-graph-div" in html
+    assert 'class="metric-heading"' in html
+    # CDN bundle exactly once (only the first figure embeds plotly.js)
+    assert html.count("cdn.plot.ly") <= 2
+
+
+def test_unknown_metric_only_yields_empty_string():
+    html = render_combined_html(
+        issue_times=_ART_A / "ART_A_IssueTimes.xlsx",
+        cfd=_ART_A / "ART_A_CFD.xlsx",
+        workflow=_ART_A / "workflow_ART_A.txt",
+        transitions=_ART_A / "ART_A_Transitions.xlsx",
+        metrics=["does_not_exist"],
+        log=_silent,
+    )
+    assert html == ""

--- a/tests/testdata_generator/unit/test_report_chain.py
+++ b/tests/testdata_generator/unit/test_report_chain.py
@@ -1,0 +1,61 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       17.05.2026
+# Geändert:       17.05.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für testdata_generator.gui._build_report_html_file: prüft die
+#   Verkettung run_transform → render_combined_html → Temp-HTML. transform_data
+#   und build_reports werden gemockt (kein echtes I/O, kein Browser).
+# =============================================================================
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from testdata_generator.gui import _build_report_html_file
+
+
+def test_chain_writes_html_file_and_passes_full_range(tmp_path: Path):
+    json_path = tmp_path / "ART_X_generated.json"
+    json_path.write_text("{}", encoding="utf-8")
+    workflow = tmp_path / "wf.txt"
+    workflow.write_text("<First>To Do\n<Closed>Done\n", encoding="utf-8")
+
+    with patch("transform_data.transform.run_transform") as m_tr, \
+         patch("build_reports.cli.render_combined_html",
+               return_value="<!DOCTYPE html><html></html>") as m_rc:
+        out = _build_report_html_file(json_path, workflow, log=lambda _: None)
+
+    assert out.endswith(".html")
+    assert Path(out).read_text(encoding="utf-8").startswith("<!DOCTYPE html>")
+
+    # transform called with derived out_dir/prefix
+    _, tr_kwargs = m_tr.call_args
+    assert tr_kwargs["prefix"] == "ART_X_generated"
+    assert tr_kwargs["output_dir"] == tmp_path
+
+    # render called with full range (None/None) and derived xlsx paths
+    _, rc_kwargs = m_rc.call_args
+    assert rc_kwargs["from_date"] is None
+    assert rc_kwargs["to_date"] is None
+    assert rc_kwargs["issue_times"] == tmp_path / "ART_X_generated_IssueTimes.xlsx"
+
+    Path(out).unlink()
+
+
+def test_empty_html_returns_empty_string(tmp_path: Path):
+    json_path = tmp_path / "g.json"
+    json_path.write_text("{}", encoding="utf-8")
+    workflow = tmp_path / "wf.txt"
+    workflow.write_text("<First>A\n<Closed>B\n", encoding="utf-8")
+
+    with patch("transform_data.transform.run_transform"), \
+         patch("build_reports.cli.render_combined_html", return_value=""):
+        out = _build_report_html_file(json_path, workflow, log=lambda _: None)
+
+    assert out == ""

--- a/version.py
+++ b/version.py
@@ -3,7 +3,7 @@
 # Repository:     https://github.com/Jaegerfeld/situation-report
 # KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
 # Erstellt:       25.04.2026
-# Geändert:       16.05.2026
+# Geändert:       17.05.2026
 # Lizenz:         BSD-3-Clause (siehe LICENSE)
 #
 # Fachliche Funktion:
@@ -15,4 +15,4 @@
 #     PATCH: Bugfixes
 # =============================================================================
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"


### PR DESCRIPTION
## Summary
- Neuer Button **„Report erstellen"** in der testdata_generator-GUI: nach erfolgreicher Generierung aktiv; ein Klick führt `transform_data` + `build_reports` in-process aus und öffnet einen kombinierten Report (eine HTML-Seite mit allen Metriken) im Browser — über den **gesamten generierten Zeitraum** (from/to = None).
- Refactor: `_build_combined_html` von `build_reports/gui.py` nach `build_reports/export.py` verschoben (kein tkinter-Zwang). Neue `build_reports.cli.render_combined_html(...)` liefert die kombinierte HTML-Seite; `run_reports` unverändert.
- Report-Kette als testbare modul-level Funktion `_build_report_html_file` (run_transform → render_combined_html → Temp-HTML).
- Version 0.11.0 → 0.12.0. CHANGELOG, README, testdata_generator-Modulseite (DE+EN) aktualisiert.

## Test plan
- [x] `pytest` voll grün (**752 passed**) inkl. neuer Tests: `render_combined_html` (ART_A-Fixtures, leerer String bei 0 Figures), Report-Kette (run_transform/render gemockt, full range geprüft)
- [ ] Manuell: testdata_generator-GUI → Workflow + Output setzen → Generieren → „Report erstellen" wird aktiv → Klick → Browser zeigt EINE kombinierte Seite mit allen Metriken über den vollen Zeitraum

🤖 Generated with [Claude Code](https://claude.com/claude-code)