### PR TITLE
chore: ruff/mypy quality gate, packaging guard test, lint cleanup

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,40 @@
+name: Quality
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**.py"
+      - "pyproject.toml"
+      - ".github/workflows/quality.yml"
+  pull_request:
+    paths:
+      - "**.py"
+      - "pyproject.toml"
+      - ".github/workflows/quality.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # ruff/mypy are pinned in pyproject [project.optional-dependencies].dev,
+      # so CI runs the exact versions used locally and in the pre-commit hook.
+      - name: Install dependencies
+        run: pip install -e ".[dev]" --quiet
+
+      - name: Ruff (lint + import order)
+        run: python -m ruff check .
+
+      - name: mypy (typed analytics core)
+        run: python -m mypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Code-quality gate: Ruff (lint, import order, bugbear, pyupgrade, complexity)
+  and mypy (typed analytics core) now run in CI via a new `Quality` workflow,
+  on every pull request and on pushes to `main`. The same checks run in the
+  git pre-commit hook (`python scripts/setup_hooks.py` to install). Ruff and
+  mypy versions are pinned in `pyproject.toml` so local, hook, and CI agree.
+- Packaging-consistency test: every module the launcher marks as available is
+  asserted to appear in the release and dev-build bundle copy lists, so a
+  launchable module can no longer be left out of the build.
+
+### Fixed
+- Helper and Testdata Generator: an error raised during a background task could
+  itself crash with a `NameError` instead of being logged, because the deferred
+  log callback referenced the exception variable after Python had cleared it.
+  The message is now formatted before the callback is scheduled, so the real
+  error is shown.
+
 ---
 
 ## [0.16.0] – 2026-06-23

--- a/build_reports/cli.py
+++ b/build_reports/cli.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from collections.abc import Callable
 from datetime import date
 from pathlib import Path
@@ -54,13 +53,13 @@ def _parse_date(value: str) -> date:
     """
     try:
         return date.fromisoformat(value)
-    except ValueError:
+    except ValueError as err:
         raise argparse.ArgumentTypeError(
             f"Invalid date '{value}' — expected YYYY-MM-DD format."
-        )
+        ) from err
 
 
-def run_reports(
+def run_reports(  # noqa: C901
     issue_times: Path,
     cfd: Path | None = None,
     workflow: Path | None = None,

--- a/build_reports/export.py
+++ b/build_reports/export.py
@@ -20,7 +20,6 @@ import io
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import plotly.graph_objects as go
 import plotly.io as pio
 
 if TYPE_CHECKING:
@@ -67,7 +66,7 @@ def export_pdf(figures: list[Any], output_path: Path, width: int = 1400, height:
 
     # Try to merge multiple figures into one PDF using pypdf
     try:
-        from pypdf import PdfWriter  # optional dependency
+        from pypdf import PdfWriter  # noqa: F401  # availability probe for optional dep
         _export_merged_pdf(figures, output_path, width, height)
     except ImportError:
         # Fallback: export one PDF per figure with numeric suffix
@@ -94,6 +93,7 @@ def _export_merged_pdf(
         height:      Page height in pixels.
     """
     import tempfile
+
     from pypdf import PdfWriter
 
     writer = PdfWriter()
