### PR TITLE
fix: exclude terminal Done stage from Flow Distribution prominence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Flow Distribution "stage prominence" pie counted the workflow's terminal
+  Done stage. Because a closed/last stage keeps accumulating time as an issue
+  ages, it would eventually dominate without any business meaning — and this
+  affected open issues resting in Done as well, not only closed ones. The
+  terminal Done-group stage(s) are now excluded from prominence for every issue.
+
 ---
 
 ## [0.15.0] – 2026-06-22

--- a/build_reports/metrics/flow_distribution.py
+++ b/build_reports/metrics/flow_distribution.py
@@ -26,9 +26,28 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
 from ..loader import ReportData
+from ..stage_groups import GROUP_DONE, classify_stages
 from ..terminology import FLOW_DISTRIBUTION, term
 from . import register
 from .base import MetricPlugin, MetricResult
+
+
+def _done_stages(data: ReportData) -> set[str]:
+    """
+    Determine the workflow's terminal (Done-group) stages.
+
+    These are excluded from the stage-prominence chart: a closed/last stage
+    naturally accumulates ever more time and would otherwise always dominate,
+    without any business meaning. Uses the <First>/<Closed> markers when
+    available and falls back to the first/last stage otherwise.
+    """
+    stages = data.stages
+    if not stages:
+        return set()
+    first = data.first_stage if data.first_stage in stages else stages[0]
+    closed = data.closed_stage if data.closed_stage in stages else stages[-1]
+    groups = classify_stages(stages, first, closed)
+    return {s for s, g in groups.items() if g == GROUP_DONE}
 
 
 @dataclass
@@ -74,16 +93,20 @@ class FlowDistributionMetric(MetricPlugin):
 
         by_type = dict(Counter(i.issuetype for i in data.issues).most_common())
 
+        # The workflow's terminal (Done-group) stages are excluded from prominence
+        # for ALL issues: a closed/last stage keeps accumulating time as an issue
+        # ages and would otherwise always become the dominant stage without any
+        # business meaning (the last workflow status must not be considered).
+        done_stages = _done_stages(data)
+
         by_prominence: dict[str, int] = {}
         prominence_n = 0
         for issue in data.issues:
             if not (issue.stage_minutes and any(v > 0 for v in issue.stage_minutes.values())):
                 continue
-            # For closed issues exclude the terminal Done stage (current status) so that
-            # time accumulated after closing does not dominate the result.
             candidates = {
                 s: m for s, m in issue.stage_minutes.items()
-                if issue.closed_date is None or s != issue.status
+                if s not in done_stages
             }
             if not candidates or not any(v > 0 for v in candidates.values()):
                 continue

--- a/tests/build_reports/unit/test_flow_distribution.py
+++ b/tests/build_reports/unit/test_flow_distribution.py
@@ -98,7 +98,8 @@ def mixed_data() -> ReportData:
                    stage_minutes={"Analysis": 0, "Implementation": 0, "Completed": 0},
                    first_date=datetime(2025, 5, 1)),
         ],
-        cfd=[], stages=[], source_prefix="TEST",
+        cfd=[], stages=["Analysis", "Implementation", "Completed"],
+        first_stage="Analysis", closed_stage="Completed", source_prefix="TEST",
     )
 
 
@@ -119,22 +120,39 @@ class TestCompute:
         assert counts["Story"] == 1
 
     def test_by_prominence_counts_longest_active_stage(self, metric, mixed_data):
-        """by_prominence counts all issues by their longest active stage."""
+        """by_prominence counts all issues by their longest active (non-Done) stage."""
         result = metric.compute(mixed_data, SAFE)
         prom = result.chart_data.by_prominence
-        # A-1 (closed): Completed excluded → Implementation(200) wins
-        # A-2 (closed): Completed excluded → Analysis(300) wins
-        # A-3 (open):   all included → Analysis(200) wins
-        # A-4 (open):   all included → Implementation(300) wins
+        # The terminal Done stage "Completed" is excluded for every issue:
+        # A-1: Implementation(200) wins · A-2: Analysis(300) wins
+        # A-3: Analysis(200) wins      · A-4: Implementation(300) wins
         assert prom["Analysis"] == 2
         assert prom["Implementation"] == 2
 
-    def test_by_prominence_excludes_terminal_stage_for_closed_issues(self, metric, mixed_data):
-        """For closed issues the terminal Done stage (issue.status) is excluded from prominence."""
+    def test_by_prominence_excludes_terminal_done_stage(self, metric, mixed_data):
+        """The workflow's terminal Done stage is excluded from prominence for ALL issues."""
         result = metric.compute(mixed_data, SAFE)
         prom = result.chart_data.by_prominence
-        # A-1 and A-2 have Completed=5000/2000; without exclusion "Completed" would dominate
+        # "Completed" (the closed stage) has the largest minutes on A-1/A-2 but must
+        # never appear — it only accumulates time as issues age.
         assert "Completed" not in prom
+
+    def test_by_prominence_excludes_done_stage_for_open_issue(self, metric):
+        """Regression: an OPEN issue resting in the Done stage is not counted as Done.
+
+        The reported bug — the last workflow status (Done) dominated prominence
+        because it keeps ageing — affected open issues too, not only closed ones.
+        """
+        data = ReportData(
+            issues=[_issue("O-1", "Feature", "Done",
+                           stage_minutes={"Analysis": 100, "Done": 9000},
+                           first_date=datetime(2025, 1, 1))],  # open: no closed_date
+            cfd=[], stages=["Analysis", "Done"],
+            first_stage="Analysis", closed_stage="Done", source_prefix="TEST",
+        )
+        prom = metric.compute(data, SAFE).chart_data.by_prominence
+        assert "Done" not in prom
+        assert prom == {"Analysis": 1}
 
     def test_by_prominence_includes_closed_issues(self, metric, mixed_data):
         """Closed issues contribute to prominence via their active stages."""


### PR DESCRIPTION
## Bug
The Flow Distribution **stage prominence** pie listed **Done** (the terminal workflow status). That stage keeps accumulating time as an issue ages, so it inevitably becomes the dominant stage without any business meaning. Reported in `feedback/bugs/stage prominence falsch.txt`.

## Root cause
The exclusion only applied to **closed** issues (it dropped `issue.status`). Open issues resting in the Done stage still counted Done, and the rule wasn't tied to the workflow's terminal stage.

## Fix
Resolve the workflow's terminal **Done-group** stage(s) (via the `<First>`/`<Closed>` markers, with a first/last-stage fallback) and exclude them from prominence for **every** issue, not just closed ones.

## Tests
- Updated the prominence fixture to carry a realistic stage list + closed marker.
- Added a regression test: an **open** issue resting in Done is not counted as Done.
- 27 build_reports flow-distribution/cfd tests pass.

Changelog under `[Unreleased]` (no release/tag in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)