### PR TITLE
Simulate: 5-Sprachen-Wahl + Projekt-Template-Modus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Simulate GUI: language selection on par with the other modules — five
+  languages (de/en/ro/pt/fr) via a flag button (top right), replacing the former
+  de/en combobox, with full RO/PT/FR translations and per-language user manuals.
+- Simulate GUI: shared project-template mode — a **Templates** menu (Save/Load)
+  that stores the ten form fields and the language via `project_template`
+  (new `MODULE_SIMULATE` section) and restores them, interoperable with the
+  other modules' templates.
+
 ### Fixed
 - Simulate manual (all five languages): the cover page's dark-blue background
   bled through every page, making the body text hard to read. The manual now

--- a/docs/architecture.de.md
+++ b/docs/architecture.de.md
@@ -193,7 +193,7 @@ C4Component
 
     Container_Boundary(sim, "simulate") {
         Component(main, "__main__ / cli", "Python · argparse", "Entry Point: GUI ohne Argumente, CLI mit Argumenten; run_simulation()")
-        Component(gui, "gui", "tkinter", "Dateiauswahl + Parameter (Horizont, Backlog, Läufe, Split-Rate, Seed)")
+        Component(gui, "gui", "tkinter", "Dateiauswahl + Parameter (Horizont, Backlog, Läufe, Split-Rate, Seed); 5-Sprachen-Umschaltung; Projekt-Template Speichern/Laden")
         Component(throughput, "throughput", "Python", "ReportData -> Tagesdurchsatz-Reihe inkl. Null-Tage")
         Component(forecast, "forecast", "Python (stdlib)", "Monte-Carlo-Engine: how_many / when_done / probability_at_least")
         Component(charts, "charts", "Plotly", "Exceedance-Kurve, Ziel-Marker, Konfidenz-Gauge, Verteilung")
@@ -212,7 +212,7 @@ C4Component
 | Datei | Verantwortung |
 |------|---------------|
 | `__main__.py` / `cli.py` | Entry Point; argparse; `run_simulation()` |
-| `gui.py` | tkinter-Oberfläche (de/en); Parameter; HTML-Report + Browser |
+| `gui.py` | tkinter-Oberfläche (5 Sprachen per Flaggen-Umschalter); Parameter; Projekt-Template Speichern/Laden (`project_template`, `MODULE_SIMULATE`); HTML-Report + Browser |
 | `throughput.py` | `ReportData` → Tagesdurchsatz-Reihe (inkl. Null-Tage) |
 | `forecast.py` | Monte-Carlo-Engine: `how_many`, `when_done` (Scope-Wachstum), `probability_at_least` |
 | `charts.py` | Plotly: Exceedance-Kurve, Ziel-Marker, Konfidenz-Gauge, Termin-Verteilung |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,7 +193,7 @@ C4Component
 
     Container_Boundary(sim, "simulate") {
         Component(main, "__main__ / cli", "Python · argparse", "Entry point: GUI without args, CLI with args; run_simulation()")
-        Component(gui, "gui", "tkinter", "File pickers + parameters (horizon, backlog, runs, split rate, seed)")
+        Component(gui, "gui", "tkinter", "File pickers + parameters (horizon, backlog, runs, split rate, seed); 5-language switch; project-template save/load")
         Component(throughput, "throughput", "Python", "ReportData -> daily throughput series incl. zero days")
         Component(forecast, "forecast", "Python (stdlib)", "Monte-Carlo engine: how_many / when_done / probability_at_least")
         Component(charts, "charts", "Plotly", "Exceedance curve, target marker, confidence gauge, distribution")
@@ -212,7 +212,7 @@ C4Component
 | File | Responsibility |
 |------|---------------|
 | `__main__.py` / `cli.py` | Entry point; argparse; `run_simulation()` |
-| `gui.py` | tkinter UI (de/en); parameters; HTML report + browser |
+| `gui.py` | tkinter UI (5 languages via flag switch); parameters; project-template save/load (`project_template`, `MODULE_SIMULATE`); HTML report + browser |
 | `throughput.py` | `ReportData` → daily throughput series (incl. zero days) |
 | `forecast.py` | Monte-Carlo engine: `how_many`, `when_done` (scope growth), `probability_at_least` |
 | `charts.py` | Plotly: exceedance curve, target marker, confidence gauge, when-done distribution |

--- a/docs/generate_simulate_manual.py
+++ b/docs/generate_simulate_manual.py
@@ -351,6 +351,16 @@ T: dict[str, dict] = {
                  "sondern eine ehrliche Aussage ueber Unsicherheit.",
         "s6_b4": "<b>Scope-Wachstum</b> realistisch waehlen: Bei Epics entstehen aus einem "
                  "Item oft weitere - das verschiebt den Termin nach hinten.",
+        "s7_t": "7  Sprache und Templates",
+        "s7_p": "Wie die uebrigen Module bietet simulate oben rechts eine "
+                "<b>Flaggen-Schaltflaeche</b>, die die Sprache der Oberflaeche zwischen "
+                "Deutsch, Englisch, Rumaenisch, Portugiesisch und Franzoesisch "
+                "umschaltet. Die Wahl wird gespeichert und von allen Modulen geteilt.",
+        "s7_b1": "<b>Templates - Speichern:</b> Legt alle aktuellen Eingaben (Dateien "
+                 "und Parameter) samt Sprache in einer gemeinsamen Projekt-Template-Datei ab.",
+        "s7_b2": "<b>Templates - Laden:</b> Stellt Eingaben und Sprache aus einer "
+                 "Template-Datei wieder her. Dieselbe Datei koennen auch die anderen "
+                 "Module mitnutzen.",
     },
     LANG_EN: {
         "cover_sub": "User Manual",
@@ -427,6 +437,15 @@ T: dict[str, dict] = {
                  "an honest statement about uncertainty.",
         "s6_b4": "<b>Choose scope growth</b> realistically: with epics one item often "
                  "spawns more - that pushes the finish date out.",
+        "s7_t": "7  Language and templates",
+        "s7_p": "Like the other modules, simulate offers a <b>flag button</b> at the top "
+                "right that switches the interface language between German, English, "
+                "Romanian, Portuguese and French. The choice is saved and shared across "
+                "all modules.",
+        "s7_b1": "<b>Templates - Save:</b> stores all current inputs (files and "
+                 "parameters) together with the language in a shared project-template file.",
+        "s7_b2": "<b>Templates - Load:</b> restores those inputs and the language from a "
+                 "template file. The same file can also be used by the other modules.",
     },
     LANG_RO: {
         "cover_sub": "Manual de Utilizator",
@@ -502,6 +521,15 @@ T: dict[str, dict] = {
                  "afirmatie onesta despre incertitudine.",
         "s6_b4": "<b>Alegeti cresterea de scope</b> realist: la epice un element naste "
                  "adesea altele - asta impinge data de finalizare mai departe.",
+        "s7_t": "7  Limba si sabloane",
+        "s7_p": "Ca si celelalte module, simulate ofera in dreapta sus un <b>buton cu "
+                "steag</b> care comuta limba interfetei intre germana, engleza, romana, "
+                "portugheza si franceza. Alegerea este salvata si partajata intre toate "
+                "modulele.",
+        "s7_b1": "<b>Sabloane - Salvare:</b> stocheaza toate intrarile curente (fisiere "
+                 "si parametri) impreuna cu limba intr-un fisier de sablon de proiect comun.",
+        "s7_b2": "<b>Sabloane - Incarcare:</b> restaureaza acele intrari si limba dintr-un "
+                 "fisier de sablon. Acelasi fisier poate fi folosit si de celelalte module.",
     },
     LANG_PT: {
         "cover_sub": "Manual do Utilizador",
@@ -577,6 +605,15 @@ T: dict[str, dict] = {
                  "uma afirmacao honesta sobre a incerteza.",
         "s6_b4": "<b>Escolha o crescimento de scope</b> de forma realista: com epicos um "
                  "item gera muitas vezes outros - isso empurra a data para a frente.",
+        "s7_t": "7  Idioma e modelos",
+        "s7_p": "Tal como os outros modulos, o simulate oferece em cima a direita um "
+                "<b>botao de bandeira</b> que alterna o idioma da interface entre alemao, "
+                "ingles, romeno, portugues e frances. A escolha e guardada e partilhada "
+                "por todos os modulos.",
+        "s7_b1": "<b>Modelos - Guardar:</b> armazena todas as entradas atuais (ficheiros "
+                 "e parametros) juntamente com o idioma num ficheiro de modelo de projeto comum.",
+        "s7_b2": "<b>Modelos - Carregar:</b> restaura essas entradas e o idioma a partir "
+                 "de um ficheiro de modelo. O mesmo ficheiro pode ser usado pelos outros modulos.",
     },
     LANG_FR: {
         "cover_sub": "Manuel d'utilisation",
@@ -654,6 +691,15 @@ T: dict[str, dict] = {
                  "c'est une declaration honnete sur l'incertitude.",
         "s6_b4": "<b>Choisissez la croissance du perimetre</b> de maniere realiste : avec "
                  "les epics, un element en engendre souvent d'autres - cela repousse la date.",
+        "s7_t": "7  Langue et modeles",
+        "s7_p": "Comme les autres modules, simulate propose en haut a droite un "
+                "<b>bouton drapeau</b> qui bascule la langue de l'interface entre "
+                "allemand, anglais, roumain, portugais et francais. Le choix est "
+                "enregistre et partage par tous les modules.",
+        "s7_b1": "<b>Modeles - Enregistrer :</b> stocke toutes les saisies actuelles "
+                 "(fichiers et parametres) avec la langue dans un fichier de modele de projet commun.",
+        "s7_b2": "<b>Modeles - Charger :</b> restaure ces saisies et la langue depuis un "
+                 "fichier de modele. Le meme fichier peut aussi etre utilise par les autres modules.",
     },
 }
 
@@ -737,6 +783,12 @@ def build_story(lang, st, images):
     story.append(BL(t["s6_b2"], st))
     story.append(BL(t["s6_b3"], st))
     story.append(BL(t["s6_b4"], st))
+
+    # 7 Language & templates
+    story.append(H1(t["s7_t"], st))
+    story.append(P(t["s7_p"], st))
+    story.append(BL(t["s7_b1"], st))
+    story.append(BL(t["s7_b2"], st))
 
     return story, toc
 

--- a/docs/simulate_Benutzerhandbuch.pdf
+++ b/docs/simulate_Benutzerhandbuch.pdf
@@ -635,7 +635,7 @@ endobj
 endobj
 29 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260702002827+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260702002827+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260702173404+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260702173404+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -653,10 +653,10 @@ GasIb997OU&AI=/I)feqV_`f!8.e9WDu_(W>dC?`">pLqM3.N*aJGikeKSPG,?aV$/RU9nI('3^WNk:e
 endobj
 32 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 802
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 831
 >>
 stream
-Gb!$C9i'M/&;KZQ(%3l-]^5!o:R)J566N[d>:s/SZ:S:IS)?9)lE@DB!Fc=:Q$`Sb>"`2h][+5P1B\0tC=_>`36H5c8g&\4$rTbB^Vi^84=#kiV^-hUF$aUqO`AMPW_!i=iJ9;5SV>?G'36&C@cW>AH&VJ26@>e)Eg/f1&WC,G#QZ:Uj2q_iEu^d/"-0IFkKHBj_5a$/B1;3MVE"-T?2sTJZj<H(ol.Ktr&=3FaOlBON+%UNr/]4t\u<e@81VG[<-9]2;jlZ$"4Ja[!_dBlWOF;^V\qL++WQ]g.'jMK#95?'A]utl2nl@V6p&%]7+QlkUF_J`W$ZJ3Q@p&eAB'SW>[\*o"j9H:mCsNVP,mXeH*Ph8%U!5.-?9sK]C2ke#=iO;*`9frMr55#o.Vb.D.Ba*<E7>P<9#$LdV&uFD^.1%ZkX>j9.tR8FamRK-)H?U:sZtLl)9FbfnQ\IlDol4ZS@`g%jJNmq7W8*[);M[PW]<Z\&A^9WlB*-I-\^.i_sh#IT24s<QsW.eO<L8cq,bDVp\2-P[RJFqb^5fZBLMP02g>a<8k@ZpjV\4nZ;5tWQ3iQm-"3#?5I_7YISaNArU:BE8A`=bl"KQ(/2.=99QX*$&<+T[A;m//-j)U^)r_2Ackj*NEb-OR[o"AKU^q0l-kPZ(mcHhrha>IHK)P!;nMEa=u,3@pqiWq[n>T>cd;Pd&V`K_=BCQg*H"N2a3r:]G>edZl^<TPk3Q1BXM80V\Zb.,8:UH8p>p*2-IK(B"H7b/Q]l=5A?S"&HHm+T]Nd'j]7=n78s&rQ.Q9\+~>endstream
+Gb!$D>>O!=&;B$?/']@UH.gl_T.2!:66NZI\%M3>P"jpch?:kg<I]F.#Dc$gWar(O>INVCcM?Vhba?2^61&_u!66OKc3P\W:-jadUfTNMUPFYFl]`YKE_].7-5'(15rji)3#lpM\[0Y>B#89b8W4W$8rr4&6ti`D(*0;KEWdVS1d\ta_76cPBn<$8EQF9Lnsm6[IW(bnocgG!iY]^"eCAJEcEf48YK-6_Ud't_1lS!Har%!HbC9e'eQJ.j6X9K<ZE-+GQqA?b$(+a"(LUF)7(l>]36fMn$fRIP7[]6t4QLI@:r5o,1\,hQ+hHX7,-hEs)J+3cDU\f,cD0mgN(fUYRO]*!;QthMg4!76'O=3>d>OQ5ZcNQt1m,\ckWcOO*ZVH<H:0?3;Zp1S]*S"Ed5C(_9iYb(8$uL[:E"(9nSQ4QS@6:$Wm..'q.[[0PT$u]H4KXB7r9g!2LJe/s2q:rgSAl_:'C;P^Gche&B"ecb(55!gMDjs?/`=-^@^BI1EVK)n?#s@b,d"qY-PA(TpO>d&#GONc,2*EpQM]LGqZ.=K1ONX;MC=ij6OB3Vi/c[k8nhokMIr\p3WKI=Ej"\cl+8qi2.Nt=SR#g0dLcEQ6^+"'+XDWl:B$f@1J$Q^#(Q&bQa[2/%;r9Zn$Kl&OtgBb/]jl0[1t/r/T+0HKP)eZb-0'=u,3@pr&a5[n>TNf@]sl(</PPXNSY]+)Z.\a4r=qIog=;ouo78k3QaRCq*mdW@s/l`'8WPq0Z%p=lWU"!iE]5nl`_?_@@J0B&Fdd8FtAHh++t:4T6_$`Fr7`buh-d"K=%Tc(FhAi9#;*+o2;58SVN~>endstream
 endobj
 33 0 obj
 <<
@@ -681,10 +681,10 @@ GatUrgMYb*&;KZP'Q[20h*s6IU:OGX&u96"Ft_PdgL?9a=rL%M,c[]:HJtc/:ekigi$OB!J.0U6s-\B!
 endobj
 36 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1007
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1445
 >>
 stream
-Gatn#?Ye^\'ZJu..F(R0h-DOo/Bdb$,rAOmQbmXq[.MUmDT:tonjJX"ANkO)B9Jgm"@=OA)^P6Nq`FQ;$?0s?p"`?XFcFS(J<6_u+V[kR5N/J7*YQJN;Ioo'PblTE0NiBmBt/"h_,1Qb$=4LhX.79Uf>n(.V%@U!qfdl^I,$WjY"s'>>-^gpM,Hsc<?Y48\D51"*7ZOb=W-<S]U>(j$%t.S2;'8qa:4-rgSGk'8,Xh#G;7.Ea@^6F7%V(8FBFu>At(j8cRt`AA#_#(<e9A4iY!fgAYoB_+Np:3;AG9>bEQ'(.$VF..&0VXoVut*-4ofppd,9aBWsh(K#_e/PPF]Y@\945.]1CZ.nn#?aXWFPDegS8PL%?<nrudEYUYun?:uD?U!QNU6_^lDAHb;h;Mo$hjem\XQ^cZ&^X"LDmg9\%gGU@E?(^^XMQZ9FSs/BDNbA,q:-QFSe)`=)]MrNYDfUg^M`t-ujf75B39hQOS,CAc+]d'pg6P$Q6qqPS2SC=OaGc&5,":=($*E_W/.NV>_/+OmES[0Z^sB@#2a,h]qT2i,Q9ABC^/VeF?c1%^3S*NPs+2cOh`=IO=ld`";4IO@T/FD7ZEcTV4c:mK</`E[.iHquh"K65JfjII.[B"ZW/%9i+M.teI)$t0Md&QA^RAFn:Y+"IP/Wcqn)7sKk'f<-Eb+]"O5lX@Y@ai8imhiirnGm"AJrO1/Z:V:a&VG"2h[7%0c#OUUi6TYb@%d>n->B>RUq'u)`\>cDKZ+B+916CcI"6e7Gi?+aSJ0iM;k6W5;ZjX)oH0p`9kro"29rQ/`[C[6Iu#55[IAkW$Q(m+LcP/<pNh%K'(secRfRc"*S3+mZ*h2"8lt^EY]?be)2DTiG.n&s-\*H^ooX78o>abh>iq6:QPM_Gh^Ji8q1Wf_1uTRULl>H(uGdIChOY1kqs@6lqQY/2Y]N>=Yu%DR3qhGBYo-=n/,f9ULR/ndCte8h-d0eS,"lc@%2&L&2!i^.?XN;FFVCt~>endstream
+Gatm:9on$e&A@sB]Lr8Q=_UHaqT:CJ>o,rY2Mot[-uu#W=c'CO3><2Erq-HZO*+VWZA4-B9-C'VoA7+tRY-0Bqql]"DG"0;3-^,I*aF@"j]gN*Mm&&#A\!UW6D!@;S03at`etP.?"bqQS:qj(1F,C%7Tklujrr&2LEYHf>]@36Bbr_i&WS)q_DmN!jA?UHO[UZ'>d'l'%#'IL@IE'?P8`Ri>!`eYL@f<VA3-]ZC9G/b.)2F&l#OFm/CH?h4Gf[Ag<S-H;$ViaUTkWo6;cep/eBA(?kL7$M$ic[$;mCJ4;Sm04H)]YdK<>DMBR1/7@8Ck2(;0h0>hFSo.3=tV'9F;lHg`&pj&RZb/?`9jp;\<OMk!un5qfSoiNm(0>9&6\R\iF,Z0m(&o`s>eAL;36Gu;0BC,DX&7M)djB1ojokH>$?Xji-f,8R2<AJ2ah'>Z`]WURp@DqKAAhe2D`V],^deo2:P)B^T-`P)s4.Q]j-6cq;(s3'7X5p&pk?bMS<>@j57S.2g3qu7cP3Q]9,![S]6DZ$qB7gp:X4kZnmro"Jna!.B<C;'S]N&-t%StLXhkT%nO3pSP-*>5DruJ9cI;g)hE/?]D'W'N$V[ESh!ZU5;YSXQi$K5H8hi_l:_6c_9EH^PI%i&JHe6jK4-g^r$=4iYd==XIO,<$AIl&#7o1d60A_pHtnc+I+g87OUPrInjEAh/c*d;0j%Vks:fh"Q@QkbN<Q2q=_hcG%;hdb)l/ftE*-44TM1hk[?9o72\)j.Q`#8(3Tgh#!Sg(tr'pB]Og]l,f)KYuin@FgA3D?$L0t\)"*r_`'??REYY%Pgf7b./O]jWlQT*a_VDh0>2!m8D-eTftpRL`J0Vs`rf+cKk]$G)%CU^;eI'\_OGgkqe*ni!.S`2.%-*[I0.5EGm8ldHJDEf8_2^.k5g<JY9p<I]#.9@f/oigUi<eCo`W]dZIG"kS0uWs^b:uXN;")L2`hHhML)/nNQb@GMCNQ,j,AMSFbe76qNOl5rgYR3@D+PHQ!r5Q8fG/+d/%b*a5W5IB8@4V'kU;Wk8DD_Gk/B:IV\aNOme0q.\g1qphaj0hT\ZuA8se+8([ZnlHUFRa/YJC90-2,Sa>`l0<+@L:0M!"M!fV!fK?MUo6H%8Q=P:%m[&E&A<-+g^N27[NE_k=<-MERdr"R)Y4,j@,jE5F]@#9A<A\uZ3!!)MlMYs2(abjj4W)i3/oMK`PO*V^P\JLmZmG0`lXP;]25D1&7hmjaEbEH,g*#P;);=$8!X)UI;q%r?Q<NSfKA>+II"li;\'c#QoC>pc;PZI0GLFQ`/=Fg;0Zh/&9;(pf(L6nI=rKrr8IhQdcAZ+D@tPGDi'Th35:.H5nM:i..i[+.CNhts#G-t3M9Msdc2#=g`]HTu)0BCUga_lMesZ9kOj-F#qpA8bhPASZ`WtZ;b52-ss-j9rr!TjDp1+~>endstream
 endobj
 xref
 0 37
@@ -721,14 +721,14 @@ xref
 0000259436 00000 n 
 0000259528 00000 n 
 0000260146 00000 n 
-0000261039 00000 n 
-0000262828 00000 n 
-0000264685 00000 n 
-0000266374 00000 n 
+0000261068 00000 n 
+0000262857 00000 n 
+0000264714 00000 n 
+0000266403 00000 n 
 trailer
 <<
 /ID 
-[<488cc54a14d38fbdd93449a179f9c14a><488cc54a14d38fbdd93449a179f9c14a>]
+[<7520cdedf1c132f72618854edd580a6f><7520cdedf1c132f72618854edd580a6f>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 29 0 R
@@ -736,5 +736,5 @@ trailer
 /Size 37
 >>
 startxref
-267473
+267940
 %%EOF

--- a/docs/simulate_ManualUtilizador.pdf
+++ b/docs/simulate_ManualUtilizador.pdf
@@ -635,7 +635,7 @@ endobj
 endobj
 29 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260702002827+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260702002827+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260702173404+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260702173404+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -653,10 +653,10 @@ GasIb95bIu&AIV:pl;1!P8V,`/YYdl8d,u*>YO-.M`/334ui&tO[Ee[:k^IROu;-<":U#)n')o`WNj/P
 endobj
 32 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 804
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 827
 >>
 stream
-Gb!l\?YeCM'ZJu..F)GW&lnr`4cOSi9-Ig2QG3#\F.>oKYo:S&A"S4kBc=Hpc+pOnL5cTW]'"9uY-&Ti-s/PH/)Y6$dgHB"0qEqg+u,YHrA7_kK]Y`2#/Z>X6@j)KRFR+OX9+)aPiU?T:f\1".h0<#1Q3KCQlfrLl%t>bCjIbTTK*UQEu<1/PrZm,L!pEY6=F)D8kbBiD>^D:]"5h)N"<(+g_-rDS(]Oo0/j:/#h/70*[f6.FK%-[9Skt>?T5.]Tc1uB0#Y=7N_!raYTQPAb!D9O<^'61)b,e9#2Bb5[FAD(EC+)sO<qKgq;`=*Eo>dK\R[8C+M!du:#@5:nbFr@*paK)BVVNE$;,8HR?7;q974jaZZZ!"WS&oHGto&`#0!Tlo/__)N:l$Qf#"=WQsb#9c$WB3aKM49Q,[oFdi?'QBWI$Y,ITJ;(Zm:!?abEjJVk*iKL29'G/8?DXGnOIQEP)hUQ!p7.@&!_&^8`%SkUolTa)0eJV4FRZ#30u#hU/R2nd"q^FCqX<TOVW+p.1A=@BW=]tD4p.^-XA0><]8#0]](<?9ns+.1/9^iCR%`*<#:0&t_%-#Q5>2cmIYIDC$Y),gW_'ddKAL0-'6*MO'mXP+`"1/3T_-:cgd3_JD)V1[^p^G#B"oG3gn-O/tCgR40J$uI(YG?V#_,#iXPWktUuDGu5#h?G:NJ*7`i]-dMrm>:dEPd@YF]Yj,Mh70HpS,W#po0^Q=7BG;Gr(E%ZpIaB!DsHQ$2SO-IP:Jt"/=VV,pQ!Kb^L:SJs3LlFLW6kXgu]/%NRo&Rhcsqe.0~>endstream
+Gb!l\?VfE1'ZJu$.F)E(@=8#<:X^-_+YdhMjc('01!EQ8dkmVmIJPBAV&=u#;C%Vd-$#e`^?9^$YHJ6P*7Tte*&sPLk`e=6di4BX$I]BqT4X"?EU/i70QKoZ%46*j\NtY5<T%i7RH;^\kF)^X%4!ZK7&U3*p+o&4e@4-$oNmPc"Hu:\3$B,?<a[u/dA]+`a?+[m>Ur$A`qaB3Rt/CDI.5\/cVPrn2/sC]q(gKIR"!(t^ZFfN=2lp_>5gtcB'#MLWl$mQV7PoF@k)\-k$VBS>_$N?EqMC$iJ9L**/%g").hAcnpnWc69-imc6n)\.hC$gD\\Bl@+HaLgM\SinG+W9*pf"L1JW"F3OBJO-`OQSB)%NpArH#l;n$(DKk6^oTpQ@/?7unN6aJY,3r$,r/hf;hb#j<<q;mg?b,CnH43-eI\uOcELg<_lKnWLl2>n!6Jgi-+C^[WW[\9HKQ=OdF^8ZTme?*Rd\TfHQH^ruW$$$=2UBosP6Gc5D<WN4-Rfi1m#ah--<FCCL.MgF`8@Y_LD=-M8OOo:ijcqfb`O?EEKJFZL:$p,4@-L,]X-(1)D\9#se2P)I\=T3rSR:gp!n4YHVFL]'>_KO(l7hg(Wacs!c/fEc):!9c/@mIa;j'4**=OV$53!0A2)+8b#&UWWR>GO/XqA(.>$HYKWc"Q7$K']ab9GaOFsnm?6cT>dXm."B40h)/:kl!+*nQUpb#_;@%NbsN]8g%=npCQ/00(rI.uBJ"D!Le<'aroA\KY%mCpip"hQ\gF)^apM#%C%[&;-0KpuN(GDV',)5`>4hVR]444I'?@SmZEUb7*'Bgequ"~>endstream
 endobj
 33 0 obj
 <<
@@ -681,10 +681,10 @@ GatU2?#SIU'Rf_Z3%m_L&(;dm;H/E[kf5FekdG*pJ3NVe>,#;GP*f'D>4gDWPT32"OsWP)fE+a/kM1.I
 endobj
 36 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 985
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1389
 >>
 stream
-Gatn#:QO6g&B4,7'^npB9kl:P;3\H.@+W*a:XV9hY@D>6AKZh9;@8$SoEAeflO@6D&JPFcR3:Y*hom#g84]]@gC:sq%;s`(8n52[1;[Gj)t#Z(@j,C=Qr65KVU8rYTj+L"MmtE082Nqr=uJ7<[M$0S/4q3fUD+n^pU3o>T=?Q2Dbb<[<f>C@NCI\,9s(Z<E3n-a,hb[nMC-N]8Ud%RRM`(?I]%1_*aQRZanPdk\e'A2jteo6Zd4Qp``ceM<PG4*1t1O'\;GY>EOmPG9\[XoKr@Zq2+1I/epNOP)^QD4)sBbU`Ys1<.c3fS=f<'YdJ6%S58*<orRrZ">DV"%>3=]nVt&BB`V?PuALhRq8V7%DWC<j[o6f-Ln)@jI=IdXc[:h'rgLUl;e-9e=*XboTU9*J@Q8,,@VE.Gb\64SHr"HMJkA"&)h,5K*lRGJ03To*kZ>ue*-14+inV*KMNZP7@>c>?9D%^Dt<3&IBfW'VCVSgZi3k%h_V/'k](GN>.o4a)24*sHu*Q*TYolHjX'fo+s3?T!U_2f;h_LUL(&!Th5GFh8oinXF]9A03e26KPXEa@RR(LScjS2GGBd0koPSTg;N&o^9?2]&b9[?ZHf[FMRMq+N"#:MEbu\@%7E$?s/+H(,$ajpm7<3;^W+OUj0go956nY;FYBj2;3?3"5nNH^[:n62[WTe(.T;B(":Hr%f>upr"m0&(HXRO3WNCI(IT%%ig#]Z8IuN*rS.bLO^uPY65YNj>.)#&G_5kU2`YI1K"46DN;nocSTZ<3)Ck'E,oCR35,IHgA_3K%gkj9)gR]?j!"!3R?O4pRT!uJI_t)+pL"fZ;+ff6jY)1.4q<gDi?=/M-9@Ij##+N]j#HSXF6]rMQ'X.^+6C(00(][bUFpS-5*'4,e`=Suo><3!JIn5qT-h-Tes$^%Kp32J_uo]Q$,c*W9)-8!S.Og3L3,.CT2GY"LH.g*Tqgj/9#<4C#^d/Aia66(`=;~>endstream
+Gatn$9lJfF&;KZN/)Eo"-h5W\7"+m^e8\<XBps2QoT76I27o_/M)%Z!JU`)6m>':Z%JsNaYfi;&^@TR]6RkVtW;53?_#"j!XqaojeHSVRNR_tBYZfg6KWJpZ.gT/,=^F@(NDrUY^Kh80W0J'^X=FuZ+gS*rOXm,?V;N5\[gRo^n_;%[eQu"EbX>cL)<rad;HF`:4YEnDG7r.O01DGmc[tP^NZquD`$ZHMlHhTi*GoHXWHJ1L<ju2E9lZckY00^V<TGgc5#)fo)j['ckMs[-68u<r)i-g>14q!4XO07AA@3&X/o,"*aE=K*SP];\U/"%7-tf)8BPRi>H+JL%Q)[H4Wmm;-^I^&qT-"le0g0e,b.<ZQ4c2?8NQUq3ZOVI:^+A[fLL@,S1dtH1EugLJ1ebZo>Ni^3GpW3kZkdqdMga+l(Y?t,s1#JhR#2W\f2Tr;["Y;L).T+9Z8/tQ3Nh/sb9OR'hSiUHqF'^>Bp6V:U7+b4F]mde=LGZK/e2SoC<kP@h$W@=>hK\%>u0%56d%0$0\mGa@>WQ55Vbl@hqN]EN9emEiJ,3um`*[_8/uZbHn>/'ob:IN:V!(bJOa+ko"f*V#F!Cd-*F>CE8lBqA@),#p1/)A6DqNIgmI>oK\u4RVW=mqB;m2[Ga&%`oa&bn!on1(JNZ,VhR1hGp#,9QWTPE[*-r+.KBJ8ho@Ab2_phERA=/5NAT<//])piqG=VnF6fc'c2inK8.K5ICF_qK1Uel:*)X;X(2;.F$j1OOW#\!B'c-Fm"+Iio%^k8'Q4Q2S1mKb%_Jcc8<L6hcGJBRKuJ:Ar%i7=KdM:@TX,:?640PYWF.Ie)6\5NkqSd^>2cKDqFg0!62C5*ZdE/:mUnd%pnK4,ktSmK3t(U(XI+W/heUl65<_:V_I\Q=E',H&Atq4?N43ZB8Kc>C_!2(g.B)nF"T4e\KaUk!B2cN.p@hM%.sg(576+"-L`KU1W3P_>#l(3fka<3P!,'n1#%lNrO,[G8=U><LM5[(&M1,T2`f8eh]6J"_atP<ZfC>>^`Ml/7Ttl<QJo/tBi<G_*F8V]Gp60K,=)Xn?MjHqLJGg`<M4)HsS@E&TMMMsL\#3tTLJ;'nn8ApKT[B6M>P-HejO)bLH)oP$&SjN_1hD9(TThXs"@F/3Spg.iX'ak27)+Ro!XLrho@m6n[bQGAPlcURKQFuS[1kWGST'CZV-q82;e^Ojp!m>?iK50e`U99AW,Sd.kBV;!EB.A1r+-aEb[cSjA0YYE*qfs!W;8pu,?gM&X;?E#62\NZg48-cqZEN7C2A8*lHGK\C1AQ/UkITGX8MZ4'0ceHD,dhsuf!f(_%T.ZEm`S@<;q@r](!XX6<P4(#uj.+MnF+c]R5cqp`lT]RhO7ZQP#Fn6Gnc~>endstream
 endobj
 xref
 0 37
@@ -721,14 +721,14 @@ xref
 0000259436 00000 n 
 0000259528 00000 n 
 0000260143 00000 n 
-0000261038 00000 n 
-0000262707 00000 n 
-0000264466 00000 n 
-0000266042 00000 n 
+0000261061 00000 n 
+0000262730 00000 n 
+0000264489 00000 n 
+0000266065 00000 n 
 trailer
 <<
 /ID 
-[<f7fc9be8bf13723ae9f46632fb523f27><f7fc9be8bf13723ae9f46632fb523f27>]
+[<da5b02bd2c7ebce8e01abf190650fe49><da5b02bd2c7ebce8e01abf190650fe49>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 29 0 R
@@ -736,5 +736,5 @@ trailer
 /Size 37
 >>
 startxref
-267118
+267546
 %%EOF

--- a/docs/simulate_ManualUtilizator.pdf
+++ b/docs/simulate_ManualUtilizator.pdf
@@ -635,7 +635,7 @@ endobj
 endobj
 29 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260702002827+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260702002827+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260702173404+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260702173404+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -653,10 +653,10 @@ GasIb95i9E&AJ$CI)f-Laio('f-6**W)UQOiaU>qZcH:)XaTH;8"19WJh".UN\m3n2'ZK_jS3Ze^f?0_
 endobj
 32 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 807
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 832
 >>
 stream
-Gb!$E?VfE1'ZJu$.F)E(ebFX\Vb(t4+Ya9mGiQcMDWRilMsJ%Bdn`^f/JPK^d0<5(8?mQgmiGinKRn`,[GuK4S5hO3B4)_0'MK-rl3cFKiisW51f?"=AdfI_KNlU#7[t2N-k)lHUo&gNMXXMX#Y(1i%+/R2>VP4hcAJsn8WH)X+uJI:S.dAFNbX-oF+-Ga>Brh7Q633GU7&XS0c]2bWuF"<`8`J(H2-LL1*3.cM<['AmR<IG'?QL6Mt!]c.4jdnoW)OsHf9dfL'e<_Uno&!.;n851q6u488Z-O&Q298&J?H*-4<tN>FfOg$ag)oO'bN!8e"[5=jm5lEZ@:rMYc!I@>Qn"8h?V<-^G(LHT/u^EDnt8c^pTMU6:j20kN+GFDp#B+r!DX1PrO/\Iu&!(cA?2lLc4pc'u#eQp'+b8"W3'ZD+smD,K\b3QhS.4MKH6`JG9qU!-Kj?s>bE`Y)ea\F8^@PhNN*Q`G<SR"GP!bV1!1HQe9<L^YL=^J5j)"7`3$=7ZsAjg\X:3^iG@MT].EMe:h!:1@WqPZZj+XFlR.gL!:<U5Q`!R)r[MZ6ulpAY"4=]&[fp\@B/`5O-+nrJm918ZONPWNCs>EhE;/3G<bib=Y4)AK#EXg(P,)>oa(Jo7"`M/Lj]&gt;_;1BU&_0'c(Gk7?:Dr5R,[I.UP:3lM<hnT*/_NUlT20L:OQgjD<#re5tEUF&17m,#[agc@iaqn^o2hgI,%H"`]\7%09g@cR=^-1Edn;[a12$E\*m:qQX$p#K=?l1RjDC+$T*441R/]%"YWH:T)q$5C5UT;##$~>endstream
+Gb!$E:J]_1&B4,;'^ll(=a'MR:R.RV+f,g9E9"5L)miW)KXH6mVm#FeE='.?X9,\=9=B$#Dr/cu:#Os&p,ZCY-W;"W&P-<@!%Fd!S`&6ZHcR&5:.YL3kCh>m,3P10V#.4nLEk(qG8<6k9NZ-SM30#L$<S9[K]Yi"fu`k`NaN!R7L1ss(fsaG]#+!*39&"`H-TY>5:Y]n?MZ-Z4N;SPe:*7"^eGQ1nX$H1klB2)Ql\/US`n35VF\m[#[c,rMX+`A_If@=:,o+ka(5aX<R(c8efn0Kdh%P,;oV*_-C%G?.jU08>U,Ihe*:37qcJ*!DLAL@X9#Xs=l.pQ3Ir:8=n-<hbaEI>/$,D??o^fdHa^k8G*P4$c^q`8+tG4n6k6P's5nG:i>A&T8^tU9Pq^&<[,.T\PTBCs=(RXo*SKQqIhZV?MXNm?7C?&0;Jk$-G>J[EUsuUXePi\"4DJ@t[KZ$/qF=0Fg*W0.)\Lk3K!/e-+c$XqPQML(VZEKm!hL=i9-5cHo:`YqQg7Vh'Ke9fI@pG;?IlBJfSC%aQ8je6%&n.-9.[+(;s4CND@j#j#cquB<$<i@j`*@C^U^j;kf'B,4f/JDC7N;D/VrJW62S-;aQ4Hq=j?N-%,+"t&X.QO*=VC^^1#;#.d7c;m"!hL,L$K1`B;G70A<l6Agtqk$J:$+8i=cEHIH)YG/&GrEgAfG5+c3^_a/k&3o0VO]m89*18]TVdEG[c^G.S4)lFu\cAGD6gi1"R^;dHNnZK$(le3Nu^A4aSoW=MTq^1[&H"%!''8,V)YNjV!7.t97HQlWeip+gaN%"Y\Ep\cd3k2_,A]T<&/h(hK~>endstream
 endobj
 33 0 obj
 <<
@@ -681,10 +681,10 @@ GatUr?#SIU'Sc)T/'^l:oYWN#8TbjSZsAOjg!FUXd#6a#;maS?VHf#$JGf7pP3jZsds*8B6qJZi]R8'&
 endobj
 36 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 969
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1362
 >>
 stream
-Gatn#:QM;0&B4*cMKaoafaT"W(^"j&C:A7UU25QT;/S7g]&e`+N%n0dT0>"nJ!`X!N1pT7(=:R3?bLb684]]Hm*<De*`iRMV9pBYN%jJ1a611H.th_B;^i"&[^rI^F=1($&PkiG7'!+sAD<dFC8%-NU/F=c8g,sMmgFhs`)H32IumU5>#\O<Zs!iO)NF`TX+UBod;AGPZs!Caim6p]M,BT6J\k#(#0&=<O8ba!'Yd-;48S]^cWt['XY?cXhG?D<Pl)6<aR^+pY+.1O/#s/S2P&>/FfdasG7<:Wd2Lb+\"YY/fS`T!6))UjSZnU/:NZ/Y@/'=5UJt_H)J^7ZJ$YZbcefJrBfoBCCg0Pb1[7Sj:0$HPhM@Z\96"#q2UaLWX*%o2+-^IJgpspF9\#!"OUqII7T@sg&$?^MLFJgESSlEo26?$8Q<L9D:eT6Z3S+_'Q)gFVn7aAd]TBJeV8p/)41.#,9qod_l<;SXdSu=l#@&;7a0@)$:$pk7!p1Dnr0!eh?'D2Qrm:tnp.%T/HTs8t$A=Q8:Y^iT#Oh6l5.JZ97i%0W04.>$mU'J)jdtl4*5$ePmIS&k$]s4q/8gK4f'%=)n;=GfGJ^uWb/36)C5Z`=-P9,b4/_-c]:2oZ)buV[eprI"^d*qL8*&a9&0fG?)HN1Xq+l#;jERK>,>sPRpt$Q]f=]gI`dV-U^\O!^`]_?Kb8M"@8/uXs.If8BbT-RL6giTH8=Q_SnqjS1)Am@Llk8G?S\fJE-kTK2DN,P5&`VW/,L_f"@HN[2$GlpLg_pBG"0/d/"6tptQ?A3eB#H[Lc(9mh[%M\KXi+9YJX==.4'pQf"6Xa?7j$'A4C\`2Un!0NNr0%EKB&>H=pH/+6<3Ef'E=?_gQ>9WM-S7F8)?#4\7oPCVU7']3bOXhmk-^IT<jT01*@%=0S.6.\"Ek8/:X7>3&(Wk(nXNMcM*`IZtG9\+.t%]!b1H2Hi~>endstream
+Gatn$:N+uW&B4,7'^nr88Z_S;s3nHQM2MFLdF9XB'Y00g,@pstaXicmThf#(C!3d_+[-_E,`7i[c#;aX>ltNF1V_ZSGdkN>NIa[*fth2K_r`1-Cf]Fo8s`PD)CSNa8X`!m[5N/YY[;Zh<(<od=!dDu=%Ser8<#Bi0aN`ol]m%6_LD/qF!kTs,UtC/"BCU5SWsL>*Nj:C2]D??Y>ln>(Sg;nQ6KhP`c'ocC=+a7MQV(,MLB`'bu\^f9:[H2B18LLPGc`/5#)etn(3,G5/`ZH<*!']XeG<eed5<I-[#+s,H6X%ZD'Z`WAH-2@M)5iBN-0TX('ZUKD*S(MUV7Aba>\d.Z:CXngSScrqp?hO6oMS<E-NScll0u<LYgl\C]_`okF)9F^IgFW]Equ@\/4oapb^_I9U8sXjU,)r@5ui>%IHbe5o^1IH^[u[q]PK2RM:<V%_VERM',4XW,O)VH0U>hlf4,Ot3Q/`k9Ghe=P2KNDpfr=/rEGQ9o*1i9DZ(DjrJ&f5BAM+hPa@2oada;fj;6h`4IfrkMXri*+,cT$YpM'0Dn1hDtCao/:R*J^o2Kf8lamCsK<IqNUAp%N`HgM[."b"Xodi$Jb%t:;NLri/DVQSHtjhD@0p[\s_S-pGBbdc>uH.fq$+5\E-9/@Ib8')`2(3hZHB(OUuaCI5>%%b5[T`+Nl?r%Y5l4lA%6/Fa:Db_1#^Qs1"A!`dpL<EUj^e8+r*;ML:C)!sdFV,8FGVE?=E_>pPAp)M[V]gP@$FHf#nNC\S42SV"Z76X8t;0T@du#50cF+S;>S:;5\"TGGKST`.,`S;':E5n$,Ja!6C1K8Nk@NLp?)a2g"t*nal:3iR>d6:]EXHI$)c1lOf[,Gaps6Zd<_S:;#KR_JjQgQqSC+rd?;^iMt8gCK7Ye@IA@9/_'7G2[/GP<!q%5\bOS!jtm1YQbE"lNZPHN.traLESkB]-E1+5Tr;r<1B55EJ]aZgCcs^d^JPbo++JbZSR0`8FsCBb*7$Hjk0J=PFldjr93/'=l",AXgARDhb5V/icnf'3t;DVd0-=4_D7,!rTt;G0>$6]RJ*lV?J0O$,d]AWm*-P@5%[;X8ZGH^P?)^LiHu&m4bo%[?%W$hjTAd4oZI]s5,S8p50QI`!dVro;N"Jl+LAIGC;7r>7gBnVI?cJ/d]o^kO5qr0_"JY`:/1E`Y.hRg/EF,8:4]T'`nl/Q3m^d_>V$%=JF"!&8&j_MSK"+&H(gsm@rS&IM5(/KSsFGsgX8Z*@ouMJb9,p6LpWML+nSP'2AqVV0mQZn02);F[hQb)f8st#'P;YO.$!pd\i?TJLSF;3mV#ap*8-+XNB;o$htEh'ZBjk@:Mfuo*39)?bE:Y(~>endstream
 endobj
 xref
 0 37
@@ -721,14 +721,14 @@ xref
 0000259436 00000 n 
 0000259528 00000 n 
 0000260143 00000 n 
-0000261041 00000 n 
-0000262688 00000 n 
-0000264444 00000 n 
-0000265998 00000 n 
+0000261066 00000 n 
+0000262713 00000 n 
+0000264469 00000 n 
+0000266023 00000 n 
 trailer
 <<
 /ID 
-[<f8c678832558c983a385921220b3fb01><f8c678832558c983a385921220b3fb01>]
+[<223ba85aaf22ed00875ff57ef74f576b><223ba85aaf22ed00875ff57ef74f576b>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 29 0 R
@@ -736,5 +736,5 @@ trailer
 /Size 37
 >>
 startxref
-267058
+267477
 %%EOF

--- a/docs/simulate_ManuelUtilisateur.pdf
+++ b/docs/simulate_ManuelUtilisateur.pdf
@@ -635,7 +635,7 @@ endobj
 endobj
 29 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260702002827+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260702002827+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260702173405+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260702173405+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -653,10 +653,10 @@ GasIb95i<6&AI=/HoF[FcH\Cu?Ag3EU/IZs-SAin9nW#hFV9-fEnG-94G59=Ou;-<":U$dpT=a=.Vs#,
 endobj
 32 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 811
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 837
 >>
 stream
-Gb!l]c#0"9'SZ9D`S&p9jiREVZ`97cM-@Gfh9]Fc"HOQQ"83T.r70`X-?4Ve+Z5N7&0MPII.qUC$3ghEefM.!\4gj]_n\6p"dgPJaV:A1BG1sr)^uU01PQ8@_C]>"__7bt'S]Ht;\MN$7<kmj"=),E#4JcUNu5arQdKC8AB1?'&XmbXc3]aj7oJ:)L4>l#XZ[sWfT3LedB(dM@5>[NZu"M)o2/HLX*gDfGu^FZq2+/pE-Ba-ejM8>r]n28>+LLolcRg"3?kT!_La1M.0i_->PYQ5DBuKUL'o3$Q?m0h5#@VSA;P2P^84I-hGoU_A$H5p[>\fZ#;_D/[o%DV7p)LFU(RWoi5@AoO7u\bMe:?`3[AH`0?$%#MD9abkl5aq1+4LG(_LQ26Q\uV^8m,8c+WGIcX-:0`cQUG1]$1\Fqm/T[QSc?jt-.3[!D?G'dllbKfEK-`V+\\eIlC_fT#Q,:$oQdR->Osk-W!,9+6sH6&]7q,K$T#\SXLO*&`eo@9J!EV:PQMWB%+eOa?IY<XrnP/U^e:rBUh_Y/gZ'H1mUeO86k^[<MSV9Fde^")0'YUV*\!?_j+-rV6*,kPMSL?or2(WI_\he(hR^$pIr=k3X+hg7GN(D2>Q`Tq,4)-ZLop61C682o9!L8'BD?FH4T4PHc;??d`QN0R(U<Efm82jtL_XG!7Qah*7Xpl,$l6,1c/_rh[,ZB>njj2?'9YC[Td<G3]K:f!lf7<Ul0_Z@=%epj['3Ja7\fqu!,os#ZU/dd5B[g5!+NdW41dR2@bAoYAkJEE/9.Q`miqN8ZaS&H)gR[7b6~>endstream
+Gb!l]:N+]I&B4,;'^q>%PjQcqoD4,.9+`RC'Z-sgf9lc:fM4=_T-)a#)add:a\n%M'!7p2qqc7_B1F:>85Qd-"n6\do.'kk/63l<$l3os>=?(oaOhG+&ELOQ(.'=1&r3]O8k=2i,*kEI9rq0rFjMDT'-T&1Y9H=1$1$gBim*SBPgE/SGbp'MZ,36Nq3?7XO`^:ppsso*c\lD!er88jT@1%(%@33Tc8YP_Xn/PT_r:n:Y?K5C\oCI^ZMH68l_`.!"l<:Rm`>d!Gc;>^CD*ThXAt,QZOGrT8=XLG#]6)O#:'1N_RE!kE1P><FNmX1p"0hp%O-'CQL2(;;u#oI.NcOTM/_<DK*#((OcVKAs#0Wj>t;Nj+]3aA'WY><,*/fBIWW7Y,\HH]&U!;S+3ZJ<=qsJp#O\j(5O*$Sl1qd^jIJrq<V!*Ap!hAmBlhqUIt1Q+UU<PG@blsuo22E^`IY68lYeY'HeW#l:FQ"e$6Lis6BN8,W(/TUY+#adlWM6[22m<#nRdTG]R*LjKhF&H&3+(8fS4,]d\7QeR[e\$A<!WPqjqlEEl)B.GaMP/;7'p\XhfCJQSjOuRPA]Wn%X:\3?&*uEG*OV"La]\J_P&Jl1SQD4oq/:'39-[Qp_RuERf-Y-_h[`chr28*-)9fZ@AZkAFAkZXWW!bRl+]taJs9GVe*kM2V<&k$a,7t<.'"4.(1<kmK*<`\Ai0XE)ALO[L6lmgN:3nK$,&ke#Y$:F"W5DJu/LL\MPr1I3%n5VL@F>Eft%lq<*0>]-]+r_i^pCeEh-!B8=An<UMm)m"Z]ZB?#!J`gE[c\m]Q;U0@,B++\:\lNklkUG6c+~>endstream
 endobj
 33 0 obj
 <<
@@ -681,10 +681,10 @@ GatUr?Z4[W'ZJu..F(TFoT*^L+t9M/0VIeg@*!kAo0XVj6;'6i1Pp3%.4tD\#Kh36[rIV*0OP8(`I%$`
 endobj
 36 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1000
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1404
 >>
 stream
-Gatn#6#YO:&;BTL(%5&%Rq-5rU+".(`,RGEdBn8aQ)80F1aI*9MFN_8?VjoflP;sLU0'Z2:rL$BhE4\dK0q1c3rpFI\@`Cb'"^;[@LB_#pq3XK.`U4<eH/EdSZEbaflPPV`'`Y&d0\*%hR.%nL<6mOW!*j*&;Z#<]1Saoih?4Y437eBa_ECR3[kqJXi,+ojc+Z6d4b'\F[c9R\LESO->^0dg%\5cL/"8qk`V?>n3:B+O57Frk?2r(2,g6Khb\dI9:]pq@u0_Z3MuY5f0*62H7m%&7eZ-9(p[)Af=\c#>%sg7U&$oB=+kms(S+pXJY:>i[n;HWK=+mj]_iR#M;Nc^r3JD+cZIcXKaCI*=YFO_I;Qpke^s)[H>99n=l7;$02iF^<NoEp:oV$=Fj!RmP[_%$c"Z=jj\:Q[+5rOQD+hb$hO9Ht4#G_`@BJo%:;YSJf=2=@f,&J=>C10IFf+jZdl?W%;qJ9Db8))0!LGaiP@m35QJK%QK>JA+?(.P#c"0Qc2TFV$,>I63CiLP;9XrF5+`@cYK>$k1O(9uVK;XBR@"[>uj"7M`s0jYW5OVoGC\TpDl\FC%gK&e7Rok7&!i5?8pdB!nB/t3*=a"H#BB=i%.cnWi36N414Id$3pj-rs[4SOqn%;;M^*.hKU&i;r,9e.<(p]&&qU=)Bol;<O1_HHBQ@m!P[7AcVYP)).hq$j)8uEgNI%qO?JtMQMnsC)nO?MPnd=m,_ajRQgC<\^MbcN=9YTZJ^`\9AAH??->AbuUMi<u$\+\0.*E\qKe$[J0cXi?;([\PFf!FG*l!WEm%b&QbF9^rs654u<m5KC3C=EFB?^S*J;40f+E40fr9QaO,K+?Q%%>\:JRhU>0Epo2VWS@92F2s5bK5ZjZ9,6*qtdp6p,FhG4'K1foib0+%f`Vk?A)=Ju>+e-lUR;d:0`fr_YB@DV>H<d@AchIDBq#gF9&lQf3jkI!oH&e,nKr*1]\;+=01)^R5rWbKa^AsCXdDu~>endstream
+Gatn%95bb.'SZ;X'k^HI8M$=#pNRQ'mNsBO<f8T9TfH0eh&17WLE#=+(SkS1%V"&u6\$H+N:&jd\IV;_K1"^D2$*0t\@<:c"kFWKMH*c._T2?/DS^SP<M][/?!!7J=OD3;2fRN*!CnLsCO+O+mV>k1Fb<RGd0ThDfXtJqUmKgghQIIS"Iaq-9i7Q6$HB-T^j<l:Fn(KecfmIU;Ym6A;]K?kXB,*I9r&B==U]W+?3Y8k)m!t_I[bGN7'E&6<MD*Q&3e#PBB<g8/t@T)<T!>P#HOns(LVAko[V8)79?b.iTU_#X/9Y*M9:#^>tWVQ-Kk2'D@+R%oX5C,D8=l&C3fYLaU7t=qna>t.=9Wf26S^-/dp6gZMJQX`8?J+Mn?r\PdY.O?*m>/JuIB1C0KCEWj68Kb7@BK'e>cR51Ft"EGaP(O1es@eWQ"Q2mVIt)JUl4Tp4gI:-t5'QhXr)?QQ%Z]"Q+pX%ot6a>Ao4g!k/GDMf2LlN%gRon-mDABV.KQD)/A5%l%.^58g_(s\r2d6137!`lh=d<XM:Ii$EV7Z!*_OS>P)lE)4jJY9*tBPA0c#QIkd;L_q9Ki[eD[&8];&_j>]d;38&<+MX+=4VWEUHe!q-ScLo8`l6+U-Y']M`dNo)Md&g3_o2CjQ:8/I%ZHWg3`[VB]+^ObVhLAR[kInFp.Xg<S2XY&gj%Q:<mPbfWuKs^3rmhidR<::ZN$TPk\#!_HR[mDrVZt/eJP$-E$5rE270i>*U'TK"R5&%a$h&7gt7-dCo7Q=]Q%E99[/UZI,Yb,I@$Q?-#i]Zo;T]:oV(^$fIN:(#]*7pukc4"ELiDE6u#55.5=niJ-AOQo":V57n>qm7<d8j_O,VJ^c)R?=qhm@jo\9h^>ukD%sOR6QG:nKOt)hKNC79rSI)*Y-ZjZ4]BRIS[/+p@?O*D91>/Ap471.(h<-0=Y"unTuVSHl+$JSA@?"Q8+8FnVgH=LN5:Xs$Aq<@g>0cu-_nU&_b8@eGg3d;nO]0d,Z)9e#9)k&"]/5q/-(^9:3fm1V=UE3Yl50-I_$0ff(-sY'4is1k"KrS,PcC#&(oRgfm3];lspNd(nB--P4(=fL9u?!S4Q3*7?&8N<?/?GA&`k'i^j_4e!ZE=/I0G3(W^Hh9(>j%jZ([6c#=/,[\M@O*6uPqC3,EBJ)XLDT,cTFBp@,=i=eNEXT!t(nRNVVe%q,_SYZ^7qcL^UQ4C`#T<Sp>cPO>1eLU:jkC&o+_T/EJLJ.DMe\@>Z"kj@U;L=u"U-bY1?2;(eBXQ=M1B/nrbZ!N9^,_.jc]0X`C%>"Yr%?;o(6H8TcJDHLZI9N4oDD$Y^+005::b:SGN=C8NhB.O.Bi)$%gJJtr\[8"Im0M8[uTr6V.P_DCZK'4s)U`Q\6h)jcN[eI5E_i;7K~>endstream
 endobj
 xref
 0 37
@@ -721,14 +721,14 @@ xref
 0000259436 00000 n 
 0000259528 00000 n 
 0000260148 00000 n 
-0000261050 00000 n 
-0000262797 00000 n 
-0000264633 00000 n 
-0000266235 00000 n 
+0000261076 00000 n 
+0000262823 00000 n 
+0000264659 00000 n 
+0000266261 00000 n 
 trailer
 <<
 /ID 
-[<f84b10d1a2c1ba219edc2baea617660a><f84b10d1a2c1ba219edc2baea617660a>]
+[<c9633ff7e5ee38cb8b5574b5f84a0fd7><c9633ff7e5ee38cb8b5574b5f84a0fd7>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 29 0 R
@@ -736,5 +736,5 @@ trailer
 /Size 37
 >>
 startxref
-267327
+267757
 %%EOF

--- a/docs/simulate_UserManual.pdf
+++ b/docs/simulate_UserManual.pdf
@@ -635,7 +635,7 @@ endobj
 endobj
 29 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260702002827+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260702002827+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260702173404+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260702173404+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -653,10 +653,10 @@ GasIb95i9E&AJ$CI)iZDPF:r)YH8'CU'JJQiaTdE2=^k#cMpBRJs'07cq6BpeU4Q'!J;PnHTqT+%CS?L
 endobj
 32 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 796
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 825
 >>
 stream
-Gb!$E9i'M/&;KZQ(%3l-ZL$qEG>FJhJ<6^/^k`@7f@_FP@QQPEC&`Uh%O$RW<QPK-/]St(][+5P1GOH5KA'g9!%/)5cNtkY9L4Ob,ZcruU;r)[fIBI#A?Cq39K5emTUnRu3%T%bEuRJ.bs\WB,VcSmW'.#5&Ktu`/36@ojTn=0BnV!OJoMM5,R'4S`=[l@jZ0Y5I^I7Uoce68`adf+I#[T/\P<qG8:D^B%!\>9ar%!HbQ!CPXOAN"b&Qg8<S_c61$'sQ%SSCn"dmlXWOMN:.cq-M-VQ"bbXP,EES)DpQt^\lUb`P/N?0UEfRUq1`B=&&0nGgPW-n,'3bGJU$3ddNb`Pl:HOJUuf?n+#@\hhm'T8>m,)`Pd?a3?E*+Q=]Lg'GTr)X`+<b:=7B%:>)ITKTRgX-JVpp3Rs9RIY_/Z##FTMTgZj/W@5Jgi-+ideEG[cO8BQ=LrOY-"mJC>TKB>^[1"mUu<4MSTo]Lf"Xm,i$_p#5JV\55<]eCW*.1$J[ORh;mZ+c.lf3=0jq>HASKs<+:^-Ek-'Abnn*\PLL^M23:`[R=""+j6LEJGs%$<mOfRkqN0O;p<j&"2/[e&fp4s;b^P(Xg`A(>cC>Ubm?$Uhah<68L<n[?Y`$^0T(Eu:Ft'do7[ap,ZYJaF=]J5gM(^ZG=h:3tQDN=(*\tPg)h1l:L)VFXp*]H\Op6iMFo=D/_n::^Od:LoHU>[JI`7a9\!?tcILUKnij:2$$Qm*)0ZdBjSc;s((D!:=\M#\:9&K*)*&L(-^`d0KjNDcHTu6C]6M(d,#sss~>endstream
+Gb!$E>>O!=&;B$?/'_W)A_GbKT.5Bl+f/'c7Xa779fA$4fFEp?g4*J36\nCNWar(O>J=k8HujIDC]XhH[Dut^S0^/.,`k8H#:ZO39Q6+^%h[jQ.7mq.S<+X_`11:h3f?UL39&/&B;&h[K[g9i(c`ei*qSEJ&@OWXcB9P8Je:Zp+lJ#]>ZlWR_!.[TiJ:]`c<QGQXn-#.9H0&_(jBb&j)\CAdcD((+%VCo?72[,L+1RA+/1Z_[)o@h>l.N$2k=n]`K&+Y9WONg0WddF?IB4Z=DW5l?r@kR[R0P<_Zca$R9&KDRX'^,FK:5!!OG6u*mR&Fi9OBB5'nJ`At7uj"gesp-E6^bQFMolU5.sc8@KUMKk6^o@9W<L==4Q<Z.W>L/UEf`#tF)Xg%_jUGM$h?eQ#(]FMg3>Us^kB^5pr"V7j6tC-/:SJQa`RV1oF]]3m]aC1BiD-1'@^=&//8ONcdF#jsCa=&\/k`!8$>JW,8#MmPda`i]e8p#2&imtrW7gSAtUQPl6Ga/Z;J3\>Z7NHeN6M<f2iBe[l"^6_d06(D[4Va@]YaNMTTo5s8;5J"G<^-CmOVIB.o#9mr2p$$;%(-6m;%Gk2.i0*.PG/Bs?;B7K;d*]]!^AAjmOkIU8Ic8mBL%`b^1W&Od>5@]q.d-WOQW&qrh.44bdN4\bR:)Ji+4[aW7L<>tRX.1kK146`rA2s@U3]4iQG<<T6IVW8<jOdBaaYSNL-$]$?59N;&&1/mjm/eh^MhhqqpFH@Q^CdLmrqIX6!_D;lllX*^?YYd+1@1/a_*>"bA7jko?qZ6`YY]FR=9iL*,d#hIfLTJCA7~>endstream
 endobj
 33 0 obj
 <<
@@ -681,10 +681,10 @@ GatUr?#SIU'Sc)T/)HbhBfjfA'WDS[J9K+R3acefX;AF@-/)fYM&mt`F+=-Ra`6AgBegA,iol#B&)VH"
 endobj
 36 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 941
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1346
 >>
 stream
-Gatm8>E@f$'RnB3pg+NT0(mkWj!=6+Qgt1jb6A:CjsI!c;.=`cLXL[eE]UP]!KF#\MNj$9SaU_s"?8BZHLGM)D25a*J<9!g&;hoY5N5%34;<b+N@G+!BGt#S@'\mgeHgrIJYNgIe\%kY[2"mJV,7RH)BfXtqq$Ne^;?RggHEC[BZWju,oS3M=1(FTj)-C)E3q,XB2+,1(%&Y--4r-Tr#.$B-fYsuI>@5$FK[L6X.i4%VF4G@:c0gO=mn8"N]s8>E_NkM03bYQ[9S;`Q#,".fulji<qH7+8u7fe!0qI^RLI\$^#Js+%Kq2c]iIJL)Q_Mik4tF],_#Q_E*k^V>GdmI/'Oqaa]_QAYA4e8'd&?hie^95ZaQ%)?Hj:d<p8`+Tho=Db*kPd;Mp`C<KBunG?Z0Ohu&N%qjN2km7bE/5?-E/dJ&&NE"[TPo+LM?naRKeDCup07U;_DA/[t+D%_H,;Dog\\cI$0lH(k+<mS5J^nC,ccHjOfE_%$`9Yp._oj`WjS0O3;hDuTGS89+kHagHd\XkKX8!,s&^3Pb5TmK@-`NKHYh!r])D=lEq',MC(<M@gnA%YG5"]X/[TjF!")JXD1S\i%Z&Isjb-MV.?=/69h;1_(Z)IW;!qZSA-;KaJ81&,2A$1sSKdr\%t$.6t][sUa5?Q#lPIZ\&>HlL&^.JQPR-4m7OjDpW"\q`SESm3W:YZOLW;QtU8mmEb5oAi[]i_"Xf"8+"<g]cP_Rh/(3'"P[N,j!Ru]"t#Erm;2YH]-%$s7[MiYDiCO'K0*&3!MuXTB>q2\j:1do/X+iZ-s?LHe=Q!NPjs#`IsUPU7#8<g%cq&EBT"dX@q^q[&E\J8F50rI3cbf*sm_\:ME3>1YJ.3Dl2cHIi1@0g-3BclncoUqj^,<RZiYsI3<?f7[%dri^f+RY&jIdXs*i%rUQ#6:j`I)5HUm~>endstream
+Gatm9>Ar7S'Roe[pg/]OD9S(SFj"8Jkt;6QU&i0Y(Krl*fL_l*;YBVL#Kh5T'['rnK`RYeAU_+08-'21Z$\JTn@HWiNIXPrG7]p/e@0[(YO5GM(Sse/Qmg-'c+oL"M^jM:Xpd9^_-+Ut!a1enUr[SPJr*A23(!@[,nN:Y]6[a)hurV(V0S5s9G5?VOe<b8Fd'JtW"sX'ap<LUof*I3&CtXpm`FEHAS*g45lDGjb=M)4;jlfBMC^o#f.a7uX][`SX:$E10j0c(XhZ\pnH:DdP"P_p4t.eYEZPH:Q+>-55j9eZ1'1H,?Z83-/Km@7]oYPp3EVEeK#caSQJg6hQ$MjEX]SnA>[g*e-EIiZr'!'toBPB$DKVaQ'WfH?,%&P1ZB/b>e_Nip'h\p`GY:Ypjt]"d]t1e[DZ%Ci=P"64e7PIJSht<(<?dm/WEN&k8K48\X^-@&"IGI%N`df,d*=D+,E4Sf_-*4k.6-T.=#\g[1a*X\DY05\?K7"cVh&;JBXJ@GDs$.iNE4k^"H-"om<e2Akg<M]l'>"1(pkI4Ni'!%j1VLc&sVob5u1S[,=UqrH\mTmMI]SHUXkVn8cB%GUc^q+fimHuMd&gj`]4O<4k,kWq\EJ!f(_o>$D+2MmVm)Wm$%h(+\.a&mG&9:Dq0O"*has+2,[\b0!Jt+b,T]L@8qUq`BVJtI;[1>ZjC8PQtj-cJtn&o,^21_$CJnKgS1sudDC154*#eDhH<@.nf_%b289@jhRYs!/fpiom'LKo0'_nJ9@2k#/G]=liU+M'INu=^$Jjbk7"%)90;euR4cGA_F\31NUJ'e^-^?u9%J]uG<1o@IJD/X9?oAJ)TX5%"B5!FX:IshHDlkD^`_M2hZb+T%OW(S;\l$@aJ%]b_RWRRu:%XiCfIj&[-ab`OUNM5I6E^Hfg%TRoETu55\Cu2?g\IA(7.rE`[(re!gGtkQb-VF2:@Y?0^2)1[q0.TSdO^!P3TE4ro,RE5,(&&2Aa/2Ts$_i%2Y?&ag3+OY?fL&8ZX"A/5bT.H(7R;eCS8Q8T3s$+^$XjD$Lg+tR\S>))0RJNM?ftJD*0R`8XALQ&Vh/A$9KGapZ+eT0(I5'#OVC]I'TM&3_k+-0$N(<r8+Ur8#GMglCQAp<pqQnX)HK?lb6FQ%NB&oItW0BL>f*%q:*mn3$ZbQkPCPuf(c>\d5?<UN]\MPAp,eMRl8_84MG'BHAG4k`MB"B.?O..?6IlP/J0S2+!!QA$>lFW9)9ZYEqV"@@=>4.`,426Js2gIjIQ^m[ApopUP%XSa4<G1>tY,r8a#FGp!=1qdS%a+`=X3>..\Q^%GkP]Qp%k0m&udHL&@]TXSr7D<lRT~>endstream
 endobj
 xref
 0 37
@@ -721,14 +721,14 @@ xref
 0000259436 00000 n 
 0000259528 00000 n 
 0000260130 00000 n 
-0000261017 00000 n 
-0000262629 00000 n 
-0000264391 00000 n 
-0000265948 00000 n 
+0000261046 00000 n 
+0000262658 00000 n 
+0000264420 00000 n 
+0000265977 00000 n 
 trailer
 <<
 /ID 
-[<dd4f79b93311358bf95036c511a67274><dd4f79b93311358bf95036c511a67274>]
+[<315b188d649743e41f766ccfe79ddd4e><315b188d649743e41f766ccfe79ddd4e>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 29 0 R
@@ -736,5 +736,5 @@ trailer
 /Size 37
 >>
 startxref
-266980
+267415
 %%EOF

--- a/modules/simulate.en.md
+++ b/modules/simulate.en.md
@@ -41,6 +41,20 @@ python -m simulate ART_A_IssueTimes.xlsx --horizon 84 --backlog 50 \
 | `--seed N` | Seed for reproducible runs. |
 | `--output FILE` | HTML report destination. |
 
+## GUI: language & templates
+
+Like the other module GUIs, simulate supports five languages (German, English,
+Romanian, Portuguese, French). The **flag button** at the top right switches the
+interface; the choice is stored in `~/.situation_report/prefs.json` and shared
+across all modules.
+
+The **Templates** menu saves and loads the current inputs:
+
+- **Save** stores files and parameters together with the language in the shared
+  project template (`project_template`, `simulate` section).
+- **Load** restores inputs and language. The same template file is shared with
+  the other modules – each module only writes its own section.
+
 ## Method
 
 Standard library only (no numpy/pandas): the empirical daily-throughput

--- a/modules/simulate.md
+++ b/modules/simulate.md
@@ -41,6 +41,22 @@ python -m simulate ART_A_IssueTimes.xlsx --horizon 84 --backlog 50 \
 | `--seed N` | Seed für reproduzierbare Läufe. |
 | `--output FILE` | HTML-Report-Zieldatei. |
 
+## GUI: Sprache & Templates
+
+Wie die übrigen Modul-GUIs unterstützt simulate fünf Sprachen
+(Deutsch, Englisch, Rumänisch, Portugiesisch, Französisch). Die
+**Flaggen-Schaltfläche** oben rechts schaltet die Oberfläche um; die Wahl wird
+in `~/.situation_report/prefs.json` gespeichert und von allen Modulen geteilt.
+
+Über das Menü **Templates** lassen sich die aktuellen Eingaben speichern und
+laden:
+
+- **Speichern** legt Dateien und Parameter samt Sprache im gemeinsamen
+  Projekt-Template ab (`project_template`, Abschnitt `simulate`).
+- **Laden** stellt Eingaben und Sprache wieder her. Dieselbe Template-Datei
+  wird von den anderen Modulen mitgenutzt – jedes Modul schreibt nur seinen
+  eigenen Abschnitt.
+
 ## Methode
 
 Reine Standardbibliothek (kein numpy/pandas): Aus dem History-Fenster –

--- a/project_template.py
+++ b/project_template.py
@@ -8,7 +8,7 @@
 #
 # Fachliche Funktion:
 #   Gemeinsames Projekt-Template für alle Module (build_reports, transform_data,
-#   testdata_generator, helper). Eine einzige JSON-Datei hält je einen Abschnitt
+#   testdata_generator, helper, simulate). Eine einzige JSON-Datei hält je einen Abschnitt
 #   pro Modul, sodass die Pipeline-Konfiguration (Workflow, Pfade, Projekt,
 #   Zeitraum) einmal gesetzt und in jedem Modul-GUI geladen werden kann.
 #
@@ -34,6 +34,7 @@ MODULE_BUILD_REPORTS = "build_reports"
 MODULE_TRANSFORM_DATA = "transform_data"
 MODULE_TESTDATA_GENERATOR = "testdata_generator"
 MODULE_HELPER = "helper"
+MODULE_SIMULATE = "simulate"
 
 DEFAULT_LANGUAGE = "en"
 

--- a/simulate/gui.py
+++ b/simulate/gui.py
@@ -50,9 +50,9 @@ _MANUAL_BASE = "https://jaegerfeld.github.io/situation-report/"
 _MANUAL_URLS: dict[str, str] = {
     LANG_DE: _MANUAL_BASE + "simulate_Benutzerhandbuch.pdf",
     LANG_EN: _MANUAL_BASE + "simulate_UserManual.pdf",
-    LANG_RO: _MANUAL_BASE + "simulate_UserManual.pdf",
-    LANG_PT: _MANUAL_BASE + "simulate_UserManual.pdf",
-    LANG_FR: _MANUAL_BASE + "simulate_UserManual.pdf",
+    LANG_RO: _MANUAL_BASE + "simulate_ManualUtilizator.pdf",
+    LANG_PT: _MANUAL_BASE + "simulate_ManualUtilizador.pdf",
+    LANG_FR: _MANUAL_BASE + "simulate_ManuelUtilisateur.pdf",
 }
 
 

--- a/simulate/gui.py
+++ b/simulate/gui.py
@@ -3,16 +3,19 @@
 # Repository:     https://github.com/Jaegerfeld/situation-report
 # KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
 # Erstellt:       01.07.2026
-# Geändert:       01.07.2026
+# Geändert:       02.07.2026
 # Lizenz:         BSD-3-Clause (siehe LICENSE)
 #
 # Fachliche Funktion:
 #   tkinter-GUI für den Monte-Carlo-Forecast. Erlaubt Auswahl einer
 #   IssueTimes-Datei (optional CFD), Eingabe der Simulationsparameter
 #   (History-Fenster, Horizont, Backlog, Läufe, Scope-Wachstum, Seed) und
-#   erzeugt den HTML-Report. Die display-unabhängige Logik (Übersetzungen _T
-#   und parse_form) ist getrennt gehalten und unit-getestet; der tkinter-Teil
-#   wird im Test nicht instanziiert (benötigt eine laufende Anzeige).
+#   erzeugt den HTML-Report. Wie die übrigen Modul-GUIs unterstützt sie fünf
+#   Sprachen (Flaggen-Umschalter oben rechts) sowie den gemeinsamen
+#   Projekt-Template-Modus (Menü „Templates“ → Speichern/Laden). Die
+#   display-unabhängige Logik (Übersetzungen _T, parse_form sowie die
+#   Template-Abschnittsfunktionen) ist getrennt gehalten und unit-getestet;
+#   der tkinter-Teil wird im Test nicht instanziiert (benötigt eine Anzeige).
 # =============================================================================
 
 from __future__ import annotations
@@ -26,6 +29,8 @@ from datetime import date, datetime
 from pathlib import Path
 from tkinter import filedialog, messagebox, ttk
 
+import project_template
+
 from .cli import run_simulation
 
 # ---------------------------------------------------------------------------
@@ -34,7 +39,10 @@ from .cli import run_simulation
 
 LANG_DE = "de"
 LANG_EN = "en"
-_LANG_ORDER = [LANG_DE, LANG_EN]
+LANG_RO = "ro"
+LANG_PT = "pt"
+LANG_FR = "fr"
+_LANG_ORDER = [LANG_DE, LANG_EN, LANG_RO, LANG_PT, LANG_FR]
 _PREFS_PATH = Path.home() / ".situation_report" / "prefs.json"
 
 #: Hosted user-manual PDF per language (GitHub Pages, deployed from docs/).
@@ -42,6 +50,9 @@ _MANUAL_BASE = "https://jaegerfeld.github.io/situation-report/"
 _MANUAL_URLS: dict[str, str] = {
     LANG_DE: _MANUAL_BASE + "simulate_Benutzerhandbuch.pdf",
     LANG_EN: _MANUAL_BASE + "simulate_UserManual.pdf",
+    LANG_RO: _MANUAL_BASE + "simulate_UserManual.pdf",
+    LANG_PT: _MANUAL_BASE + "simulate_UserManual.pdf",
+    LANG_FR: _MANUAL_BASE + "simulate_UserManual.pdf",
 }
 
 
@@ -79,12 +90,23 @@ def _save_lang_pref(lang: str) -> None:
 _T: dict[str, dict[str, str]] = {
     LANG_DE: {
         "window_title": "Monte-Carlo-Forecast",
-        "lbl_lang": "Sprache",
+        "menu_template": "Templates",
+        "menu_tpl_save": "Speichern…",
+        "menu_tpl_load": "Laden…",
+        "menu_help": "Hilfe",
+        "menu_manual": "Manual",
+        "tip_language": "Sprache wechseln",
+        "dlg_tpl_save": "Template speichern",
+        "dlg_tpl_load": "Template laden",
+        "log_tpl_saved": "Template gespeichert: {}",
+        "log_tpl_loaded": "Template geladen: {}",
+        "log_tpl_error": "Fehler beim Template: {}",
+        "log_tpl_missing": "Hinweis: Datei aus Template nicht gefunden: {}",
         "grp_data": "Daten",
         "grp_params": "Parameter",
         "lbl_issue_times": "IssueTimes (.xlsx)",
         "lbl_cfd": "CFD (.xlsx, optional)",
-        "btn_browse": "Durchsuchen …",
+        "btn_browse": "Durchsuchen…",
         "lbl_history_days": "History-Fenster (Tage)",
         "lbl_history_end": "History-Ende (JJJJ-MM-TT, leer = heute)",
         "lbl_horizon": "Horizont (Tage)",
@@ -106,12 +128,23 @@ _T: dict[str, dict[str, str]] = {
     },
     LANG_EN: {
         "window_title": "Monte-Carlo Forecast",
-        "lbl_lang": "Language",
+        "menu_template": "Templates",
+        "menu_tpl_save": "Save…",
+        "menu_tpl_load": "Load…",
+        "menu_help": "Help",
+        "menu_manual": "Manual",
+        "tip_language": "Change language",
+        "dlg_tpl_save": "Save Template",
+        "dlg_tpl_load": "Load Template",
+        "log_tpl_saved": "Template saved: {}",
+        "log_tpl_loaded": "Template loaded: {}",
+        "log_tpl_error": "Template error: {}",
+        "log_tpl_missing": "Note: file from template not found: {}",
         "grp_data": "Data",
         "grp_params": "Parameters",
         "lbl_issue_times": "IssueTimes (.xlsx)",
         "lbl_cfd": "CFD (.xlsx, optional)",
-        "btn_browse": "Browse …",
+        "btn_browse": "Browse…",
         "lbl_history_days": "History window (days)",
         "lbl_history_end": "History end (YYYY-MM-DD, empty = today)",
         "lbl_horizon": "Horizon (days)",
@@ -130,6 +163,120 @@ _T: dict[str, dict[str, str]] = {
         "msg_done": "Report generated: {path}",
         "msg_no_data": "No throughput in the history window — nothing to simulate.",
         "msg_error": "Error: {error}",
+    },
+    LANG_RO: {
+        "window_title": "Prognoză Monte-Carlo",
+        "menu_template": "Şabloane",
+        "menu_tpl_save": "Salvare…",
+        "menu_tpl_load": "Încărcare…",
+        "menu_help": "Ajutor",
+        "menu_manual": "Manual",
+        "tip_language": "Schimbă limba",
+        "dlg_tpl_save": "Salvare şablon",
+        "dlg_tpl_load": "Încărcare şablon",
+        "log_tpl_saved": "Şablon salvat: {}",
+        "log_tpl_loaded": "Şablon încărcat: {}",
+        "log_tpl_error": "Eroare şablon: {}",
+        "log_tpl_missing": "Notă: fişier din şablon negăsit: {}",
+        "grp_data": "Date",
+        "grp_params": "Parametri",
+        "lbl_issue_times": "IssueTimes (.xlsx)",
+        "lbl_cfd": "CFD (.xlsx, opţional)",
+        "btn_browse": "Răsfoire…",
+        "lbl_history_days": "Fereastră istoric (zile)",
+        "lbl_history_end": "Sfârşit istoric (AAAA-LL-ZZ, gol = azi)",
+        "lbl_horizon": "Orizont (zile)",
+        "lbl_target_date": "Dată ţintă (AAAA-LL-ZZ, înlocuieşte orizontul)",
+        "lbl_backlog": "Backlog (elemente, gol = fără prognoză de termen)",
+        "lbl_runs": "Rulări",
+        "lbl_split_rate": "Creştere scop (elemente noi per finalizat)",
+        "lbl_seed": "Sămânţă (gol = aleatoriu)",
+        "btn_generate": "Generare raport …",
+        "dlg_issue_times": "Selectaţi fişierul IssueTimes",
+        "dlg_cfd": "Selectaţi fişierul CFD",
+        "dlg_save": "Salvare raport",
+        "msg_need_issue_times": "Selectaţi un fişier IssueTimes.",
+        "msg_invalid": "Intrare nevalidă: {error}",
+        "msg_generating": "Se generează raportul …",
+        "msg_done": "Raport generat: {path}",
+        "msg_no_data": "Niciun debit în fereastra de istoric — nimic de simulat.",
+        "msg_error": "Eroare: {error}",
+    },
+    LANG_PT: {
+        "window_title": "Previsão Monte-Carlo",
+        "menu_template": "Modelos",
+        "menu_tpl_save": "Guardar…",
+        "menu_tpl_load": "Carregar…",
+        "menu_help": "Ajuda",
+        "menu_manual": "Manual",
+        "tip_language": "Mudar idioma",
+        "dlg_tpl_save": "Guardar modelo",
+        "dlg_tpl_load": "Carregar modelo",
+        "log_tpl_saved": "Modelo guardado: {}",
+        "log_tpl_loaded": "Modelo carregado: {}",
+        "log_tpl_error": "Erro no modelo: {}",
+        "log_tpl_missing": "Nota: ficheiro do modelo não encontrado: {}",
+        "grp_data": "Dados",
+        "grp_params": "Parâmetros",
+        "lbl_issue_times": "IssueTimes (.xlsx)",
+        "lbl_cfd": "CFD (.xlsx, opcional)",
+        "btn_browse": "Procurar…",
+        "lbl_history_days": "Janela de histórico (dias)",
+        "lbl_history_end": "Fim do histórico (AAAA-MM-DD, vazio = hoje)",
+        "lbl_horizon": "Horizonte (dias)",
+        "lbl_target_date": "Data-alvo (AAAA-MM-DD, substitui o horizonte)",
+        "lbl_backlog": "Backlog (itens, vazio = sem previsão de data)",
+        "lbl_runs": "Execuções",
+        "lbl_split_rate": "Crescimento do âmbito (novos itens por concluído)",
+        "lbl_seed": "Semente (vazio = aleatório)",
+        "btn_generate": "Gerar relatório …",
+        "dlg_issue_times": "Selecionar ficheiro IssueTimes",
+        "dlg_cfd": "Selecionar ficheiro CFD",
+        "dlg_save": "Guardar relatório",
+        "msg_need_issue_times": "Selecione um ficheiro IssueTimes.",
+        "msg_invalid": "Entrada inválida: {error}",
+        "msg_generating": "A gerar o relatório …",
+        "msg_done": "Relatório gerado: {path}",
+        "msg_no_data": "Sem throughput na janela de histórico — nada a simular.",
+        "msg_error": "Erro: {error}",
+    },
+    LANG_FR: {
+        "window_title": "Prévision Monte-Carlo",
+        "menu_template": "Modèles",
+        "menu_tpl_save": "Enregistrer…",
+        "menu_tpl_load": "Charger…",
+        "menu_help": "Aide",
+        "menu_manual": "Manuel",
+        "tip_language": "Changer de langue",
+        "dlg_tpl_save": "Enregistrer le modèle",
+        "dlg_tpl_load": "Charger le modèle",
+        "log_tpl_saved": "Modèle enregistré : {}",
+        "log_tpl_loaded": "Modèle chargé : {}",
+        "log_tpl_error": "Erreur de modèle : {}",
+        "log_tpl_missing": "Note : fichier du modèle introuvable : {}",
+        "grp_data": "Données",
+        "grp_params": "Paramètres",
+        "lbl_issue_times": "IssueTimes (.xlsx)",
+        "lbl_cfd": "CFD (.xlsx, optionnel)",
+        "btn_browse": "Parcourir…",
+        "lbl_history_days": "Fenêtre d'historique (jours)",
+        "lbl_history_end": "Fin d'historique (AAAA-MM-JJ, vide = aujourd'hui)",
+        "lbl_horizon": "Horizon (jours)",
+        "lbl_target_date": "Date cible (AAAA-MM-JJ, remplace l'horizon)",
+        "lbl_backlog": "Backlog (éléments, vide = pas de prévision de date)",
+        "lbl_runs": "Exécutions",
+        "lbl_split_rate": "Croissance du périmètre (nouveaux éléments par terminé)",
+        "lbl_seed": "Graine (vide = aléatoire)",
+        "btn_generate": "Générer le rapport …",
+        "dlg_issue_times": "Choisir le fichier IssueTimes",
+        "dlg_cfd": "Choisir le fichier CFD",
+        "dlg_save": "Enregistrer le rapport",
+        "msg_need_issue_times": "Veuillez choisir un fichier IssueTimes.",
+        "msg_invalid": "Entrée invalide : {error}",
+        "msg_generating": "Génération du rapport …",
+        "msg_done": "Rapport généré : {path}",
+        "msg_no_data": "Aucun débit dans la fenêtre d'historique — rien à simuler.",
+        "msg_error": "Erreur : {error}",
     },
 }
 
@@ -251,6 +398,27 @@ def parse_form(
 
 
 # ---------------------------------------------------------------------------
+# Projekt-Template-Abschnitt (display-unabhängig, unit-getestet)
+# ---------------------------------------------------------------------------
+
+#: Reihenfolge/Menge der Felder, die im simulate-Template-Abschnitt liegen.
+_TEMPLATE_FIELDS = (
+    "issue_times", "cfd", "history_days", "history_end", "horizon",
+    "target_date", "backlog", "runs", "split_rate", "seed",
+)
+
+
+def _build_template_section(values: dict[str, str]) -> dict:
+    """Assemble the simulate section for the shared project template."""
+    return {key: str(values.get(key, "")) for key in _TEMPLATE_FIELDS}
+
+
+def _parse_template_section(data: dict) -> dict:
+    """Normalise a simulate template section; missing keys → empty string."""
+    return {key: str(data.get(key, "")) for key in _TEMPLATE_FIELDS}
+
+
+# ---------------------------------------------------------------------------
 # tkinter-GUI (nicht im Test instanziiert)
 # ---------------------------------------------------------------------------
 
@@ -270,25 +438,92 @@ class ForecastApp:
         self.root = root
         self.lang = _load_lang_pref()
         self.vars: dict[str, tk.StringVar] = {
-            k: tk.StringVar(value=_DEFAULTS.get(k, "")) for k in (
-                "issue_times", "cfd", "history_days", "history_end",
-                "horizon", "target_date", "backlog", "runs", "split_rate", "seed")
+            k: tk.StringVar(value=_DEFAULTS.get(k, "")) for k in _TEMPLATE_FIELDS
         }
         self.status = tk.StringVar(value="")
-        root.title(_tr(self.lang, "window_title"))
+        self._flag_imgs: dict[str, tk.PhotoImage] = {}
+        self._create_flag_imgs()
         self._build()
 
     def _t(self, key: str) -> str:
         return _tr(self.lang, key)
 
+    # -- Sprache ------------------------------------------------------------
+
+    def _create_flag_imgs(self) -> None:
+        """Build PhotoImage flags for all supported languages via inline pixels."""
+        W, H = 32, 20
+
+        de = tk.PhotoImage(width=W, height=H)
+        for y in range(H):
+            color = ["#000000", "#DD0000", "#FFCC00"][y * 3 // H]
+            de.put("{" + " ".join([color] * W) + "}", to=(0, y))
+
+        gb = tk.PhotoImage(width=W, height=H)
+        for y in range(H):
+            row: list[str] = []
+            for x in range(W):
+                cx = abs(x - (W - 1) / 2)
+                cy = abs(y - (H - 1) / 2)
+                nx, ny = x / (W - 1), y / (H - 1)
+                if cx < W * 0.13 or cy < H * 0.13:
+                    row.append("#C8102E")
+                elif cx < W * 0.24 or cy < H * 0.24:
+                    row.append("#FFFFFF")
+                elif abs(nx - ny) < 0.16 or abs(nx - (1 - ny)) < 0.16:
+                    row.append("#FFFFFF")
+                else:
+                    row.append("#012169")
+            gb.put("{" + " ".join(row) + "}", to=(0, y))
+
+        ro = tk.PhotoImage(width=W, height=H)
+        for y in range(H):
+            row = ["#002B7F" if x < W // 3 else "#FCD116" if x < 2 * W // 3 else "#CE1126"
+                   for x in range(W)]
+            ro.put("{" + " ".join(row) + "}", to=(0, y))
+
+        pt = tk.PhotoImage(width=W, height=H)
+        for y in range(H):
+            row = ["#006600" if x < W * 2 // 5 else "#FF0000" for x in range(W)]
+            pt.put("{" + " ".join(row) + "}", to=(0, y))
+
+        fr = tk.PhotoImage(width=W, height=H)
+        for y in range(H):
+            row = ["#002395" if x < W // 3 else "#FFFFFF" if x < 2 * W // 3 else "#ED2939"
+                   for x in range(W)]
+            fr.put("{" + " ".join(row) + "}", to=(0, y))
+
+        self._flag_imgs = {LANG_DE: de, LANG_EN: gb, LANG_RO: ro, LANG_PT: pt, LANG_FR: fr}
+
+    def _toggle_language(self) -> None:
+        """Cycle the UI language through all available languages and rebuild."""
+        idx = _LANG_ORDER.index(self.lang) if self.lang in _LANG_ORDER else -1
+        self._set_language(_LANG_ORDER[(idx + 1) % len(_LANG_ORDER)])
+
+    def _set_language(self, lang: str) -> None:
+        """Persist the language and rebuild the whole window in that language."""
+        self.lang = lang if lang in _LANG_ORDER else LANG_EN
+        _save_lang_pref(self.lang)
+        for child in self.root.winfo_children():
+            child.destroy()
+        self._build()
+
     def _open_manual(self) -> None:
         """Öffnet das gehostete Benutzerhandbuch (aktuelle Sprache) im Browser."""
         webbrowser.open(_MANUAL_URLS.get(self.lang, _MANUAL_URLS[LANG_EN]))
 
+    # -- Aufbau -------------------------------------------------------------
+
     def _build(self) -> None:
+        self.root.title(self._t("window_title"))
+        self._build_menu()
         frm = ttk.Frame(self.root, padding=12)
         frm.grid(sticky="nsew")
-        self._build_lang(frm)
+        self._flag_btn = tk.Button(
+            frm, image=self._flag_imgs[self.lang], command=self._toggle_language,
+            relief="flat", cursor="hand2", bd=0, padx=4, pady=2,
+        )
+        self._flag_btn.grid(column=2, row=0, sticky="ne", pady=(0, 4))
         self._build_data(frm)
         self._build_params(frm)
         ttk.Button(frm, text=self._t("btn_generate"),
@@ -297,26 +532,20 @@ class ForecastApp:
         ttk.Label(frm, textvariable=self.status, foreground="#14304a").grid(
             column=0, columnspan=3, sticky="w")
 
-    def _build_lang(self, frm: ttk.Frame) -> None:
-        ttk.Label(frm, text=self._t("lbl_lang")).grid(column=0, row=0, sticky="w")
-        box = ttk.Combobox(frm, values=_LANG_ORDER, width=6, state="readonly")
-        box.set(self.lang)
-        box.bind("<<ComboboxSelected>>", lambda _e: self._switch_lang(box.get()))
-        box.grid(column=1, row=0, sticky="w", pady=(0, 8))
-        ttk.Button(frm, text="?", width=2, command=self._open_manual).grid(
-            column=2, row=0, sticky="e", pady=(0, 8))
-
-    def _switch_lang(self, lang: str) -> None:
-        self.lang = lang if lang in _LANG_ORDER else LANG_EN
-        _save_lang_pref(self.lang)
-        for child in self.root.winfo_children():
-            child.destroy()
-        self.root.title(self._t("window_title"))
-        self._build()
+    def _build_menu(self) -> None:
+        menubar = tk.Menu(self.root)
+        tpl_menu = tk.Menu(menubar, tearoff=False)
+        menubar.add_cascade(label=self._t("menu_template"), menu=tpl_menu)
+        tpl_menu.add_command(label=self._t("menu_tpl_save"), command=self._save_template)
+        tpl_menu.add_command(label=self._t("menu_tpl_load"), command=self._load_template)
+        help_menu = tk.Menu(menubar, tearoff=False)
+        menubar.add_cascade(label=self._t("menu_help"), menu=help_menu)
+        help_menu.add_command(label=self._t("menu_manual"), command=self._open_manual)
+        self.root.config(menu=menubar)
 
     def _build_data(self, frm: ttk.Frame) -> None:
         grp = ttk.LabelFrame(frm, text=self._t("grp_data"), padding=8)
-        grp.grid(column=0, columnspan=3, sticky="ew", pady=4)
+        grp.grid(column=0, columnspan=3, row=1, sticky="ew", pady=4)
         self._file_row(grp, 0, "lbl_issue_times", "issue_times",
                        "dlg_issue_times")
         self._file_row(grp, 1, "lbl_cfd", "cfd", "dlg_cfd")
@@ -332,7 +561,7 @@ class ForecastApp:
 
     def _build_params(self, frm: ttk.Frame) -> None:
         grp = ttk.LabelFrame(frm, text=self._t("grp_params"), padding=8)
-        grp.grid(column=0, columnspan=3, sticky="ew", pady=4)
+        grp.grid(column=0, columnspan=3, row=2, sticky="ew", pady=4)
         fields = ["history_days", "history_end", "horizon", "target_date",
                   "backlog", "runs", "split_rate", "seed"]
         for row, key in enumerate(fields):
@@ -348,11 +577,60 @@ class ForecastApp:
         if path:
             self.vars[var_key].set(path)
 
+    # -- Projekt-Template ---------------------------------------------------
+
+    def _save_template(self) -> None:
+        """Write the current form fields as this module's project-template section."""
+        path = filedialog.asksaveasfilename(
+            title=self._t("dlg_tpl_save"), defaultextension=".json",
+            filetypes=[("JSON files", "*.json"), ("All files", "*.*")])
+        if not path:
+            return
+        try:
+            section = _build_template_section(
+                {k: v.get() for k, v in self.vars.items()})
+            project_template.save_template(
+                Path(path), project_template.MODULE_SIMULATE, section,
+                language=self.lang)
+            self.status.set(self._t("log_tpl_saved").format(Path(path).name))
+        except Exception as exc:  # noqa: BLE001 — GUI darf nicht crashen
+            self.status.set(self._t("log_tpl_error").format(exc))
+
+    def _load_template(self) -> None:
+        """Load this module's section from a project-template file into the UI."""
+        path = filedialog.askopenfilename(
+            title=self._t("dlg_tpl_load"),
+            filetypes=[("JSON files", "*.json"), ("All files", "*.*")])
+        if not path:
+            return
+        try:
+            envelope = project_template.load_template(Path(path))
+            section = _parse_template_section(
+                project_template.get_section(
+                    envelope, project_template.MODULE_SIMULATE))
+        except Exception as exc:  # noqa: BLE001 — GUI darf nicht crashen
+            self.status.set(self._t("log_tpl_error").format(exc))
+            return
+
+        for key, var in self.vars.items():
+            var.set(section[key])
+
+        issue_times = section["issue_times"]
+        missing = bool(issue_times) and not Path(issue_times).is_file()
+
+        new_lang = envelope.get("language", self.lang)
+        self._set_language(new_lang)
+
+        if missing:
+            self.status.set(self._t("log_tpl_missing").format(issue_times))
+        else:
+            self.status.set(self._t("log_tpl_loaded").format(Path(path).name))
+
+    # -- Ausführung ---------------------------------------------------------
+
     def _on_generate(self) -> None:
         try:
-            params = parse_form(*(self.vars[k].get() for k in (
-                "issue_times", "cfd", "history_days", "history_end",
-                "horizon", "target_date", "backlog", "runs", "split_rate", "seed")))
+            params = parse_form(*(self.vars[k].get() for k in _TEMPLATE_FIELDS))
         except ValueError as exc:
             messagebox.showerror(self._t("window_title"),
                                  self._t("msg_invalid").format(error=exc))

--- a/tests/simulate/unit/test_gui.py
+++ b/tests/simulate/unit/test_gui.py
@@ -57,8 +57,9 @@ class TestTranslations:
         assert set(_MANUAL_URLS) == set(_LANG_ORDER)
         assert _MANUAL_URLS[LANG_DE].endswith("simulate_Benutzerhandbuch.pdf")
         assert _MANUAL_URLS[LANG_EN].endswith("simulate_UserManual.pdf")
-        for lang in (LANG_RO, LANG_PT, LANG_FR):
-            assert _MANUAL_URLS[lang].endswith("simulate_UserManual.pdf")
+        assert _MANUAL_URLS[LANG_RO].endswith("simulate_ManualUtilizator.pdf")
+        assert _MANUAL_URLS[LANG_PT].endswith("simulate_ManualUtilizador.pdf")
+        assert _MANUAL_URLS[LANG_FR].endswith("simulate_ManuelUtilisateur.pdf")
 
     def test_lang_order_is_five_languages(self) -> None:
         assert _LANG_ORDER == [LANG_DE, LANG_EN, LANG_RO, LANG_PT, LANG_FR]

--- a/tests/simulate/unit/test_gui.py
+++ b/tests/simulate/unit/test_gui.py
@@ -20,15 +20,19 @@ from pathlib import Path
 import pytest
 
 from simulate.gui import (
+    _LANG_ORDER,
     _MANUAL_URLS,
     _T,
     LANG_DE,
     LANG_EN,
+    LANG_FR,
+    LANG_PT,
+    LANG_RO,
     _tr,
     parse_form,
 )
 
-_ALL_LANGS = (LANG_DE, LANG_EN)
+_ALL_LANGS = (LANG_DE, LANG_EN, LANG_RO, LANG_PT, LANG_FR)
 
 
 class TestTranslations:
@@ -50,9 +54,14 @@ class TestTranslations:
         assert _tr("xx", "window_title") == _T[LANG_EN]["window_title"]
 
     def test_manual_urls(self) -> None:
-        assert set(_MANUAL_URLS) == {LANG_DE, LANG_EN}
+        assert set(_MANUAL_URLS) == set(_LANG_ORDER)
         assert _MANUAL_URLS[LANG_DE].endswith("simulate_Benutzerhandbuch.pdf")
         assert _MANUAL_URLS[LANG_EN].endswith("simulate_UserManual.pdf")
+        for lang in (LANG_RO, LANG_PT, LANG_FR):
+            assert _MANUAL_URLS[lang].endswith("simulate_UserManual.pdf")
+
+    def test_lang_order_is_five_languages(self) -> None:
+        assert _LANG_ORDER == [LANG_DE, LANG_EN, LANG_RO, LANG_PT, LANG_FR]
 
 
 class TestParseForm:

--- a/tests/simulate/unit/test_gui_template.py
+++ b/tests/simulate/unit/test_gui_template.py
@@ -1,0 +1,51 @@
+# =============================================================================
+# Autor:          Robert Seebauer
+# Repository:     https://github.com/Jaegerfeld/situation-report
+# KI-Unterstützung: Erstellt mit Unterstützung von Claude (Anthropic)
+# Erstellt:       02.07.2026
+# Geändert:       02.07.2026
+# Lizenz:         BSD-3-Clause (siehe LICENSE)
+#
+# Fachliche Funktion:
+#   Unit-Tests für die Projekt-Template-Abschnittsfunktionen von
+#   simulate.gui (_build_template_section / _parse_template_section) sowie die
+#   Registrierung von MODULE_SIMULATE im gemeinsamen project_template.
+# =============================================================================
+
+from __future__ import annotations
+
+import project_template
+from simulate.gui import (
+    _TEMPLATE_FIELDS,
+    _build_template_section,
+    _parse_template_section,
+)
+
+
+def test_build_section_has_all_fields_as_strings():
+    sec = _build_template_section({"runs": 25000, "history_days": 180})
+    assert set(sec) == set(_TEMPLATE_FIELDS)
+    assert sec["runs"] == "25000"
+    assert sec["history_days"] == "180"
+    assert sec["issue_times"] == ""
+
+
+def test_parse_round_trip():
+    values = {k: f"v_{k}" for k in _TEMPLATE_FIELDS}
+    sec = _build_template_section(values)
+    assert _parse_template_section(sec) == sec
+
+
+def test_parse_missing_keys_default_to_empty():
+    parsed = _parse_template_section({})
+    assert all(parsed[k] == "" for k in _TEMPLATE_FIELDS)
+
+
+def test_expected_fields_present():
+    assert "issue_times" in _TEMPLATE_FIELDS
+    assert "cfd" in _TEMPLATE_FIELDS
+    assert "seed" in _TEMPLATE_FIELDS
+
+
+def test_module_simulate_registered():
+    assert project_template.MODULE_SIMULATE == "simulate"


### PR DESCRIPTION
Bringt das `simulate`-Modul auf denselben Stand wie die übrigen Modul-GUIs: fünf Sprachen mit Flaggen-Umschalter und den gemeinsamen Projekt-Template-Modus.

## Was
- **Sprache:** `_LANG_ORDER` auf `de/en/ro/pt/fr` erweitert, Flaggen-Umschalter oben rechts statt der bisherigen de/en-Combobox. Volle RO/PT/FR-Übersetzungen; gemeinsame Menü-/Template-Strings verbatim aus `transform_data`/`build_reports`. `_MANUAL_URLS` zeigt für ro/pt/fr auf die vorhandenen übersetzten PDFs.
- **Templates:** Menü **Templates** (Speichern/Laden) über `project_template` (neue Konstante `MODULE_SIMULATE`). Der Abschnitt hält die zehn Formularfelder und stellt beim Laden auch die Sprache wieder her — interoperabel mit den Templates der anderen Module.
- **Tests:** `test_gui` auf alle fünf Sprachen erweitert; neue `test_gui_template` (Feld-Vollständigkeit, Round-Trip, Modul-Registrierung).
- **Doku:** Manual-Generator um Abschnitt „Sprache & Templates“ ergänzt (alle 5 PDFs neu erzeugt); mkdocs-Seiten (de+en) und Architektur-Doku (de+en) aktualisiert; Changelog-Eintrag unter `[Unreleased] → Added`.

## Verifikation
- `pytest` (simulate + project_template), `ruff`, `mypy` — grün (auch via pre-commit-Hook).
- GUI real instanziiert: alle 5 Sprachen durchgeschaltet (Titel/Flagge/Menü), Flaggen-Toggle zyklisch, Template Save→Load-Round-Trip stellt Felder **und** Sprache wieder her.

🤖 Generated with [Claude Code](https://claude.com/claude-code)