@@ -111,7 +111,7 @@ def _export_merged_pdf(
             writer.write(f)
 
 
-def write_zero_day_excel(records: "list[IssueRecord]", path: Path) -> None:
+def write_zero_day_excel(records: list[IssueRecord], path: Path) -> None:
     """
     Write a list of zero-day IssueRecords to an Excel file.
 
@@ -174,7 +174,7 @@ def write_zero_day_excel(records: "list[IssueRecord]", path: Path) -> None:
 
 
 def write_report_excel(
-    records: "list[IssueRecord]",
+    records: list[IssueRecord],
     stages: list[str],
     path: Path,
 ) -> None:
@@ -259,7 +259,7 @@ def write_report_excel(
 
 def _build_combined_html(
     figures: list,
-    section_breaks: "dict[int, str] | None" = None,
+    section_breaks: dict[int, str] | None = None,
 ) -> str:
     """
     Combine multiple plotly Figure objects into a single self-contained HTML string.

--- a/build_reports/filters.py
+++ b/build_reports/filters.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import date
 
 from .loader import CfdRecord, IssueRecord, ReportData
 

--- a/build_reports/gui.py
+++ b/build_reports/gui.py
@@ -35,13 +35,13 @@ try:
 except ImportError:
     _VERSION = "?"
 
-import project_template
-
 from openpyxl import load_workbook
 from tkcalendar import Calendar
 
+import project_template
+
 from .cli import run_reports
-from .export import _build_combined_html, write_zero_day_excel
+from .export import _build_combined_html
 from .metrics import all_metrics
 from .metrics.flow_load import FlowLoadMetric
 from .metrics.flow_time import CT_METHOD_A, CT_METHOD_B, FlowTimeMetric
@@ -852,10 +852,10 @@ class _ToolTip:
         text:   Initial tooltip text.
     """
 
-    def __init__(self, widget: "tk.Widget", text: str) -> None:
+    def __init__(self, widget: tk.Widget, text: str) -> None:
         self._widget = widget
         self._text = text
-        self._tip_window: "tk.Toplevel | None" = None
+        self._tip_window: tk.Toplevel | None = None
         widget.bind("<Enter>", self._show, add="+")
         widget.bind("<Leave>", self._hide, add="+")
 
@@ -2163,7 +2163,7 @@ class BuildReportsApp(tk.Tk):
         self._log(self._tr("log_started"))
         self._show_in_browser_from_inputs(inputs)
 
-    def _show_in_browser_from_inputs(self, inputs: dict) -> None:
+    def _show_in_browser_from_inputs(self, inputs: dict) -> None:  # noqa: C901
         """
         Compute metrics in a background thread and open results in the browser.
 
@@ -2172,7 +2172,7 @@ class BuildReportsApp(tk.Tk):
         """
         self._set_buttons_enabled(False)
 
-        def worker() -> None:
+        def worker() -> None:  # noqa: C901
             from .filters import FilterConfig, apply_filters
             from .loader import load_report_data
             from .metrics import all_metrics as _all_metrics

--- a/build_reports/loader.py
+++ b/build_reports/loader.py
@@ -165,7 +165,7 @@ def load_issue_times(path: Path) -> tuple[list[IssueRecord], list[str]]:
         if not any(row):
             continue
 
-        def cell(name: str) -> object:
+        def cell(name: str, row: list = row) -> object:
             return row[col[name]] if name in col else None
 
         stage_minutes = {

--- a/build_reports/metrics/__init__.py
+++ b/build_reports/metrics/__init__.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from .base import MetricPlugin, MetricResult
+from .base import MetricPlugin
 
 _REGISTRY: dict[str, MetricPlugin] = {}
 
@@ -69,9 +69,11 @@ def all_metrics() -> list[MetricPlugin]:
 
 # Import metric modules to trigger auto-registration.
 # Add new metric modules here when they are created.
-from . import flow_time          # noqa: E402, F401
-from . import flow_velocity      # noqa: E402, F401
-from . import flow_load          # noqa: E402, F401
-from . import cfd                # noqa: E402, F401
-from . import flow_distribution  # noqa: E402, F401
-from . import process_flow       # noqa: E402, F401
+from . import (
+    cfd,  # noqa: E402, F401
+    flow_distribution,  # noqa: E402, F401
+    flow_load,  # noqa: E402, F401
+    flow_time,  # noqa: E402, F401
+    flow_velocity,  # noqa: E402, F401
+    process_flow,  # noqa: E402, F401
+)

--- a/build_reports/metrics/base.py
+++ b/build_reports/metrics/base.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..loader import ReportData
 
 
 @dataclass
@@ -58,7 +61,7 @@ class MetricPlugin(ABC):
     metric_id: str = ""
 
     @abstractmethod
-    def compute(self, data: "ReportData", terminology: str) -> MetricResult:  # noqa: F821
+    def compute(self, data: ReportData, terminology: str) -> MetricResult:
         """
         Compute statistics for this metric from the provided report data.
 
@@ -92,7 +95,7 @@ class MetricPlugin(ABC):
     # compute() / render() without source_prefix injection.
     # ------------------------------------------------------------------
 
-    def run(self, data: "ReportData", terminology: str) -> MetricResult:  # noqa: F821
+    def run(self, data: ReportData, terminology: str) -> MetricResult:
         """
         Compute the metric and inject the source_prefix from data.
 

--- a/build_reports/metrics/cfd.py
+++ b/build_reports/metrics/cfd.py
@@ -23,7 +23,6 @@ from datetime import date, timedelta
 import plotly.graph_objects as go
 
 from ..loader import ReportData
-from ..terminology import FLOW_DISTRIBUTION, term
 from . import register
 from .base import MetricPlugin, MetricResult
 

--- a/build_reports/metrics/flow_load.py
+++ b/build_reports/metrics/flow_load.py
@@ -21,7 +21,7 @@
 from __future__ import annotations
 
 import statistics
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import date
 
 import plotly.graph_objects as go
@@ -30,9 +30,10 @@ from ..loader import IssueRecord, ReportData
 from ..repel import add_repelled_hlines
 from ..stage_groups import (
     GROUP_IN_PROGRESS,
-    classify_stages, issue_stage_group,
+    classify_stages,
+    issue_stage_group,
 )
-from ..terminology import FLOW_LOAD, term
+from ..terminology import FLOW_LOAD
 from . import register
 from .base import MetricPlugin, MetricResult
 
@@ -160,10 +161,15 @@ class FlowLoadMetric(MetricPlugin):
         ct_median = ct_p85 = None
         done_count = 0
         if closed_issues:
-            ct_days = sorted([
-                (i.closed_date - i.first_date).total_seconds() / 86400
+            ct_pairs = [
+                (i.closed_date, i.first_date)
                 for i in closed_issues
-                if (i.closed_date - i.first_date).total_seconds() > 0
+                if i.closed_date is not None and i.first_date is not None
+            ]
+            ct_days = sorted([
+                (closed - first).total_seconds() / 86400
+                for closed, first in ct_pairs
+                if (closed - first).total_seconds() > 0
             ])
             if ct_days:
                 n = len(ct_days)
@@ -214,8 +220,6 @@ class FlowLoadMetric(MetricPlugin):
             return []
 
         ld: _LoadData = result.chart_data
-        s = result.stats
-        label = term(FLOW_LOAD, terminology)
 
         header = (
             f"Flow Load: Aging Work in Progress  |  "
@@ -270,7 +274,7 @@ class FlowLoadMetric(MetricPlugin):
         # Reference lines — repelled so annotations don't overlap when values are close
         all_ages = [a for ages in ld.by_stage.values() for a in ages]
         y_max = max(all_ages) if all_ages else 1.0
-        hlines = []
+        hlines: list[tuple[float | None, str, str, str]] = []
         if ld.ct_median is not None:
             hlines.append((ld.ct_median, "blue", "dot", f"{ld.ct_median}d"))
         if ld.ct_pct85 is not None:

--- a/build_reports/metrics/flow_velocity.py
+++ b/build_reports/metrics/flow_velocity.py
@@ -27,7 +27,10 @@ import plotly.graph_objects as go
 
 from ..loader import ReportData
 from ..pi_config import (
-    PIInterval, assign_pi, default_quarter_intervals, load_pi_config,
+    PIInterval,
+    assign_pi,
+    default_quarter_intervals,
+    load_pi_config,
 )
 from ..terminology import FLOW_VELOCITY, term
 from . import register
@@ -142,7 +145,6 @@ class FlowVelocityMetric(MetricPlugin):
 
         from_date = closed[0]
         to_date = closed[-1]
-        days_total = (to_date - from_date).days + 1
 
         stats = dict(
             count=len(closed),

--- a/build_reports/metrics/process_flow.py
+++ b/build_reports/metrics/process_flow.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import math
 import statistics
 from collections import Counter, defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 
 import plotly.graph_objects as go

--- a/build_reports/stage_groups.py
+++ b/build_reports/stage_groups.py
@@ -75,7 +75,7 @@ def classify_stages(
     return result
 
 
-def issue_stage_group(issue: "IssueRecord") -> str:
+def issue_stage_group(issue: IssueRecord) -> str:
     """
     Determine the status group of an issue from its workflow transition dates.
 

--- a/docs/_font_config.py
+++ b/docs/_font_config.py
@@ -13,8 +13,9 @@
 #   Suchpfade: docs/assets/fonts/ → Windows-Fonts → Linux-Fonts → ReportLab-Vera
 # =============================================================================
 
-from pathlib import Path
 import sys
+from pathlib import Path
+
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
 
@@ -63,6 +64,7 @@ def setup() -> tuple[str, str, str, str]:
     missing = [k for k, v in paths.items() if not v]
     warnings.warn(
         f"Unicode-Font nicht gefunden ({missing}), Fallback auf Helvetica "
-        f"(rumänische Sonderzeichen werden nicht korrekt dargestellt)"
+        f"(rumänische Sonderzeichen werden nicht korrekt dargestellt)",
+        stacklevel=2,
     )
     return "Helvetica", "Helvetica-Bold", "Helvetica-Oblique", "Helvetica-BoldOblique"

--- a/docs/generate_feature_overview_pptx.py
+++ b/docs/generate_feature_overview_pptx.py
@@ -1,9 +1,10 @@
 """Generate a PowerPoint feature overview for situation-report."""
 from pathlib import Path
+
 from pptx import Presentation
-from pptx.util import Inches, Pt, Emu
 from pptx.dml.color import RGBColor
 from pptx.enum.text import PP_ALIGN
+from pptx.util import Inches, Pt
 
 # ---------------------------------------------------------------------------
 # Design tokens
@@ -284,7 +285,6 @@ def add_text_box(slide, text, left, top, width, height,
 
 def build_title_slide(prs, data):
     slide = prs.slides.add_slide(prs.slide_layouts[6])  # blank
-    slide.shapes.title  # may be None on blank layout — ignore
 
     # Full-bleed dark background
     add_rect(slide, 0, 0, 13.33, 7.5, C_DARK)

--- a/docs/generate_get_data_manual.py
+++ b/docs/generate_get_data_manual.py
@@ -19,18 +19,28 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from _font_config import setup as _setup_fonts
-_FN, _FB, _FI, _FBI = _setup_fonts()  # normal, bold, italic, bold_italic
-from version import __version__ as _VERSION
 
+_FN, _FB, _FI, _FBI = _setup_fonts()  # normal, bold, italic, bold_italic
 from reportlab.lib import colors
 from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.units import cm
 from reportlab.platypus import (
-    BaseDocTemplate, Frame, HRFlowable, NextPageTemplate, PageBreak,
-    PageTemplate, Paragraph, Preformatted, Spacer, Table, TableStyle,
+    BaseDocTemplate,
+    Frame,
+    HRFlowable,
+    NextPageTemplate,
+    PageBreak,
+    PageTemplate,
+    Paragraph,
+    Preformatted,
+    Spacer,
+    Table,
+    TableStyle,
 )
+
+from version import __version__ as _VERSION
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/docs/generate_helper_manual.py
+++ b/docs/generate_helper_manual.py
@@ -19,18 +19,27 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from _font_config import setup as _setup_fonts
-_FN, _FB, _FI, _FBI = _setup_fonts()  # normal, bold, italic, bold_italic
-from version import __version__ as _VERSION
 
+_FN, _FB, _FI, _FBI = _setup_fonts()  # normal, bold, italic, bold_italic
 from reportlab.lib import colors
 from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.units import cm
 from reportlab.platypus import (
-    ActionFlowable, BaseDocTemplate, Frame, HRFlowable, PageBreak,
-    PageTemplate, Paragraph, Spacer, Table, TableStyle,
+    ActionFlowable,
+    BaseDocTemplate,
+    Frame,
+    HRFlowable,
+    PageBreak,
+    PageTemplate,
+    Paragraph,
+    Spacer,
+    Table,
+    TableStyle,
 )
+
+from version import __version__ as _VERSION
 
 OUTPUT_DE = Path(__file__).parent / "helper_Benutzerhandbuch.pdf"
 OUTPUT_EN = Path(__file__).parent / "helper_UserManual.pdf"

--- a/docs/generate_launcher_manual.py
+++ b/docs/generate_launcher_manual.py
@@ -19,18 +19,26 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from _font_config import setup as _setup_fonts
-_FN, _FB, _FI, _FBI = _setup_fonts()  # normal, bold, italic, bold_italic
-from version import __version__ as _VERSION
 
+_FN, _FB, _FI, _FBI = _setup_fonts()  # normal, bold, italic, bold_italic
 from reportlab.lib import colors
 from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.units import cm
 from reportlab.platypus import (
-    BaseDocTemplate, Frame, HRFlowable, PageBreak, PageTemplate,
-    Paragraph, Spacer, Table, TableStyle,
+    BaseDocTemplate,
+    Frame,
+    HRFlowable,
+    PageBreak,
+    PageTemplate,
+    Paragraph,
+    Spacer,
+    Table,
+    TableStyle,
 )
+
+from version import __version__ as _VERSION
 
 OUTPUT_DE = Path(__file__).parent / "launcher_Benutzerhandbuch.pdf"
 OUTPUT_EN = Path(__file__).parent / "launcher_UserManual.pdf"

--- a/docs/generate_manual.py
+++ b/docs/generate_manual.py
@@ -22,9 +22,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from _font_config import setup as _setup_fonts
-_FN, _FB, _FI, _FBI = _setup_fonts()  # normal, bold, italic, bold_italic
-from version import __version__ as _VERSION
 
+_FN, _FB, _FI, _FBI = _setup_fonts()  # normal, bold, italic, bold_italic
 import plotly.io as pio
 from reportlab.lib import colors
 from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY
@@ -32,10 +31,22 @@ from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.units import cm
 from reportlab.platypus import (
-    BaseDocTemplate, Frame, HRFlowable, Image as RLImage, NextPageTemplate,
-    PageBreak, PageTemplate, Paragraph, Spacer, Table, TableStyle,
+    BaseDocTemplate,
+    Frame,
+    NextPageTemplate,
+    PageBreak,
+    PageTemplate,
+    Paragraph,
+    Spacer,
+    Table,
+    TableStyle,
+)
+from reportlab.platypus import (
+    Image as RLImage,
 )
 from reportlab.platypus.tableofcontents import TableOfContents
+
+from version import __version__ as _VERSION
 
 # ---------------------------------------------------------------------------
 # Test data paths (for chart generation)

--- a/docs/generate_portfolio_manual.py
+++ b/docs/generate_portfolio_manual.py
@@ -20,18 +20,27 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from _font_config import setup as _setup_fonts
-_FN, _FB, _FI, _FBI = _setup_fonts()  # normal, bold, italic, bold_italic
-from version import __version__ as _VERSION
 
+_FN, _FB, _FI, _FBI = _setup_fonts()  # normal, bold, italic, bold_italic
 from reportlab.lib import colors
 from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.units import cm
 from reportlab.platypus import (
-    ActionFlowable, BaseDocTemplate, Frame, HRFlowable, PageBreak,
-    PageTemplate, Paragraph, Spacer, Table, TableStyle,
+    ActionFlowable,
+    BaseDocTemplate,
+    Frame,
+    HRFlowable,
+    PageBreak,
+    PageTemplate,
+    Paragraph,
+    Spacer,
+    Table,
+    TableStyle,
 )
+
+from version import __version__ as _VERSION
 
 OUTPUT_DE = Path(__file__).parent / "portfolio_Benutzerhandbuch.pdf"
 OUTPUT_EN = Path(__file__).parent / "portfolio_UserManual.pdf"

--- a/docs/generate_process_pptx.py
+++ b/docs/generate_process_pptx.py
@@ -1,15 +1,15 @@
-# -*- coding: utf-8 -*-
 """
 Generate a business-process capability map for situation-report.
 Target audience: non-technical stakeholders.
 """
 from pathlib import Path
+
+from lxml import etree
 from pptx import Presentation
-from pptx.util import Inches, Pt, Emu
 from pptx.dml.color import RGBColor
 from pptx.enum.text import PP_ALIGN
 from pptx.oxml.ns import qn
-from lxml import etree
+from pptx.util import Inches, Pt
 
 OUTPUT = Path(__file__).parent / "situation_report_prozess.pptx"
 
@@ -336,7 +336,6 @@ def slide_overview(prs):
 
     for i, step in enumerate(STEPS):
         c   = STEP_COLORS[i]
-        lc  = RGBColor(int(c[0]*0.75), int(c[1]*0.75), int(c[2]*0.75))
         x   = x0 + i * (box_w + gap)
 
         # Colored box

--- a/docs/generate_testdata_generator_manual.py
+++ b/docs/generate_testdata_generator_manual.py
@@ -18,18 +18,28 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from _font_config import setup as _setup_fonts
-_FN, _FB, _FI, _FBI = _setup_fonts()  # normal, bold, italic, bold_italic
-from version import __version__ as _VERSION
 
+_FN, _FB, _FI, _FBI = _setup_fonts()  # normal, bold, italic, bold_italic
 from reportlab.lib import colors
 from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.units import cm
 from reportlab.platypus import (
-    BaseDocTemplate, Frame, HRFlowable, NextPageTemplate, PageBreak,
-    PageTemplate, Paragraph, Preformatted, Spacer, Table, TableStyle,
+    BaseDocTemplate,
+    Frame,
+    HRFlowable,
+    NextPageTemplate,
+    PageBreak,
+    PageTemplate,
+    Paragraph,
+    Preformatted,
+    Spacer,
+    Table,
+    TableStyle,
 )
+
+from version import __version__ as _VERSION
 
 try:
     from reportlab.platypus import Image as RLImage

--- a/docs/generate_transform_data_manual.py
+++ b/docs/generate_transform_data_manual.py
@@ -19,19 +19,27 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from _font_config import setup as _setup_fonts
-_FN, _FB, _FI, _FBI = _setup_fonts()  # normal, bold, italic, bold_italic
-from version import __version__ as _VERSION
 
+_FN, _FB, _FI, _FBI = _setup_fonts()  # normal, bold, italic, bold_italic
 from reportlab.lib import colors
 from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.units import cm
 from reportlab.platypus import (
-    BaseDocTemplate, Frame, NextPageTemplate, PageBreak,
-    PageTemplate, Paragraph, Spacer, Table, TableStyle,
+    BaseDocTemplate,
+    Frame,
+    NextPageTemplate,
+    PageBreak,
+    PageTemplate,
+    Paragraph,
+    Spacer,
+    Table,
+    TableStyle,
 )
 from reportlab.platypus.tableofcontents import TableOfContents
+
+from version import __version__ as _VERSION
 
 # ---------------------------------------------------------------------------
 # Colors

--- a/helper/gui.py
+++ b/helper/gui.py
@@ -479,7 +479,8 @@ class _App:
                 )
                 self._root.after(0, lambda: self._log_msg(self._t("log_done")))
             except Exception as exc:
-                self._root.after(0, lambda: self._log_msg(self._t("log_error").format(exc)))
+                msg = self._t("log_error").format(exc)
+                self._root.after(0, lambda: self._log_msg(msg))
             finally:
                 for timer in _progress_timer:
                     self._root.after_cancel(timer)

--- a/portfolio/aggregator.py
+++ b/portfolio/aggregator.py
@@ -168,8 +168,10 @@ def _load_member(member: Member) -> ReportData:
     titles show the ART name rather than the file-derived project key.
     """
     paths = _resolve_member_paths(member)
+    issue_times = paths["issue_times"]
+    assert issue_times is not None  # guaranteed by _resolve_member_paths
     data = load_report_data(
-        paths["issue_times"], paths["cfd"], paths["workflow"], paths["transitions"]
+        issue_times, paths["cfd"], paths["workflow"], paths["transitions"]
     )
     data.source_prefix = member.name
     return data

--- a/portfolio/gui.py
+++ b/portfolio/gui.py
@@ -20,12 +20,12 @@ from __future__ import annotations
 
 import json
 import threading
+import tkinter as tk
 import webbrowser
 from datetime import date
 from pathlib import Path
-from typing import Any
-import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
+from typing import Any
 
 from .aggregator import (
     DEFAULT_COMPARISON_METRICS,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,16 +11,20 @@ docs = ["mkdocs-material>=9.5", "mkdocs-static-i18n>=1.3", "babel>=2.14"]
 # pywebview requires .NET SDK on Windows for pythonnet; install manually if needed
 gui = ["pywebview>=4.4"]
 build = ["pyinstaller>=6.0"]
-dev = ["pytest-cov>=5.0", "genbadge[coverage]>=1.1"]
+# ruff/mypy are pinned to a minor series so the quality gate is reproducible:
+# a floating version could fire new lint rules or shift complexity counts in CI
+# on code that was never touched. Bump these deliberately, in lockstep with the
+# pre-commit hook and quality.yml.
+dev = ["pytest-cov>=5.0", "genbadge[coverage]>=1.1", "ruff==0.15.*", "mypy==2.1.*"]
 
 [tool.setuptools.packages.find]
-include = ["get_data*", "transform_data*", "build_reports*", "testdata_generator*", "simulate*", "helper*"]
+include = ["get_data*", "transform_data*", "build_reports*", "testdata_generator*", "simulate*", "helper*", "portfolio*", "launcher*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
 [tool.coverage.run]
-source = ["build_reports", "transform_data", "get_data", "simulate", "testdata_generator", "helper"]
+source = ["build_reports", "transform_data", "get_data", "simulate", "testdata_generator", "helper", "portfolio", "launcher"]
 omit = ["*/tests/*", "*/docs/*", "*_gui.pyw", "*_gui.py", "*/gui.py", "*/__main__.py"]
 
 [tool.coverage.report]
@@ -28,3 +32,36 @@ exclude_lines = ["pragma: no cover", "if __name__ == .__main__.:"]
 
 [tool.ruff]
 line-length = 100
+extend-exclude = [
+    "*-AMD-R9-DARKSTAR.py",  # OneDrive sync-conflict copies
+    "feedback",             # archived ideas/bugs workflow folder, not source
+]
+
+[tool.ruff.lint]
+# F (pyflakes) catches real bugs — unused/undefined names; I = import sorting;
+# B = bugbear; UP = pyupgrade; C901 = cyclomatic complexity. E501 (line length)
+# and E402 (sys.path-before-import in the doc generators) are intentionally not
+# gated to avoid noise.
+select = ["F", "I", "B", "UP", "C901"]
+ignore = ["B905"]  # zip-without-explicit-strict — revisit later
+
+[tool.ruff.lint.mccabe]
+max-complexity = 15
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true   # tkcalendar / plotly / openpyxl ship no type stubs
+follow_imports = "silent"
+warn_unused_ignores = true
+exclude = '(gui|__main__)\.py$'  # tkinter GUIs are excluded for now (noisy typing)
+# Typed analytics core. Expand to cli.py / export.py / the GUIs over time.
+files = [
+    "portfolio",
+    "build_reports/metrics",
+    "build_reports/loader.py",
+    "build_reports/filters.py",
+    "build_reports/stage_groups.py",
+    "build_reports/terminology.py",
+    "build_reports/pi_config.py",
+    "build_reports/repel.py",
+]

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,6 +1,35 @@
 #!/bin/sh
-# Auto-update README.md version badge when version.py is staged.
+# Pre-commit hook for SituationReport.
+#
+#   1. Auto-update the README version badge when version.py is staged.
+#   2. Run the same quality gate as CI (ruff + mypy) so lint/type problems are
+#      caught before they reach a PR. Mirrors .github/workflows/quality.yml;
+#      ruff/mypy versions are pinned in pyproject [dev] so local == CI == hook.
+#
+# Only runs the gate when Python files are staged. Bypass in an emergency with
+# `git commit --no-verify`.
+
+# 1. README version badge -----------------------------------------------------
 if git diff --cached --name-only | grep -q "^version\.py$"; then
     python scripts/update_readme_version.py
     git add README.md
+fi
+
+# 2. Quality gate -------------------------------------------------------------
+if git diff --cached --name-only --diff-filter=ACM | grep -q "\.py$"; then
+    echo "pre-commit: running ruff + mypy ..."
+
+    if ! python -m ruff check .; then
+        echo "pre-commit: ruff found problems. Fix them (or run 'ruff check . --fix'), then re-commit." >&2
+        echo "            Bypass with 'git commit --no-verify' if you must." >&2
+        exit 1
+    fi
+
+    if ! python -m mypy; then
+        echo "pre-commit: mypy found type errors. Fix them, then re-commit." >&2
+        echo "            Bypass with 'git commit --no-verify' if you must." >&2
+        exit 1
+    fi
+
+    echo "pre-commit: ruff + mypy clean."
 fi

--- a/scripts/update_pptx_v090.py
+++ b/scripts/update_pptx_v090.py
@@ -13,7 +13,6 @@
 # =============================================================================
 
 import copy
-import sys
 from pathlib import Path
 
 from pptx import Presentation

--- a/testdata_generator/cli.py
+++ b/testdata_generator/cli.py
@@ -44,10 +44,10 @@ def _parse_date(value: str) -> date:
     """
     try:
         return date.fromisoformat(value)
-    except ValueError:
+    except ValueError as err:
         raise argparse.ArgumentTypeError(
             f"Invalid date '{value}' — expected YYYY-MM-DD format."
-        )
+        ) from err
 
 
 def _parse_issue_types(values: list[str]) -> dict[str, float]:
