### PR TITLE
docs: complete module manual links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Toolsuite for querying Jira issue data and processing it into flow metrics and r
 | [`launcher`](https://jaegerfeld.github.io/situation-report/modules/launcher/) | Central launcher GUI for all modules | available |
 | [`transform_data`](https://jaegerfeld.github.io/situation-report/modules/transform_data/) | Transform raw Jira data into stage-time metrics | available |
 | [`build_reports`](https://jaegerfeld.github.io/situation-report/modules/build_reports/) | Generate flow metrics and reports | available |
-| `portfolio` | Aggregated Large-Solution & Portfolio reports across several ARTs | available |
+| [`portfolio`](https://jaegerfeld.github.io/situation-report/modules/portfolio/) | Aggregated Large-Solution & Portfolio reports across several ARTs | available |
 | `get_data` | Fetch issue data from Jira via REST API | planned |
 | [`testdata_generator`](https://jaegerfeld.github.io/situation-report/modules/testdata_generator/) | Generate synthetic test data | available |
-| `simulate` | Simulations and forecasting models | planned |
+| [`simulate`](https://jaegerfeld.github.io/situation-report/modules/simulate/) | Simulations and forecasting models | available |
 | [`helper`](https://jaegerfeld.github.io/situation-report/modules/helper/) | Helper tools (JSON Merger) | available |
 
 ## Setup

--- a/docs/modules/index.de.md
+++ b/docs/modules/index.de.md
@@ -5,10 +5,11 @@
 | [launcher](launcher.md) | Zentraler Einstiegspunkt – startet alle Module | verfügbar |
 | [transform_data](transform_data.md) | Transformation von Jira-Rohdaten in Stage-Time-Metriken | verfügbar |
 | [build_reports](build_reports.md) | Erzeugung von Metriken und Reports | verfügbar |
+| [portfolio](portfolio.md) | Aggregierte Large-Solution- & Portfolio-Reports über mehrere ARTs | verfügbar (Alpha) |
 | [helper](helper.md) | JSON-Dateien zusammenführen (Jira-Paginierung) | verfügbar (Alpha) |
 | [testdata_generator](testdata_generator.md) | Generierung synthetischer Testdaten | verfügbar (Beta) |
 | [get_data](get_data.md) | Datenabruf aus Jira via REST API | geplant |
-| [simulate](simulate.md) | Simulationen und Vorhersagemodelle | geplant |
+| [simulate](simulate.md) | Simulationen und Vorhersagemodelle | verfügbar (Alpha) |
 
 ## Gemeinsames Projekt-Template
 

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -5,10 +5,11 @@
 | [launcher](launcher.md) | Central entry point – launches all modules | available |
 | [transform_data](transform_data.md) | Transform raw Jira data into stage-time metrics | available |
 | [build_reports](build_reports.md) | Generate metrics and reports | available |
+| [portfolio](portfolio.md) | Aggregated Large-Solution & Portfolio reports across several ARTs | available (Alpha) |
 | [helper](helper.md) | Merge JSON files (Jira pagination) | available (Alpha) |
 | [testdata_generator](testdata_generator.md) | Generate synthetic test data | available (Beta) |
 | [get_data](get_data.md) | Retrieve data from Jira via REST API | planned |
-| [simulate](simulate.md) | Simulations and prediction models | planned |
+| [simulate](simulate.md) | Simulations and prediction models | available (Alpha) |
 
 ## Shared project template
 

--- a/docs/modules/portfolio.de.md
+++ b/docs/modules/portfolio.de.md
@@ -1,0 +1,80 @@
+# portfolio
+
+Fasst mehrere bereits konfigurierte ARTs zu einem kombinierten
+**Large-Solution-** oder **Portfolio-**Report zusammen — als **Pooled** (die
+Solution als ein System betrachtet) oder als **Vergleich** (Einheiten
+nebeneinander). Nutzt die Metriken aus `build_reports`; die einzelnen
+ART-Reports werden nur referenziert, nicht verändert.
+
+**Status:** verfügbar (Alpha)
+
+## Handbücher
+
+| Sprache | Download |
+|---------|----------|
+| Deutsch (DE) | [Benutzerhandbuch](../portfolio_Benutzerhandbuch.pdf) |
+| English (EN) | [User Manual](../portfolio_UserManual.pdf) |
+| Română (RO) | [Manual de Utilizator](../portfolio_ManualUtilizator.pdf) |
+| Português (PT) | [Manual do Utilizador](../portfolio_ManualUtilizador.pdf) |
+| Français (FR) | [Manuel d'utilisation](../portfolio_ManuelUtilisateur.pdf) |
+
+---
+
+## Grundbegriffe
+
+| Begriff | Bedeutung |
+|---------|-----------|
+| ART | Agile Release Train / Teamgruppe — die Ebene, auf der du in `build_reports` bereits berichtest. |
+| Solution | Eine Gruppierung mehrerer ARTs (referenziert deren Projekt-Templates). |
+| Portfolio | Eine Gruppierung mehrerer Solutions (Portfolio > Solutions > ARTs). |
+| Pooled | Modus: Alle Issues werden zu **einem** Datensatz zusammengeführt — die Solution als ein System. |
+| Vergleich | Modus: Jede Einheit (ART oder Solution) wird separat nebeneinander dargestellt. |
+
+## Oberfläche
+
+![Screenshot der Portfolio-GUI](../assets/Portfolio-GUI.png)
+
+## Start
+
+### GUI
+
+```bash
+python -m portfolio
+```
+
+Oder auf die Kachel **Solutions & Portfolios** links im SituationReport-Launcher
+klicken.
+
+### Kommandozeile
+
+```bash
+python -m portfolio solution.json --mode pooled --output report.html
+# Vergleichsmodus / PDF-Ausgabe:
+python -m portfolio solution.json --mode comparison --pdf report.pdf
+```
+
+Die Konfigurationsdatei (`solution.json`) listet die Mitglieder auf (ARTs bei
+einer Solution, Solutions bei einem Portfolio) und wird in der GUI erstellt bzw.
+bearbeitet.
+
+## Architektur
+
+```
+portfolio/
+├── __main__.py        Dispatcher: GUI ohne Argumente, CLI mit Argumenten
+├── cli.py             run_solution_report() + argparse-CLI
+├── solution_config.py Solution-/Portfolio-Konfiguration (Mitglieder, Modus, Terminologie)
+├── aggregator.py      Zusammenführung auf Datensatz-Ebene + Rendering (HTML/PDF)
+└── summary.py         Management-Summary (Items, Done, WIP, CT-Perzentile)
+```
+
+Nutzt `build_reports` (Loader, Metriken, Export) wieder. Die Aggregation erfolgt
+per **Record-Pooling** — die ART-Issues werden auf Datensatz-Ebene
+zusammengeführt und die bestehenden Metriken laufen unverändert darüber (ein
+gepoolter Median ≠ der Mittelwert der Mediane).
+
+## Tests
+
+```bash
+python -m pytest tests/portfolio/
+```

--- a/docs/modules/portfolio.md
+++ b/docs/modules/portfolio.md
@@ -1,0 +1,77 @@
+# portfolio
+
+Aggregates several already-configured ARTs into a combined **Large-Solution** or
+**Portfolio** report — as **pooled** (the solution seen as one system) or
+**comparison** (units side by side). It reuses the `build_reports` metrics; the
+individual ART reports are only referenced, not changed.
+
+**Status:** available (Alpha)
+
+## Manuals
+
+| Language | Download |
+|----------|----------|
+| Deutsch (DE) | [Benutzerhandbuch](../portfolio_Benutzerhandbuch.pdf) |
+| English (EN) | [User Manual](../portfolio_UserManual.pdf) |
+| Română (RO) | [Manual de Utilizator](../portfolio_ManualUtilizator.pdf) |
+| Português (PT) | [Manual do Utilizador](../portfolio_ManualUtilizador.pdf) |
+| Français (FR) | [Manuel d'utilisation](../portfolio_ManuelUtilisateur.pdf) |
+
+---
+
+## Key concepts
+
+| Term | Meaning |
+|------|---------|
+| ART | Agile Release Train / team group — the level you already report on in `build_reports`. |
+| Solution | A grouping of several ARTs (references their project templates). |
+| Portfolio | A grouping of several Solutions (Portfolio > Solutions > ARTs). |
+| Pooled | Mode: all issues are merged into **one** dataset — the solution as a single system. |
+| Comparison | Mode: each unit (ART or Solution) is shown separately, side by side. |
+
+## Interface
+
+![Portfolio GUI screenshot](../assets/Portfolio-GUI.png)
+
+## Start
+
+### GUI
+
+```bash
+python -m portfolio
+```
+
+Or click the **Solutions & Portfolios** card on the left of the SituationReport
+launcher.
+
+### Command line
+
+```bash
+python -m portfolio solution.json --mode pooled --output report.html
+# comparison mode / PDF output:
+python -m portfolio solution.json --mode comparison --pdf report.pdf
+```
+
+The configuration file (`solution.json`) lists the members (ARTs for a solution,
+Solutions for a portfolio) and is created/edited in the GUI.
+
+## Architecture
+
+```
+portfolio/
+├── __main__.py        Dispatcher: GUI without arguments, CLI with arguments
+├── cli.py             run_solution_report() + argparse CLI
+├── solution_config.py Solution/Portfolio config (members, mode, terminology)
+├── aggregator.py      Record-level pooling + rendering (HTML/PDF)
+└── summary.py         Management summary (items, done, WIP, CT percentiles)
+```
+
+Reuses `build_reports` (loader, metrics, export). Aggregation is done by
+**record pooling** — ART issues are merged at the record level and the existing
+metrics run over them unchanged (a pooled median ≠ the mean of medians).
+
+## Tests
+
+```bash
+python -m pytest tests/portfolio/
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
     - launcher: modules/launcher.md
     - transform_data: modules/transform_data.md
     - build_reports: modules/build_reports.md
+    - portfolio: modules/portfolio.md
     - helper: modules/helper.md
     - testdata_generator: modules/testdata_generator.md
     - get_data: modules/get_data.md


### PR DESCRIPTION
Fixes bug: README module table had incomplete manual/docs links.

Two problems:
- `simulate` was still listed as **planned** and **without a link**, although it is released since 0.17.x with a docs page and 5-language manuals.
- `portfolio` was **available** but **unlinked**, because it had no mkdocs docs page at all (no `docs/modules/portfolio.md`, no nav entry, missing from the module overview).

Changes:
- New `docs/modules/portfolio.md` + `portfolio.de.md` (manuals table, GUI screenshot, concepts, start GUI/CLI, architecture, tests) + mkdocs nav entry.
- `README.md`: link `simulate` (planned → available) and link `portfolio`.
- `docs/modules/index.md` + `index.de.md`: add `portfolio` row, set `simulate` to available (Alpha).

All available modules are now linked; only `get_data` stays "planned" (not yet implemented). Verified with `mkdocs build --strict` — no broken links. Docs-only change, test suite untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
