### PR TITLE
feat(flow_load): proportional box width by issue count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Flow Load: each stage's box can be drawn with a width proportional to the
+  number of issues in that stage, so the mass of open work is visible at a
+  glance. Optional and on by default — toggle via the GUI checkbox, the
+  `--flat-box-width` CLI flag, or the `proportional_box_width` template field.
+
 ### Fixed
 - Flow Distribution "stage prominence" pie counted the workflow's terminal
   Done stage. Because a closed/last stage keeps accumulating time as an issue

--- a/build_reports/cli.py
+++ b/build_reports/cli.py
@@ -76,6 +76,7 @@ def run_reports(
     terminology: str = SAFE,
     ct_method: str = CT_METHOD_A,
     target_ct: int = 90,
+    proportional_box_width: bool = True,
     pi_config: Path | None = None,
     output_pdf: Path | None = None,
     open_browser: bool = False,
@@ -150,6 +151,7 @@ def run_reports(
             plugin.target_ct = target_ct
         if isinstance(plugin, FlowLoadMetric):
             plugin.target_ct = target_ct
+            plugin.proportional_box_width = proportional_box_width
         if isinstance(plugin, FlowVelocityMetric):
             plugin.pi_config_path = str(pi_config) if pi_config else ""
 
@@ -215,6 +217,7 @@ def render_combined_html(
     terminology: str = SAFE,
     ct_method: str = CT_METHOD_A,
     target_ct: int = 90,
+    proportional_box_width: bool = True,
     pi_config: Path | None = None,
     log: Callable[[str], None] = print,
 ) -> str:
@@ -267,6 +270,7 @@ def render_combined_html(
             plugin.target_ct = target_ct
         if isinstance(plugin, FlowLoadMetric):
             plugin.target_ct = target_ct
+            plugin.proportional_box_width = proportional_box_width
         if isinstance(plugin, FlowVelocityMetric):
             plugin.pi_config_path = str(pi_config) if pi_config else ""
 
@@ -356,6 +360,10 @@ def main() -> None:
                         metavar="FILE", dest="pi_config",
                         help="JSON file defining custom PI intervals for Flow Velocity "
                              "(default: quarterly intervals)")
+    parser.add_argument("--flat-box-width", action="store_false",
+                        dest="proportional_box_width",
+                        help="Draw all Flow Load boxes at equal width (default: width "
+                             "proportional to the number of issues per stage)")
     parser.add_argument("--pdf", type=Path, default=None,
                         metavar="FILE",
                         help="Export all figures to this PDF file")
@@ -381,6 +389,7 @@ def main() -> None:
         terminology=args.terminology,
         ct_method=args.ct_method,
         target_ct=args.target_ct,
+        proportional_box_width=args.proportional_box_width,
         pi_config=args.pi_config,
         output_pdf=args.pdf,
         open_browser=args.browser,

--- a/build_reports/gui.py
+++ b/build_reports/gui.py
@@ -202,6 +202,8 @@ _T: dict[str, dict[str, str]] = {
         "dlg_excl_resolution": "Resolutions zum Ausschließen wählen",
         "tip_excl_status":   "Issues mit diesen Jira-Status vollständig aus allen Metriken ausschließen (z.\u202fB. Canceled).",
         "tip_excl_resolution": "Issues mit diesen Resolutions vollständig ausschließen (z.\u202fB. Won\u2019t Do).",
+        "chk_proportional_box": "Boxbreite ~ Anzahl Elemente (Flow Load)",
+        "tip_proportional_box": "Im Flow-Load-Diagramm wird die Breite jedes Boxplots proportional zur Anzahl der enthaltenen Issues gezeichnet, sodass die Masse der offenen Arbeit auf einen Blick sichtbar ist.",
         "chk_zero_day":      "Zero-Day-Issues ausschließen  (<",
         "lbl_zero_day_min":  "min)",
         "tip_zero_day":      "Issues, deren Cycle Time (First \u2192 Closed Date) kleiner als der Schwellwert ist, werden vollst\u00e4ndig aus allen Metriken entfernt.",
@@ -319,6 +321,8 @@ _T: dict[str, dict[str, str]] = {
         "dlg_excl_resolution": "Select resolutions to exclude",
         "tip_excl_status":   "Completely exclude issues with these Jira statuses from all metrics (e.g. Canceled).",
         "tip_excl_resolution": "Completely exclude issues with these resolutions (e.g. Won\u2019t Do).",
+        "chk_proportional_box": "Box width ~ number of items (Flow Load)",
+        "tip_proportional_box": "In the Flow Load chart each boxplot is drawn with a width proportional to the number of issues it contains, so the mass of open work is visible at a glance.",
         "chk_zero_day":      "Exclude zero-day issues  (<",
         "lbl_zero_day_min":  "min)",
         "tip_zero_day":      "Issues whose cycle time (First \u2192 Closed Date) is below the threshold are completely removed from all metrics.",
@@ -437,6 +441,8 @@ _T: dict[str, dict[str, str]] = {
         "dlg_excl_resolution": "Selectați rezoluțiile de exclus",
         "tip_excl_status":   "Excludeți complet issue-urile cu aceste statusuri Jira din toate metricile (ex. Anulat).",
         "tip_excl_resolution": "Excludeți complet issue-urile cu aceste rezoluții (ex. Won’t Do).",
+        "chk_proportional_box": "Lățimea boxului ~ numărul de elemente (Flow Load)",
+        "tip_proportional_box": "În diagrama Flow Load, fiecare boxplot are lățimea proporțională cu numărul de issue-uri conținute, astfel încât masa muncii deschise este vizibilă dintr-o privire.",
         "chk_zero_day":      "Excludeți issue-urile zero-day  (<",
         "lbl_zero_day_min":  "min)",
         "tip_zero_day":      "Issue-urile al căror timp de ciclu (Prima dată → Data închiderii) este sub prag sunt eliminate complet din toate metricile.",
@@ -552,6 +558,8 @@ _T: dict[str, dict[str, str]] = {
         "dlg_excl_resolution": "Selecionar resoluções a excluir",
         "tip_excl_status":   "Excluir completamente issues com estes status Jira de todas as métricas (ex. Cancelado).",
         "tip_excl_resolution": "Excluir completamente issues com estas resoluções (ex. Won’t Do).",
+        "chk_proportional_box": "Largura da caixa ~ número de itens (Flow Load)",
+        "tip_proportional_box": "No gráfico Flow Load, cada boxplot é desenhado com largura proporcional ao número de itens que contém, para a massa de trabalho aberto ser visível de relance.",
         "chk_zero_day":      "Excluir issues zero-day  (<",
         "lbl_zero_day_min":  "min)",
         "tip_zero_day":      "Issues cujo tempo de ciclo (Primeira data → Data de fecho) está abaixo do limite são completamente removidos de todas as métricas.",
@@ -667,6 +675,8 @@ _T: dict[str, dict[str, str]] = {
         "dlg_excl_resolution": "Sélectionner les résolutions à exclure",
         "tip_excl_status":   "Exclure complètement les issues avec ces statuts Jira de toutes les métriques (ex. Annulé).",
         "tip_excl_resolution": "Exclure complètement les issues avec ces résolutions (ex. Won’t Do).",
+        "chk_proportional_box": "Largeur des boîtes ~ nombre d'éléments (Flow Load)",
+        "tip_proportional_box": "Dans le diagramme Flow Load, chaque boxplot est dessiné avec une largeur proportionnelle au nombre d'éléments qu'il contient, pour voir d'un coup d'œil où se trouve la masse du travail en cours.",
         "chk_zero_day":      "Exclure les issues zero-day  (<",
         "lbl_zero_day_min":  "min)",
         "tip_zero_day":      "Les issues dont le temps de cycle (Première date → Date de clôture) est inférieur au seuil sont complètement retirés de toutes les métriques.",
@@ -894,6 +904,7 @@ def _build_template_dict(
     exclude_zero_day: bool = False,
     zero_day_threshold_minutes: int = 5,
     target_ct: int = 90,
+    proportional_box_width: bool = True,
 ) -> dict:
     """
     Assemble the template dictionary that is written to JSON.
@@ -940,6 +951,7 @@ def _build_template_dict(
         "exclude_zero_day": exclude_zero_day,
         "zero_day_threshold_minutes": zero_day_threshold_minutes,
         "target_ct": target_ct,
+        "proportional_box_width": proportional_box_width,
         "terminology": terminology,
         "ct_method": ct_method,
         "metrics": metrics,
@@ -987,6 +999,7 @@ def _parse_template_dict(data: dict) -> dict:
         "exclude_zero_day": bool(data.get("exclude_zero_day", False)),
         "zero_day_threshold_minutes": int(data.get("zero_day_threshold_minutes", 5)),
         "target_ct": int(data.get("target_ct", 90)),
+        "proportional_box_width": bool(data.get("proportional_box_width", True)),
         "terminology": str(data.get("terminology", SAFE)),
         "ct_method": str(data.get("ct_method", CT_METHOD_A)),
         "metrics": dict(data.get("metrics", {})),
@@ -1034,6 +1047,7 @@ class BuildReportsApp(tk.Tk):
         self._excl_zero_day_var = tk.BooleanVar(value=False)
         self._zero_day_minutes_var = tk.StringVar(value="5")
         self._target_ct_var = tk.StringVar(value="90")
+        self._proportional_box_var = tk.BooleanVar(value=True)
         self._available_projects: list[str] = []
         self._available_issuetypes: list[str] = []
         self._available_statuses: list[str] = []
@@ -1511,6 +1525,18 @@ class BuildReportsApp(tk.Tk):
         tk.Label(f, text="d", anchor="w").grid(row=row, column=2, sticky="w", **pad)
         row += 1
 
+        chk_prop = tk.Checkbutton(
+            f,
+            text=self._tr("chk_proportional_box"),
+            variable=self._proportional_box_var,
+            anchor="w",
+        )
+        chk_prop.grid(row=row, column=0, columnspan=3, sticky="w", **pad)
+        self._i18n.append((chk_prop, "chk_proportional_box"))
+        self._tips.append(
+            (_ToolTip(chk_prop, self._tr("tip_proportional_box")), "tip_proportional_box"))
+        row += 1
+
         # --- Action buttons ---
         ttk.Separator(f, orient="horizontal").grid(
             row=row, column=0, columnspan=3, sticky="ew", pady=6
@@ -1640,6 +1666,7 @@ class BuildReportsApp(tk.Tk):
                 exclude_zero_day=self._excl_zero_day_var.get(),
                 zero_day_threshold_minutes=int(self._zero_day_minutes_var.get() or 5),
                 target_ct=int(self._target_ct_var.get() or 90),
+                proportional_box_width=self._proportional_box_var.get(),
                 terminology=self._terminology_var.get(),
                 ct_method=self._ct_method_var.get(),
                 metrics={mid: var.get() for mid, var in self._metric_vars.items()},
@@ -1707,6 +1734,7 @@ class BuildReportsApp(tk.Tk):
         self._excl_zero_day_var.set(state["exclude_zero_day"])
         self._zero_day_minutes_var.set(str(state["zero_day_threshold_minutes"]))
         self._target_ct_var.set(str(state["target_ct"]))
+        self._proportional_box_var.set(state["proportional_box_width"])
         self._terminology_var.set(state["terminology"])
         self._ct_method_var.set(state["ct_method"])
 
@@ -2066,6 +2094,7 @@ class BuildReportsApp(tk.Tk):
             target_ct = int(self._target_ct_var.get() or 90)
         except ValueError:
             target_ct = 90
+        proportional_box_width = self._proportional_box_var.get()
 
         selected = [mid for mid, var in self._metric_vars.items() if var.get()]
         metrics = selected if selected else None
@@ -2087,6 +2116,7 @@ class BuildReportsApp(tk.Tk):
             terminology=terminology,
             ct_method=ct_method,
             target_ct=target_ct,
+            proportional_box_width=proportional_box_width,
             metrics=metrics,
         )
 
@@ -2150,6 +2180,8 @@ class BuildReportsApp(tk.Tk):
                         plugin.target_ct = inputs.get("target_ct", 90)
                     if isinstance(plugin, FlowLoadMetric):
                         plugin.target_ct = inputs.get("target_ct", 90)
+                        plugin.proportional_box_width = inputs.get(
+                            "proportional_box_width", True)
                     if isinstance(plugin, FlowVelocityMetric):
                         pi_cfg = inputs.get("pi_config")
                         plugin.pi_config_path = str(pi_cfg) if pi_cfg else ""
@@ -2241,6 +2273,7 @@ class BuildReportsApp(tk.Tk):
                     terminology=inputs["terminology"],
                     ct_method=inputs["ct_method"],
                     target_ct=inputs.get("target_ct", 90),
+                    proportional_box_width=inputs.get("proportional_box_width", True),
                     pi_config=inputs.get("pi_config"),
                     output_pdf=Path(out_path),
                     log=self._log,

--- a/build_reports/metrics/flow_load.py
+++ b/build_reports/metrics/flow_load.py
@@ -99,6 +99,9 @@ class FlowLoadMetric(MetricPlugin):
 
     metric_id = FLOW_LOAD
     target_ct: int = 90
+    #: When True, each stage's box is drawn with a width proportional to the
+    #: number of issues in that stage, so the mass of WIP is visible at a glance.
+    proportional_box_width: bool = True
 
     def compute(self, data: ReportData, terminology: str) -> MetricResult:
         """
@@ -222,16 +225,24 @@ class FlowLoadMetric(MetricPlugin):
 
         fig = go.Figure()
 
+        # Optionally scale each box's width by how many issues it contains, so the
+        # stage holding the mass of WIP is obvious at a glance. A visible minimum
+        # keeps low-count stages readable.
+        max_count = max((len(ld.by_stage[s]) for s in ld.stages_ordered), default=0)
+
         for stage in ld.stages_ordered:
             ages = ld.by_stage[stage]
-            fig.add_trace(go.Box(
+            box_kwargs = dict(
                 y=ages, name=stage,
                 boxpoints="all", jitter=0.3, pointpos=0,
                 marker=dict(color="red", size=4, opacity=0.6),
                 line=dict(color="black"),
                 fillcolor="white",
                 showlegend=False,
-            ))
+            )
+            if self.proportional_box_width and max_count > 0:
+                box_kwargs["width"] = 0.25 + 0.65 * (len(ages) / max_count)
+            fig.add_trace(go.Box(**box_kwargs))
 
         # Legend entries for reference lines (dummy traces)
         # Target CT is always shown; CT Median and P85 only when closed issues exist

--- a/tests/build_reports/unit/test_flow_load.py
+++ b/tests/build_reports/unit/test_flow_load.py
@@ -210,6 +210,32 @@ class TestRender:
         result = metric.compute(mixed_data, SAFE)
         assert result.chart_data.target_ct_days == 30
 
+    def _counts_data(self) -> ReportData:
+        """Three open issues in Analysis, one in Implementation (different stage counts)."""
+        return ReportData(
+            issues=[
+                _issue("A1", stage_minutes={"Analysis": 100}),
+                _issue("A2", stage_minutes={"Analysis": 100}),
+                _issue("A3", stage_minutes={"Analysis": 100}),
+                _issue("I1", stage_minutes={"Implementation": 100}),
+            ],
+            cfd=[], stages=STAGES, source_prefix="",
+        )
+
+    def test_box_width_proportional_to_count(self, metric):
+        """With the option on, the stage holding more issues gets a wider box."""
+        metric.proportional_box_width = True
+        fig = metric.render(metric.compute(self._counts_data(), SAFE), SAFE)[0]
+        widths = {t.name: t.width for t in fig.data if t.type == "box"}
+        # Analysis has 3 issues, Implementation has 1 → Analysis box is wider
+        assert widths["Analysis"] > widths["Implementation"]
+
+    def test_box_width_flat_when_disabled(self, metric):
+        """With the option off, no per-box width is set (plotly default applies)."""
+        metric.proportional_box_width = False
+        fig = metric.render(metric.compute(self._counts_data(), SAFE), SAFE)[0]
+        assert all(t.width is None for t in fig.data if t.type == "box")
+
 
 class TestStatusGroupFiltering:
     """Tests for status-group-aware issue and stage filtering in FlowLoadMetric."""

--- a/tests/build_reports/unit/test_gui.py
+++ b/tests/build_reports/unit/test_gui.py
@@ -593,3 +593,13 @@ class TestParseTemplateDict:
         parsed = _parse_template_dict(tpl)
         assert parsed["exclude_zero_day"] is True
         assert parsed["zero_day_threshold_minutes"] == 15
+
+    def test_proportional_box_width_roundtrip(self):
+        """The Flow Load proportional-box-width flag survives a build → parse roundtrip."""
+        tpl = _build_template_dict(**_sample_template(proportional_box_width=False))
+        assert tpl["proportional_box_width"] is False
+        assert _parse_template_dict(tpl)["proportional_box_width"] is False
+
+    def test_proportional_box_width_defaults_true(self):
+        """An older template without the key defaults the flag to True (option on)."""
+        assert _parse_template_dict({"version": 1})["proportional_box_width"] is True


### PR DESCRIPTION
Implements `feedback/Ideen/Idee Boxplotbreite relativ zur anzahl elemente.txt`.

## What
In the **Flow Load** (Aging WIP) chart, each stage's box is drawn with a **width proportional to the number of issues** in that stage, so the mass of open work is visible at a glance. A visible minimum keeps low-count stages readable.

**Optional, on by default**:
- GUI: a "Box width ~ number of items (Flow Load)" checkbox (5 languages) + template persistence (`proportional_box_width`).
- CLI: `--flat-box-width` disables it.
- Metric: `FlowLoadMetric.proportional_box_width` (default True).

## Tests
- Render: wider box for the higher-count stage; no per-box width when disabled.
- Template build/parse roundtrip; older templates default the flag to True.
- 425 build_reports/portfolio unit tests pass (errors are the known tmp_path env issue).

Changelog under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)