@@ -73,10 +73,10 @@ def _parse_issue_types(values: list[str]) -> dict[str, float]:
         type_name, weight_str = parts
         try:
             weight = float(weight_str)
-        except ValueError:
+        except ValueError as err:
             raise argparse.ArgumentTypeError(
                 f"Invalid weight '{weight_str}' in '{entry}' — must be a number."
-            )
+            ) from err
         if weight < 0:
             raise argparse.ArgumentTypeError(
                 f"Weight must be non-negative, got {weight} in '{entry}'."

--- a/testdata_generator/generator.py
+++ b/testdata_generator/generator.py
@@ -193,7 +193,7 @@ def _sample_pi_close_dt(
     )
 
 
-def _simulate_issue(
+def _simulate_issue(  # noqa: C901
     workflow: WorkflowSpec,
     config: GeneratorConfig,
     rng: random.Random,

--- a/testdata_generator/gui.py
+++ b/testdata_generator/gui.py
@@ -506,7 +506,7 @@ class _App:
         self._btn_report.configure(text=self._t("btn_report"))
         self._log_frame.configure(text=self._t("lbl_log"))
         lang = self._lang_var.get()
-        for rb, (val, lbl_de, lbl_en) in zip(self._pattern_rbs, _PATTERN_LABELS):
+        for rb, (_val, lbl_de, lbl_en) in zip(self._pattern_rbs, _PATTERN_LABELS):
             rb.configure(text=lbl_de if lang == LANG_DE else lbl_en)
         self._build_menu()
 
@@ -707,7 +707,7 @@ class _App:
                 return None
         return result if result else None
 
-    def _run(self) -> None:
+    def _run(self) -> None:  # noqa: C901
         if self._running:
             return
 
@@ -841,7 +841,8 @@ class _App:
                     0, lambda: self._btn_report.configure(state="normal")
                 )
             except Exception as exc:
-                self._root.after(0, lambda: self._log_msg(self._t("log_error").format(exc)))
+                msg = self._t("log_error").format(exc)
+                self._root.after(0, lambda: self._log_msg(msg))
             finally:
                 for timer in _progress_timer:
                     self._root.after_cancel(timer)
@@ -897,8 +898,8 @@ class _App:
                     0, lambda: self._log_msg(self._t("log_report_done"))
                 )
             except Exception as exc:
-                self._root.after(0, lambda: self._log_msg(
-                    self._t("log_report_error").format(exc)))
+                msg = self._t("log_report_error").format(exc)
+                self._root.after(0, lambda: self._log_msg(msg))
             finally:
                 for t in _timer:
                     self._root.after_cancel(t)

--- a/tests/build_reports/acceptance/test_cfd_acceptance.py
+++ b/tests/build_reports/acceptance/test_cfd_acceptance.py
@@ -108,7 +108,6 @@ class TestCfdTrendLinePositions:
 
     def test_inflow_above_outflow(self, cfd_result):
         """Inflow trend line ends above the outflow trend line (In Analysis stacks higher than Completed)."""
-        cd = cfd_result.chart_data
         metric = CfdMetric()
         figs = metric.render(cfd_result, SAFE)
         trend = [t for t in figs[0].data if not t.stackgroup]

--- a/tests/build_reports/acceptance/test_process_flow_acceptance.py
+++ b/tests/build_reports/acceptance/test_process_flow_acceptance.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from build_reports.loader import load_transitions, ReportData
+from build_reports.loader import ReportData, load_transitions
 from build_reports.metrics.process_flow import ProcessFlowMetric, _FlowData
 from build_reports.terminology import SAFE
 

--- a/tests/build_reports/unit/test_cli.py
+++ b/tests/build_reports/unit/test_cli.py
@@ -15,10 +15,9 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from datetime import date
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import plotly.graph_objects as go
 import pytest
@@ -26,7 +25,6 @@ import pytest
 from build_reports.cli import _parse_date, run_reports
 from build_reports.metrics.base import MetricResult
 from build_reports.terminology import GLOBAL, SAFE
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/build_reports/unit/test_export.py
+++ b/tests/build_reports/unit/test_export.py
@@ -13,8 +13,9 @@
 #   das Fallback-Verhalten für mehrere Figures ohne pypdf.
 # =============================================================================
 
+from datetime import datetime
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch
 
 import plotly.graph_objects as go
 import pytest
@@ -191,7 +192,6 @@ class TestWriteReportExcel:
 
     def test_file_is_created(self, tmp_path):
         """An XLSX file is created at the given path."""
-        from datetime import datetime
         path = tmp_path / "report.xlsx"
         write_report_excel([_make_report_record("A-1")], self._STAGES, path)
         assert path.exists()
@@ -234,6 +234,7 @@ class TestWriteReportExcel:
     def test_status_group_done_for_closed_issue(self, tmp_path):
         """A closed issue receives the status group 'Done'."""
         from datetime import datetime
+
         from openpyxl import load_workbook
         path = tmp_path / "report.xlsx"
         rec = _make_report_record("A-1", datetime(2025, 1, 2), datetime(2025, 1, 10))
@@ -247,6 +248,7 @@ class TestWriteReportExcel:
     def test_status_group_in_progress(self, tmp_path):
         """An issue with First Date but no Closed Date receives 'In Progress'."""
         from datetime import datetime
+
         from openpyxl import load_workbook
         path = tmp_path / "report.xlsx"
         rec = _make_report_record("A-2", first=datetime(2025, 1, 2), closed=None)
@@ -272,6 +274,7 @@ class TestWriteReportExcel:
     def test_ct_a_correct_value(self, tmp_path):
         """Cycle Time A equals the calendar-day difference between First Date and Closed Date."""
         from datetime import datetime
+
         from openpyxl import load_workbook
         path = tmp_path / "report.xlsx"
         rec = _make_report_record("A-1", datetime(2025, 1, 1), datetime(2025, 1, 11))
@@ -285,6 +288,7 @@ class TestWriteReportExcel:
     def test_ct_b_correct_value(self, tmp_path):
         """Cycle Time B equals the sum of stage minutes (excl. last stage) divided by 1440."""
         from datetime import datetime
+
         from openpyxl import load_workbook
         path = tmp_path / "report.xlsx"
         # 1440 min in Analysis + 2880 min in In Dev; Releasing (last stage) excluded

--- a/tests/build_reports/unit/test_flow_load.py
+++ b/tests/build_reports/unit/test_flow_load.py
@@ -17,7 +17,7 @@ from datetime import datetime
 import pytest
 
 from build_reports.loader import IssueRecord, ReportData
-from build_reports.metrics.flow_load import FlowLoadMetric, _age_days, _current_stage
+from build_reports.metrics.flow_load import FlowLoadMetric, _current_stage
 from build_reports.terminology import SAFE
 
 

--- a/tests/build_reports/unit/test_flow_time.py
+++ b/tests/build_reports/unit/test_flow_time.py
@@ -18,7 +18,12 @@ import pytest
 
 from build_reports.loader import IssueRecord, ReportData
 from build_reports.metrics.flow_time import (
-    CT_METHOD_A, CT_METHOD_B, FlowTimeMetric, _loess, _month_ticks, _point_color,
+    CT_METHOD_A,
+    CT_METHOD_B,
+    FlowTimeMetric,
+    _loess,
+    _month_ticks,
+    _point_color,
 )
 from build_reports.terminology import GLOBAL, SAFE
 
@@ -622,7 +627,6 @@ class TestMethodBClosedStage:
         closed in Dec have small carry-forward. With the fix, carry-forward is
         excluded, so Pearson r should be near zero (not strongly negative).
         """
-        from datetime import timedelta
 
         base_first = datetime(2025, 1, 1)
         issues = []

--- a/tests/build_reports/unit/test_gui.py
+++ b/tests/build_reports/unit/test_gui.py
@@ -23,10 +23,20 @@ import plotly.graph_objects as go
 import pytest
 
 from build_reports.gui import (
-    LANG_DE, LANG_EN, LANG_RO, LANG_PT, LANG_FR, _T,
-    _build_combined_html, _build_template_dict, _check_stage_consistency,
-    _default_date_range, _parse_date_safe, _parse_template_dict,
-    _read_available_filters, _split_csv, _TEMPLATE_VERSION,
+    _T,
+    LANG_DE,
+    LANG_EN,
+    LANG_FR,
+    LANG_PT,
+    LANG_RO,
+    _build_combined_html,
+    _build_template_dict,
+    _check_stage_consistency,
+    _default_date_range,
+    _parse_date_safe,
+    _parse_template_dict,
+    _read_available_filters,
+    _split_csv,
 )
 
 

--- a/tests/build_reports/unit/test_loader.py
+++ b/tests/build_reports/unit/test_loader.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime
 from pathlib import Path
 
 import openpyxl
@@ -29,7 +29,6 @@ from build_reports.loader import (
     load_report_data,
     load_transitions,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/build_reports/unit/test_pi_config.py
+++ b/tests/build_reports/unit/test_pi_config.py
@@ -21,9 +21,11 @@ from pathlib import Path
 import pytest
 
 from build_reports.pi_config import (
-    PIInterval, assign_pi, default_quarter_intervals, load_pi_config,
+    PIInterval,
+    assign_pi,
+    default_quarter_intervals,
+    load_pi_config,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/build_reports/unit/test_process_flow.py
+++ b/tests/build_reports/unit/test_process_flow.py
@@ -22,12 +22,12 @@ from build_reports.metrics.process_flow import (
     ProcessFlowMetric,
     ProcessFlowTimeMetric,
     _circular_positions,
+    _Edge,
     _edge_width,
-    _format_label,
     _format_duration,
+    _format_label,
     _node_size,
     _parse_ts,
-    _Edge,
 )
 from build_reports.terminology import PROCESS_FLOW, PROCESS_FLOW_TIME, SAFE
 

--- a/tests/build_reports/unit/test_repel.py
+++ b/tests/build_reports/unit/test_repel.py
@@ -13,7 +13,6 @@
 # =============================================================================
 
 import plotly.graph_objects as go
-import pytest
 
 from build_reports.repel import add_repelled_hlines
 

--- a/tests/build_reports/unit/test_stage_groups.py
+++ b/tests/build_reports/unit/test_stage_groups.py
@@ -18,8 +18,11 @@ import pytest
 
 from build_reports.loader import IssueRecord
 from build_reports.stage_groups import (
-    GROUP_DONE, GROUP_IN_PROGRESS, GROUP_TODO,
-    classify_stages, issue_stage_group,
+    GROUP_DONE,
+    GROUP_IN_PROGRESS,
+    GROUP_TODO,
+    classify_stages,
+    issue_stage_group,
 )
 
 

--- a/tests/build_reports/unit/test_terminology.py
+++ b/tests/build_reports/unit/test_terminology.py
@@ -14,8 +14,14 @@
 import pytest
 
 from build_reports.terminology import (
-    FLOW_DISTRIBUTION, FLOW_LOAD, FLOW_TIME, FLOW_VELOCITY,
-    GLOBAL, SAFE, all_terms, term,
+    FLOW_DISTRIBUTION,
+    FLOW_LOAD,
+    FLOW_TIME,
+    FLOW_VELOCITY,
+    GLOBAL,
+    SAFE,
+    all_terms,
+    term,
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@
 # =============================================================================
 
 from pathlib import Path
+
 import pytest
 
 TESTDATA_DIR = Path(__file__).parent / "testdata"

--- a/tests/helper/unit/test_cli.py
+++ b/tests/helper/unit/test_cli.py
@@ -17,10 +17,7 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from helper.cli import run_merge
-
 
 # ---------------------------------------------------------------------------
 # run_merge — error branches

--- a/tests/launcher/unit/test_gui.py
+++ b/tests/launcher/unit/test_gui.py
@@ -12,16 +12,16 @@
 # =============================================================================
 
 from launcher.gui import (
-    LANG_DE,
-    LANG_EN,
-    LANG_FR,
-    LANG_PT,
-    LANG_RO,
     _LANG_ORDER,
     _MODULES,
     _RELEASES_URL,
     _T,
     _UPDATE_API,
+    LANG_DE,
+    LANG_EN,
+    LANG_FR,
+    LANG_PT,
+    LANG_RO,
     _parse_version,
 )
 

--- a/tests/launcher/unit/test_packaging.py
+++ b/tests/launcher/unit/test_packaging.py
@@ -1,0 +1,72 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       23.06.2026
+# Geändert:       23.06.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Konsistenz-Wächter für das Packaging. Jedes im Launcher als verfügbar
+#   markierte Modul muss von den Release- und Dev-Build-Workflows in das
+#   Bundle kopiert werden, sonst startet ein Launcher-Button in der gebauten
+#   App ins Leere. Der Test fängt genau diese Lücke ab (historisch z. B. das
+#   anfangs vergessene 'portfolio'-Modul) und vergleicht die Modul-Registry
+#   gegen die tatsächlichen Copy-Listen in den Workflow-YAMLs.
+# =============================================================================
+
+from pathlib import Path
+
+import pytest
+
+from launcher.gui import _MODULES
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOWS = [
+    _REPO_ROOT / ".github" / "workflows" / "release.yml",
+    _REPO_ROOT / ".github" / "workflows" / "dev-build.yml",
+]
+
+# Modules a launcher button can actually start. These MUST be bundled.
+_AVAILABLE_MODULES = sorted(e.module_id for e in _MODULES if e.available)
+
+
+@pytest.fixture(scope="module")
+def workflow_texts() -> dict[str, str]:
+    """Read each packaging workflow YAML once and return {filename: text}."""
+    texts = {}
+    for wf in _WORKFLOWS:
+        assert wf.is_file(), f"Workflow file missing: {wf}"
+        texts[wf.name] = wf.read_text(encoding="utf-8")
+    return texts
+
+
+def test_available_modules_nonempty() -> None:
+    """Sanity check: the registry exposes at least one available module."""
+    assert _AVAILABLE_MODULES, "No available modules found in launcher._MODULES"
+
+
+@pytest.mark.parametrize("module_id", _AVAILABLE_MODULES)
+@pytest.mark.parametrize("workflow", [wf.name for wf in _WORKFLOWS])
+def test_available_module_is_bundled(
+    module_id: str, workflow: str, workflow_texts: dict[str, str]
+) -> None:
+    """Every available launcher module appears in each workflow's copy list.
+
+    Guards against shipping a build whose launcher offers a module the
+    packaging step never copied into the bundle.
+    """
+    text = workflow_texts[workflow]
+    assert f"'{module_id}'" in text or f" {module_id} " in text, (
+        f"Module '{module_id}' is marked available in the launcher but is not "
+        f"referenced in {workflow}'s module copy list. Add it there so the "
+        f"built app can launch it."
+    )
+
+
+def test_launcher_itself_is_bundled(workflow_texts: dict[str, str]) -> None:
+    """The launcher package itself must be bundled by every workflow."""
+    for workflow, text in workflow_texts.items():
+        assert "'launcher'" in text or " launcher " in text, (
+            f"The 'launcher' package is not referenced in {workflow}'s copy list."
+        )

--- a/tests/portfolio/unit/test_aggregator.py
+++ b/tests/portfolio/unit/test_aggregator.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from datetime import date, datetime
 
 from build_reports.loader import CfdRecord, IssueRecord, ReportData
-
 from portfolio import aggregator
 from portfolio.solution_config import KIND_PORTFOLIO, Member, SolutionConfig
 
@@ -216,8 +215,9 @@ def test_render_pooled_html_endtoend(monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 
 def test_render_pdf_prepends_summary_and_exports(monkeypatch) -> None:
-    import plotly.graph_objects as go
     from pathlib import Path
+
+    import plotly.graph_objects as go
     fig = go.Figure()
     unit = ReportData(issues=[_issue("ART_A", "ART_A-1", 1, 5)], source_prefix="Sol")
     captured: dict = {}

--- a/tests/portfolio/unit/test_gui.py
+++ b/tests/portfolio/unit/test_gui.py
@@ -19,12 +19,12 @@ from datetime import date
 import pytest
 
 from portfolio.gui import (
+    _T,
     LANG_DE,
     LANG_EN,
     LANG_FR,
     LANG_PT,
     LANG_RO,
-    _T,
     _member_dict,
     build_config_from_fields,
     default_metrics_for_mode,

--- a/tests/portfolio/unit/test_summary.py
+++ b/tests/portfolio/unit/test_summary.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 from datetime import datetime
 
 from build_reports.loader import IssueRecord, ReportData
-
 from portfolio.summary import (
     Summary,
     _percentile,

--- a/tests/testdata_generator/unit/test_cli.py
+++ b/tests/testdata_generator/unit/test_cli.py
@@ -15,15 +15,12 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from datetime import date
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from testdata_generator.cli import _parse_date, _parse_issue_types, run_generate
-
 
 # ---------------------------------------------------------------------------
 # _parse_date

--- a/tests/testdata_generator/unit/test_generator.py
+++ b/tests/testdata_generator/unit/test_generator.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import json
 from datetime import date, datetime
-from pathlib import Path
 
 import pytest
 
@@ -230,7 +229,6 @@ class TestBackflow:
         for issue in data["issues"]:
             histories = issue["changelog"]["histories"]
             for i in range(1, len(histories)):
-                prev_to = histories[i - 1]["items"][0]["toString"]
                 curr_from = histories[i]["items"][0]["fromString"]
                 curr_to = histories[i]["items"][0]["toString"]
                 if (curr_from in stages and curr_to in stages

--- a/tests/transform_data/acceptance/test_transform_ata.py
+++ b/tests/transform_data/acceptance/test_transform_ata.py
@@ -25,15 +25,16 @@ definition to ensure the pipeline meets its functional requirements.
 A fixed reference_dt is used so results are reproducible across runs.
 """
 
-import pytest
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
-from transform_data.workflow import parse_workflow
+import pytest
+
 from transform_data.processor import process_issues
+from transform_data.workflow import parse_workflow
 
 # Fixed reference date → stage minutes for open issues are deterministic
-REFERENCE_DT = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+REFERENCE_DT = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
 
 
 @pytest.fixture(scope="module")
@@ -191,6 +192,6 @@ class TestCfdInvariants:
             )
 
     def test_created_date_not_in_future(self, records):
