### PR TITLE
fix(testdata): cap transitions at to_date (triangle date-window bug) — v0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.14.4] – 2026-06-22
+
+### Fixed
+- The testdata generator's `triangle` and `flat_triangle` patterns (and the
+  normal dwell chain for incomplete issues) could produce status transitions
+  far beyond `--to-date`. With a rising cycle time wider than the
+  `from_date … to_date` window, completed issues were dated years into the
+  future (e.g. a 2023–2025 range trailing off, thinned out, until 2031),
+  making the generated data unusable. Transition timestamps are now capped at
+  `to_date`: an issue whose cycle time does not fit the window stays *in
+  progress* at the stage it had reached, matching the manual's definition of
+  `--to-date` as the latest transition date. The cluster/batch patterns were
+  already clamped and are unaffected.
+
+---
+
 ## [0.14.3] – 2026-05-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # situation-report
 
-**Version 0.14.3** ![Coverage](docs/coverage.svg)
+**Version 0.14.4** ![Coverage](docs/coverage.svg)
 
 Toolsuite for querying Jira issue data and processing it into flow metrics and reports.
 

--- a/testdata_generator/generator.py
+++ b/testdata_generator/generator.py
@@ -266,6 +266,16 @@ def _simulate_issue(
             created_ts = _random_datetime(rng, config.from_date, config.to_date)
 
     # ── Simulate transition chain ────────────────────────────────────────────
+    # No transition may fall after to_date: an issue whose cycle time does not
+    # fit inside [from_date, to_date] simply stays "in progress" at whichever
+    # stage it had reached by to_date, rather than completing in the future.
+    # (Triangle/flat-triangle CTs and over-budget dwell chains can otherwise run
+    # years past the window — see _sample_pi_close_dt for the equivalent clamp on
+    # the cluster/batch path.)
+    to_dt = datetime(
+        config.to_date.year, config.to_date.month, config.to_date.day,
+        23, 59, 59, tzinfo=timezone(timedelta(hours=1)),
+    )
     histories: list[dict] = []
     current_idx = 0
     current_ts = created_ts
@@ -277,7 +287,10 @@ def _simulate_issue(
         dwells = _fill_time_budget(rng, n_fwd, target_ct_hours)
         for dwell in dwells:
             nxt = current_idx + 1
-            current_ts += timedelta(hours=max(1.0, dwell))
+            next_ts = current_ts + timedelta(hours=max(1.0, dwell))
+            if next_ts > to_dt:
+                break  # remaining transitions fall past to_date → issue stays open
+            current_ts = next_ts
             histories.append(_make_history(stages[current_idx], stages[nxt], current_ts, hist_id))
             hist_id += 1
             current_idx = nxt
@@ -290,7 +303,10 @@ def _simulate_issue(
             if current_idx > first_idx and rng.random() < config.backflow_prob:
                 back_idx = max(first_idx, current_idx - 1)
                 dwell = rng.randint(config.min_dwell_hours, config.max_dwell_hours)
-                current_ts += timedelta(hours=dwell)
+                next_ts = current_ts + timedelta(hours=dwell)
+                if next_ts > to_dt:
+                    break  # transition would fall past to_date → issue stays open
+                current_ts = next_ts
                 histories.append(
                     _make_history(stages[current_idx], stages[back_idx], current_ts, hist_id)
                 )
@@ -299,7 +315,10 @@ def _simulate_issue(
                 continue
             nxt = current_idx + 1
             dwell = rng.randint(config.min_dwell_hours, config.max_dwell_hours)
-            current_ts += timedelta(hours=dwell)
+            next_ts = current_ts + timedelta(hours=dwell)
+            if next_ts > to_dt:
+                break  # transition would fall past to_date → issue stays open
+            current_ts = next_ts
             histories.append(_make_history(stages[current_idx], stages[nxt], current_ts, hist_id))
             hist_id += 1
             current_idx = nxt

--- a/version.py
+++ b/version.py
@@ -3,7 +3,7 @@
 # Repository:     https://github.com/Jaegerfeld/situation-report
 # KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
 # Erstellt:       25.04.2026
-# Geändert:       23.05.2026
+# Geändert:       22.06.2026
 # Lizenz:         BSD-3-Clause (siehe LICENSE)
 #
 # Fachliche Funktion:
@@ -15,4 +15,4 @@
 #     PATCH: Bugfixes
 # =============================================================================
 
-__version__ = "0.14.3"
+__version__ = "0.14.4"


### PR DESCRIPTION
## Summary
Bugfix release **v0.14.4**.

The testdata generator's `triangle` / `flat_triangle` patterns (and the normal dwell chain for incomplete issues) could emit status transitions far beyond `--to-date`. When the cycle time exceeded the `from_date … to_date` window, completed issues were dated years into the future — e.g. a 2023–2025 range that thinned out and trailed off until 2031, making the data unusable.

Transition timestamps are now capped at `to_date`: an issue whose cycle time does not fit the window stays *in progress* at the stage it reached. This matches the manual's definition of `--to-date` as the latest transition date. Cluster/batch were already clamped via `_sample_pi_close_dt` and are unaffected.

## Changes
- `testdata_generator/generator.py`: cap every transition at end of `to_date` in both the pattern forward-chain and the normal dwell/backflow chain.
- `version.py`: 0.14.3 → 0.14.4
- `CHANGELOG.md`: 0.14.4 entry
- `README.md`: version badge

## Verification
- Regenerated the repro dataset (1200 issues, triangle, 2023–2025): transitions beyond `to_date` went 30 → **0**; last transition 2031-06-28 → **2025-12-31**.
- All 29 `test_generator.py` unit tests pass (incl. `completion_rate=1.0` and the right-censoring `TestCycleTimeDistribution` tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)