-        cutoff = datetime(2026, 12, 31, tzinfo=timezone.utc)
+        cutoff = datetime(2026, 12, 31, tzinfo=UTC)
         for r in records:
             assert r.created <= cutoff, f"{r.key}: created liegt in der Zukunft"

--- a/tests/transform_data/unit/test_processor.py
+++ b/tests/transform_data/unit/test_processor.py
@@ -23,19 +23,19 @@ independent of real export files or the current system time.
 """
 
 import json
-import pytest
-from datetime import datetime, timezone, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from transform_data.workflow import Workflow
-from transform_data.processor import process_issues
+import pytest
 
+from transform_data.processor import process_issues
+from transform_data.workflow import Workflow
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-REF_DT = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+REF_DT = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
 
 SIMPLE_WORKFLOW = Workflow(
     stages=["Funnel", "Analysis", "Implementation", "Done"],
@@ -107,12 +107,12 @@ def _process(issues: list[dict], workflow: Workflow = SIMPLE_WORKFLOW):
 
 class TestNoTransitions:
     def test_all_stage_minutes_are_zero(self):
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
         records, _ = _process([_issue("T-1", created, status="Funnel")])
         assert all(v == 0 for v in records[0].stage_minutes.values())
 
     def test_dates_are_none(self):
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
         records, _ = _process([_issue("T-1", created)])
         r = records[0]
         assert r.first_date is None
@@ -121,7 +121,7 @@ class TestNoTransitions:
 
     def test_initial_stage_falls_back_to_first_workflow_stage(self):
         """Unmapped initial status → first stage in workflow used."""
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
         records, _ = _process([_issue("T-1", created, status="Unknown")])
         assert records[0].initial_stage == "Funnel"
 
@@ -129,8 +129,8 @@ class TestNoTransitions:
 class TestPreTransitionTime:
     def test_time_before_first_transition_goes_to_initial_stage(self):
         """60 minutes elapse in Funnel before the first explicit transition."""
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)  # +60 min
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)  # +60 min
         records, _ = _process([_issue(
             "T-1", created, status="Analysis",
             transitions=[("Funnel", "Analysis", t1)],
@@ -139,8 +139,8 @@ class TestPreTransitionTime:
 
     def test_time_after_last_transition_goes_to_last_stage(self):
         """From last transition to REF_DT is attributed to the last stage."""
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)
         # REF_DT = 2026-01-01 00:00 UTC → 31 days - 1 hour after t1
         expected = int((REF_DT - t1).total_seconds() / 60)
         records, _ = _process([_issue(
@@ -156,9 +156,9 @@ class TestCarryForward:
         Issue path: Funnel (60 min) → UnknownStage (120 min) → Analysis
         The 120 min in UnknownStage must be carried forward to Funnel.
         """
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)   # +60 min: enter Unknown
-        t2 = datetime(2025, 12, 1, 13, 0, tzinfo=timezone.utc)   # +120 min: enter Analysis
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)   # +60 min: enter Unknown
+        t2 = datetime(2025, 12, 1, 13, 0, tzinfo=UTC)   # +120 min: enter Analysis
         records, _ = _process([_issue(
             "T-1", created,
             transitions=[
@@ -171,8 +171,8 @@ class TestCarryForward:
         assert r.stage_minutes["Analysis"] > 0
 
     def test_unmapped_status_is_reported(self):
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)
         _, unmapped = _process([_issue(
             "T-1", created,
             transitions=[("Funnel", "UnknownStage", t1)],
@@ -180,8 +180,8 @@ class TestCarryForward:
         assert "UnknownStage" in unmapped
 
     def test_fully_mapped_workflow_has_no_unmapped(self, simple_workflow_file: Path):
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)
         _, unmapped = _process([_issue(
             "T-1", created,
             transitions=[("Funnel", "Analysis", t1)],
@@ -191,8 +191,8 @@ class TestCarryForward:
 
 class TestMilestoneDates:
     def test_first_date_set_on_entry_to_first_stage(self):
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)
         records, _ = _process([_issue(
             "T-1", created,
             transitions=[("Funnel", "Analysis", t1)],
@@ -201,10 +201,10 @@ class TestMilestoneDates:
 
     def test_first_date_only_set_once_on_first_entry(self):
         """Re-entering the first_stage does not overwrite first_date."""
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)
-        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=timezone.utc)
-        t3 = datetime(2025, 12, 1, 13, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)
+        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=UTC)
+        t3 = datetime(2025, 12, 1, 13, 0, tzinfo=UTC)
         records, _ = _process([_issue(
             "T-1", created,
             transitions=[
@@ -216,9 +216,9 @@ class TestMilestoneDates:
         assert records[0].first_date == t1  # not t3
 
     def test_closed_date_set_on_entry_to_closed_stage(self):
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)
-        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)
+        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=UTC)
         records, _ = _process([_issue(
             "T-1", created,
             status="Done",  # current status = closed stage → closed_date kept
@@ -231,11 +231,11 @@ class TestMilestoneDates:
 
     def test_closed_date_uses_last_entry_not_first(self):
         """Issue wird wiedereröffnet und erneut geschlossen — letzter Schließzeitpunkt zählt."""
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t0 = datetime(2025, 12, 1, 10, 30, tzinfo=timezone.utc)  # → Analysis (First Date)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)  # → Done (erste Schließung)
-        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=timezone.utc)  # → Funnel (Wiedereröffnung)
-        t3 = datetime(2025, 12, 1, 13, 0, tzinfo=timezone.utc)  # → Done (zweite Schließung)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t0 = datetime(2025, 12, 1, 10, 30, tzinfo=UTC)  # → Analysis (First Date)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)  # → Done (erste Schließung)
+        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=UTC)  # → Funnel (Wiedereröffnung)
+        t3 = datetime(2025, 12, 1, 13, 0, tzinfo=UTC)  # → Done (zweite Schließung)
         records, _ = _process([_issue(
             "T-1", created,
             status="Done",  # current status = closed stage → closed_date kept
@@ -251,8 +251,8 @@ class TestMilestoneDates:
 
     def test_first_date_fallback_when_first_stage_skipped(self):
         """First Date is set to the earliest stage after first_stage (before closed) if skipped."""
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)
         # Funnel -> Implementation (skips Analysis which is first_stage)
         records, _ = _process([_issue(
             "T-1", created,
@@ -262,8 +262,8 @@ class TestMilestoneDates:
 
     def test_no_first_date_if_only_stages_before_first_stage_entered(self):
         """No First Date fallback if issue only enters stages at or before first_stage."""
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)
         # Funnel -> Funnel (stays before Analysis, no stage after first_stage)
         records, _ = _process([_issue(
             "T-1", created,
@@ -273,8 +273,8 @@ class TestMilestoneDates:
 
     def test_no_first_date_if_only_closed_or_later_entered(self):
         """No First Date fallback if issue only enters the Closed stage or later (not between)."""
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)
         # Funnel -> Done (Done IS the closed_stage, not strictly between first and closed)
         records, _ = _process([_issue(
             "T-1", created,
@@ -296,9 +296,9 @@ class TestMilestoneDates:
             closed_stage="Done",
             inprogress_stage="Implementation",
         )
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)
-        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)
+        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=UTC)
         # Analysis -> Validating (skips Implementation, goes before Done)
         records, _ = _process([_issue(
             "T-1", created,
@@ -312,10 +312,10 @@ class TestMilestoneDates:
 
     def test_closed_date_cleared_when_issue_reopened_before_closed_stage(self):
         """Closed Date is cleared if the issue's current status is before the Closed stage."""
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)  # → Analysis
-        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=timezone.utc)  # → Done (= closed_stage)
-        t3 = datetime(2025, 12, 1, 13, 0, tzinfo=timezone.utc)  # → Analysis (reopened!)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)  # → Analysis
+        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=UTC)  # → Done (= closed_stage)
+        t3 = datetime(2025, 12, 1, 13, 0, tzinfo=UTC)  # → Analysis (reopened!)
         records, _ = _process([_issue(
             "T-1", created,
             status="Analysis",  # current status: before Done (closed stage)
@@ -329,10 +329,10 @@ class TestMilestoneDates:
 
     def test_closed_date_cleared_when_issue_reopened_via_fallback(self):
         """Closed Date from fallback is cleared if the issue is currently before Closed stage."""
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)  # → Implementation
-        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=timezone.utc)  # → Done (after closed_stage)
-        t3 = datetime(2025, 12, 1, 13, 0, tzinfo=timezone.utc)  # → Funnel (reopened!)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)  # → Implementation
+        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=UTC)  # → Done (after closed_stage)
+        t3 = datetime(2025, 12, 1, 13, 0, tzinfo=UTC)  # → Funnel (reopened!)
         records, _ = _process([_issue(
             "T-1", created,
             status="Funnel",  # current status: before Done (closed stage)
@@ -346,9 +346,9 @@ class TestMilestoneDates:
 
     def test_closed_date_kept_when_current_status_after_closed_stage(self):
         """Closed Date is preserved if the issue's current status is after the Closed stage."""
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)
-        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)
+        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=UTC)
         # SIMPLE_WORKFLOW: Done is the closed_stage; no stage after it in this workflow
         # Use a workflow where a stage follows Done to test "status after closed"
         wf = Workflow(
@@ -384,8 +384,8 @@ class TestMilestoneDates:
             closed_stage="Done",
             inprogress_stage="Implementation",
         )
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)
         # Funnel -> Validating only; with new rule first_date would be t1 (between Analysis and Done)
         # which then triggers inprogress fallback too — let's test pure no-first case by
         # going directly to Done (not between first and closed)
@@ -399,8 +399,8 @@ class TestMilestoneDates:
 
     def test_no_closed_date_if_no_first_date(self):
         """Issue that jumps directly from To Do to Closed without First stage gets no Closed Date."""
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 10, 0, 23, tzinfo=timezone.utc)  # 23 sec after creation
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 10, 0, 23, tzinfo=UTC)  # 23 sec after creation
         records, _ = _process([_issue(
             "T-1", created,
             transitions=[("Funnel", "Done", t1)],  # skips Analysis (First) entirely
@@ -421,9 +421,9 @@ class TestMilestoneDates:
             closed_stage="Releasing",
             inprogress_stage="Implementation",
         )
-        created = datetime(2025, 2, 13, 12, 48, tzinfo=timezone.utc)
-        t1 = datetime(2025, 2, 13, 12, 49, tzinfo=timezone.utc)  # Funnel -> Releasing (skips all)
-        t2 = datetime(2025, 11, 30, 8, 16, tzinfo=timezone.utc)  # Releasing -> Done
+        created = datetime(2025, 2, 13, 12, 48, tzinfo=UTC)
+        t1 = datetime(2025, 2, 13, 12, 49, tzinfo=UTC)  # Funnel -> Releasing (skips all)
+        t2 = datetime(2025, 11, 30, 8, 16, tzinfo=UTC)  # Releasing -> Done
         records, _ = _process([_issue(
             "T-1", created,
             status="Done",
@@ -437,9 +437,9 @@ class TestMilestoneDates:
 
     def test_closed_date_kept_when_first_date_present(self):
         """Normal flow: First Date exists → Closed Date is not affected by the guard."""
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)
-        t2 = datetime(2025, 12, 10, 9, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)
+        t2 = datetime(2025, 12, 10, 9, 0, tzinfo=UTC)
         records, _ = _process([_issue(
             "T-1", created,
             status="Done",
@@ -454,15 +454,15 @@ class TestMilestoneDates:
 
 class TestTransitions:
     def test_first_transition_is_always_created(self):
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
         records, _ = _process([_issue("T-1", created)])
         assert records[0].transitions[0].label == "Created"
         assert records[0].transitions[0].timestamp == created
 
     def test_transitions_are_sorted_by_timestamp(self):
-        created = datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc)
-        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=timezone.utc)
-        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 12, 1, 10, 0, tzinfo=UTC)
+        t1 = datetime(2025, 12, 1, 11, 0, tzinfo=UTC)
+        t2 = datetime(2025, 12, 1, 12, 0, tzinfo=UTC)
         records, _ = _process([_issue(
             "T-1", created,
             transitions=[
@@ -492,7 +492,7 @@ class TestParseDt:
 class TestReferenceNone:
     def test_no_reference_dt_uses_now(self, tmp_path):
         from transform_data.processor import process_issues
-        created = datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc)
+        created = datetime(2025, 1, 1, 10, 0, tzinfo=UTC)
         payload = _make_json([_issue("T-1", created)])
         jf = tmp_path / "T.json"
         jf.write_text(payload, encoding="utf-8")

--- a/tests/transform_data/unit/test_transform.py
+++ b/tests/transform_data/unit/test_transform.py
@@ -21,7 +21,6 @@ import pytest
 
 from transform_data.transform import TransformResult, run_transform
 
-
 WORKFLOW_FULL = "\n".join([
     "Funnel",
     "Analysis",
@@ -177,8 +176,8 @@ class TestRunTransform:
 
 class TestMain:
     def _run_main(self, argv: list[str]):
-        import sys
         from unittest.mock import patch
+
         from transform_data.transform import main
         with patch("sys.argv", ["prog"] + argv), \
              patch("transform_data.transform.run_transform") as mock_run:

--- a/tests/transform_data/unit/test_workflow.py
+++ b/tests/transform_data/unit/test_workflow.py
@@ -20,8 +20,9 @@ Tests isolate the parsing logic using the simple fixture workflow
 and temporary files for error cases.
 """
 
-import pytest
 from pathlib import Path
+
+import pytest
 
 from transform_data.workflow import parse_workflow
 

--- a/tests/transform_data/unit/test_writers.py
+++ b/tests/transform_data/unit/test_writers.py
@@ -14,7 +14,7 @@
 
 """Unit tests for transform_data.writers."""
 
-from datetime import date, datetime, timezone, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 import openpyxl
@@ -22,8 +22,7 @@ import pytest
 
 from transform_data.processor import IssueRecord, Transition
 from transform_data.workflow import parse_workflow
-from transform_data.writers import write_cfd, write_transitions, write_issue_times
-
+from transform_data.writers import write_cfd, write_issue_times, write_transitions
 
 WORKFLOW_TEXT = "\n".join([
     "Funnel",

--- a/transform_data/gui.py
+++ b/transform_data/gui.py
@@ -26,8 +26,8 @@ import tempfile
 import threading
 import tkinter as tk
 import webbrowser
-from tkinter import filedialog, scrolledtext, ttk
 from pathlib import Path
+from tkinter import filedialog, scrolledtext, ttk
 
 try:
     from version import __version__ as _VERSION

--- a/transform_data/processor.py
+++ b/transform_data/processor.py
@@ -18,8 +18,8 @@
 
 import json
 import re
-from dataclasses import dataclass, field
-from datetime import datetime, timezone, timedelta
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 
 from .workflow import Workflow
@@ -67,7 +67,7 @@ class IssueRecord:
     transitions: list[Transition]  # sorted by timestamp; first entry is always "Created"
 
 
-def process_issues(
+def process_issues(  # noqa: C901
     json_path: Path,
     workflow: Workflow,
     reference_dt: datetime | None = None,
@@ -88,7 +88,7 @@ def process_issues(
     - Issues with no transitions have all-zero stage times.
     """
     if reference_dt is None:
-        reference_dt = datetime.now(tz=timezone.utc)
+        reference_dt = datetime.now(tz=UTC)
 
     data = json.loads(json_path.read_text(encoding="utf-8"))
     records: list[IssueRecord] = []

--- a/transform_data/transform.py
+++ b/transform_data/transform.py
@@ -30,12 +30,12 @@ Example:
 import argparse
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
-from .workflow import parse_workflow
 from .processor import process_issues
-from .writers import write_transitions, write_issue_times, write_cfd
+from .workflow import parse_workflow
+from .writers import write_cfd, write_issue_times, write_transitions
 
 
 @dataclass(frozen=True)
@@ -72,7 +72,7 @@ def run_transform(
     if workflow.closed_stage is None:
         log("WARNUNG: Kein <Closed>-Marker in der Workflow-Datei — Closed Date wird nicht berechnet.")
 
-    reference_dt = datetime.now(tz=timezone.utc)
+    reference_dt = datetime.now(tz=UTC)
     records, unmapped = process_issues(json_file, workflow, reference_dt)
 
     if unmapped:

--- a/transform_data/writers.py
+++ b/transform_data/writers.py
@@ -15,7 +15,7 @@
 # =============================================================================
 
 import io
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 from openpyxl import Workbook


### PR DESCRIPTION
## Summary

Sets up a **reproducible code-quality gate** (Tier 1: Ruff + mypy) and cleans up the lint/type findings it surfaced — all in one PR, as agreed.

### Tooling
- **pyproject**: Ruff (`F`/`I`/`B`/`UP`/`C901`) + mypy on a typed *analytics core* (portfolio + metrics + loader/filters/stage_groups/terminology/pi_config/repel; GUIs excluded as noisy). `E501`/`E402` intentionally not gated. **Ruff and mypy versions are pinned** so local == hook == CI.
- Fixed a real **coverage/packaging gap**: `portfolio` and `launcher` were missing from both `[tool.coverage.run].source` and `[tool.setuptools.packages.find]`.
- **New `Quality` CI workflow** — runs ruff + mypy on every PR and push to `main`.
- **pre-commit hook** runs the same gate (`python scripts/setup_hooks.py` to install).
- **Packaging-consistency test** (`tests/launcher/unit/test_packaging.py`): every launcher-available module must appear in the release and dev-build bundle copy lists. Guards the exact gap that originally dropped the `portfolio` module from builds. (Discrimination verified: a module absent from the lists fails the test.)

### Cleanup of findings
- **Real bug** — deferred log callbacks in the Helper and Testdata Generator GUIs referenced the exception variable *after* Python cleared it at the end of the `except` block, raising `NameError` instead of logging the error. The message is now formatted before the callback is scheduled.
- `ruff --fix` import sorting / pyupgrade across the tree; resolved `B904` (`raise ... from`), `B007`/`B018`/`B023`/`B028`, unused vars/imports; `# noqa: C901` on the few intentionally complex functions.
- mypy: `TYPE_CHECKING` import for `ReportData`, `None`-narrowing in the Flow Load cycle-time calc, `Sequence`-variance and `Path | None` fixes.

### Verification
- `ruff check .` → **All checks passed**
- `mypy` → **Success: no issues found in 19 source files**
- Full test suite green (local `tmp_path` errors are a known OneDrive temp-dir `WinError 5`, not failures; CI/xvfb is clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)